### PR TITLE
fix: ensure 'until' date is inclusive and remove arbitrary 12-repeat limit (#5)

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -64,15 +64,14 @@ interface RepeatOptions {
   count: number;
 }
 
-const DEFAULT_REPEAT_COUNT = 12;
-const MAX_OCCURRENCES = 365;
+const MAX_OCCURRENCES = 3650;
 
 function parseRepeatOptions(repeatStr: string): RepeatOptions {
   const parts = repeatStr.split(',').map(s => s.trim());
   let mode: 'days' | 'months' = 'days';
   let interval = 7; // default: weekly
   let until: Date | undefined;
-  let count = DEFAULT_REPEAT_COUNT;
+  let count: number | undefined;
 
   for (const part of parts) {
     if (part.startsWith('every:')) {
@@ -91,16 +90,19 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
     } else if (part === 'monthly') {
       mode = 'months'; interval = 1;
     } else if (part.startsWith('until:')) {
-      const p = part.substring(6).split('-');
-      if (p.length === 3) {
-        until = new Date(parseInt(p[0]), parseInt(p[1]) - 1, parseInt(p[2]));
+      const dateStr = part.substring(6);
+      if (dateStr.match(/^\d{4}-\d{2}-\d{2}$/)) {
+        until = new Date(dateStr);
       }
     } else if (part.startsWith('count:')) {
-      count = parseInt(part.substring(6)) || DEFAULT_REPEAT_COUNT;
+      const parsedCount = parseInt(part.substring(6));
+      if (!isNaN(parsedCount)) count = parsedCount;
     }
   }
 
-  return { mode, interval, until, count };
+  const finalCount = count !== undefined ? count : MAX_OCCURRENCES;
+
+  return { mode, interval, until, count: finalCount };
 }
 
 // ─── Main Parser ───────────────────────────────────────────────


### PR DESCRIPTION
## 関連Issue
Closes #5 

## 概要
「`until:YYYY-MM-DD` 指定時に最終日が含まれない」バグを対応しました。

## 変更内容
- `until` のパースを `new Date('YYYY-MM-DD')` に切り替え、内部的にUTCの0時として解釈を統一しました。

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した

## スクリーンショット / GIF (UI変更がある場合)
```
# 2026-03-01
- 10:00-11:00 Repeat Schedule @repeat(daily, until:2026-03-20)
```
<img width="1140" height="828" alt="image" src="https://github.com/user-attachments/assets/990cbe20-1104-47ed-b552-ec9701b58563" />


## 備考・次やること
追加で「untilを指定してもデフォルトの12回制限で展開が打ち切られる」バグを同時に対応しました。

### 追加の変更内容
- `MAX_OCCURRENCES` を `3650` (約10年) に引き上げ。
- `DEFAULT_REPEAT_COUNT` の廃止。