### PR TITLE
Prevent scheduled repeat duplication with overlapping tasks

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -199,7 +199,7 @@ export function parseTmd(text: string): TaskMarkData {
 function expandRepeats(data: TaskMarkData): TaskMarkData {
   const expandedDays: Record<string, DayData> = {};
   for (const [date, day] of Object.entries(data.days)) {
-    expandedDays[date] = { date, items: [...day.items] };
+    expandedDays[date] = { date, items: day.items.map(item => ({ ...item, tags: [...item.tags] })) };
   }
 
   Object.values(data.days).forEach(day => {


### PR DESCRIPTION
## 関連Issue
Closes #1 

## 概要
「1つのリピート」と「1つのタスク」が重なると、それ以降のリピートが2回に増える現象を修正しました。

## 変更内容
- `expandRepeats` の冒頭において、処理を始める前にカレンダー内部の`items`配列の要素を完全に独立したクローン（ディープコピー）として展開用オブジェクト`expandedDays`に保持させるよう修正しました。

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した

## スクリーンショット / GIF (UI変更がある場合)
<img width="1876" height="944" alt="image" src="https://github.com/user-attachments/assets/d8bbfba8-94aa-4066-80fa-f690a40169ea" />
