### PR TITLE
feat: リピートのキャンセル機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Automatically expand recurring schedules. Tasks (`- [ ]` / `- [x]`) manage indep
 
 Options can be combined using commas. If a limit is not explicitly defined, recurrences will continually expand up to a safe maximum of 3650 occurrences (approx. 10 years).
 
+> **Note on `except:`**: Skipped dates are simply removed from the schedule — the total count is not compensated. If you need a different schedule on a cancelled date, add a separate one-off item for that day.
+
 ---
 
 ## `.tmd` File Format

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Automatically expand recurring schedules. Tasks (`- [ ]` / `- [x]`) manage indep
 - 09:00-10:00 Monthly Report @repeat(monthly, count:6) #Important
 - 09:00 Morning Stretch @repeat(daily, until:2026-06-30)
 - 14:00 Bi-Weekly 1on1 @repeat(every:2weeks, count:8) #MTG
+- 10:00-11:00 Weekly Sync @repeat(weekly, except:2026-03-23) #MTG
 ```
 
 | Modifier | Description | Example |
@@ -104,6 +105,7 @@ Automatically expand recurring schedules. Tasks (`- [ ]` / `- [x]`) manage indep
 | `every:Nmonths` | Every N months | `@repeat(every:3months)` |
 | `until:YYYY-MM-DD` | End date | `@repeat(weekly, until:2026-06-30)` |
 | `count:N` | Occurrences | `@repeat(monthly, count:6)` |
+| `except:YYYY-MM-DD` | Skip specific dates (space-separated for multiple) | `@repeat(weekly, except:2026-03-23 2026-04-06)` |
 
 Options can be combined using commas. If a limit is not explicitly defined, recurrences will continually expand up to a safe maximum of 3650 occurrences (approx. 10 years).
 
@@ -120,6 +122,7 @@ Options can be combined using commas. If a limit is not explicitly defined, recu
 - HH:mm-HH:mm Schedule item #Tag
 - HH:mm Schedule item with start time only
 - Schedule item @repeat(weekly, until:2026-12-31)
+- Schedule item @repeat(weekly, except:2026-03-23)
 - [ ] Uncompleted task #Tag
 - [x] Completed task
 

--- a/sample.tmd
+++ b/sample.tmd
@@ -8,7 +8,8 @@
 @end
 
 # 2026-03-16
-- 10:00-11:00 Weekly Sync @repeat(weekly, until:2026-06-30) #MTG
+- 10:00-11:00 Weekly Sync @repeat(weekly, until:2026-06-30, except:2026-03-30 2026-05-04) #MTG
+- 08:00-08:30 3-Day Standup @repeat(every:3days, count:10) #MTG
 
 # 2026-03-17
 - 09:30-10:00 Morning Stand-up #MTG

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -116,7 +116,7 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
       const parsedCount = parseInt(part.substring(6), 10);
       if (!isNaN(parsedCount)) count = parsedCount;
     } else if (part.startsWith('except:')) {
-      for (const d of part.substring(7).split(' ')) {
+      for (const d of part.substring(7).trim().split(/\s+/).filter(Boolean)) {
         try { parseLocalDate(d); exceptDates.add(d); } catch { /* ignore invalid dates */ }
       }
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -118,7 +118,9 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
     } else if (part.startsWith('except:')) {
       part.substring(7).split(' ')
         .filter(d => d.match(/^\d{4}-\d{2}-\d{2}$/))
-        .forEach(d => exceptDates.add(d));
+        .forEach(d => {
+          try { parseLocalDate(d); exceptDates.add(d); } catch { /* ignore invalid dates */ }
+        });
     }
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -256,9 +256,7 @@ function expandRepeats(data: TaskMarkData): TaskMarkData {
 function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDays: Record<string, DayData>) {
   const origin = parseLocalDate(originDateStr);
   const opts = parseRepeatOptions(item.repeat!);
-  let generated = 0;
-  let i = 1;
-  while (generated < opts.count - 1) {
+  for (let i = 1; i < opts.count; i++) {
     const nextDate = new Date(origin);
 
     if (opts.mode === 'months') {
@@ -271,15 +269,12 @@ function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDa
       nextDate.setDate(origin.getDate() + opts.interval * i);
     }
 
-    i++;
-
     if (opts.until && nextDate > opts.until) break;
 
     const isoDate = toLocaleDateStr(nextDate);
     if (opts.exceptDates.has(isoDate)) { continue; }
 
     ensureDay(expandedDays, isoDate);
-    expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${generated + 1}`, tags: [...item.tags] });
-    generated++;
+    expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${i}`, tags: [...item.tags] });
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -256,7 +256,9 @@ function expandRepeats(data: TaskMarkData): TaskMarkData {
 function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDays: Record<string, DayData>) {
   const origin = parseLocalDate(originDateStr);
   const opts = parseRepeatOptions(item.repeat!);
-  for (let i = 1; i < opts.count; i++) {
+  let generated = 0;
+  let i = 1;
+  while (generated < opts.count - 1) {
     const nextDate = new Date(origin);
 
     if (opts.mode === 'months') {
@@ -269,12 +271,15 @@ function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDa
       nextDate.setDate(origin.getDate() + opts.interval * i);
     }
 
+    i++;
+
     if (opts.until && nextDate > opts.until) break;
 
     const isoDate = toLocaleDateStr(nextDate);
     if (opts.exceptDates.has(isoDate)) { continue; }
 
     ensureDay(expandedDays, isoDate);
-    expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${i}`, tags: [...item.tags] });
+    expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${generated + 1}`, tags: [...item.tags] });
+    generated++;
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -19,6 +19,7 @@ export interface MarkItem {
   tags: string[];
   status?: TaskStatus;
   repeat?: string;
+  cancelDates?: string[];
   group?: string;
   rawLine: number;
 }
@@ -31,6 +32,7 @@ const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{2})(?:-(
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
 const TAG_SPLIT_REGEX = /#([^\s#]+)/g;
 const EVERY_REGEX = /^(\d+)(days?|weeks?|months?)$/;
+const CANCEL_REGEX = /^\\\s+(\d{4}-\d{2}-\d{2})$/;
 
 function toLocaleDateStr(d: Date): string {
   const y = d.getFullYear();
@@ -130,6 +132,7 @@ export function parseTmd(text: string): TaskMarkData {
   let inTagsBlock = false;
   let currentDate = '';
   let currentGroup = '';
+  let lastRepeatItem: MarkItem | null = null;
 
   for (let i = 0; i < lines.length; i++) {
     const rawLine = lines[i];
@@ -149,29 +152,39 @@ export function parseTmd(text: string): TaskMarkData {
       continue;
     }
 
-    // 2. Date header
+    // 2. Cancel date for the last repeat item
+    const cancelMatch = line.match(CANCEL_REGEX);
+    if (cancelMatch && lastRepeatItem) {
+      if (!lastRepeatItem.cancelDates) { lastRepeatItem.cancelDates = []; }
+      lastRepeatItem.cancelDates.push(cancelMatch[1]);
+      continue;
+    }
+
+    // 3. Date header
     const dateMatch = line.match(DATE_REGEX);
     if (dateMatch) {
       currentDate = dateMatch[1];
       ensureDay(data.days, currentDate);
       currentGroup = '';
+      lastRepeatItem = null;
       continue;
     }
 
-    // 3. Group header
+    // 4. Group header
     const groupMatch = line.match(GROUP_REGEX);
     if (groupMatch) {
       currentGroup = groupMatch[1].trim();
       continue;
     }
 
-    // 4. Item (schedule or task)
+    // 5. Item (schedule or task)
     const itemMatch = rawLine.match(ITEM_REGEX);
     if (itemMatch && itemMatch[2]) {
       const result = createMarkItem(itemMatch, i, currentDate, currentGroup);
       if (result) {
         data.days[currentDate].items.push(result.item);
         currentGroup = result.newGroup;
+        lastRepeatItem = result.item.repeat ? result.item : null;
       }
     }
   }
@@ -266,6 +279,8 @@ function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDa
     if (opts.until && nextDate > opts.until) break;
 
     const isoDate = toLocaleDateStr(nextDate);
+    if (item.cancelDates?.includes(isoDate)) { continue; }
+
     ensureDay(expandedDays, isoDate);
     expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${i}`, tags: [...item.tags] });
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -19,7 +19,6 @@ export interface MarkItem {
   tags: string[];
   status?: TaskStatus;
   repeat?: string;
-  cancelDates?: string[];
   group?: string;
   rawLine: number;
 }
@@ -32,7 +31,6 @@ const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{2})(?:-(
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
 const TAG_SPLIT_REGEX = /#([^\s#]+)/g;
 const EVERY_REGEX = /^(\d+)(days?|weeks?|months?)$/;
-const CANCEL_REGEX = /^\\\s+(\d{4}-\d{2}-\d{2})$/;
 
 function toLocaleDateStr(d: Date): string {
   const y = d.getFullYear();
@@ -80,6 +78,7 @@ interface RepeatOptions {
   interval: number; // days when mode='days', months when mode='months'
   until?: Date;
   count: number;
+  exceptDates: string[];
 }
 
 const MAX_OCCURRENCES = 3650;
@@ -90,6 +89,7 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
   let interval = 7; // default: weekly
   let until: Date | undefined;
   let count: number | undefined;
+  const exceptDates: string[] = [];
 
   for (const part of parts) {
     if (part.startsWith('every:')) {
@@ -115,12 +115,17 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
     } else if (part.startsWith('count:')) {
       const parsedCount = parseInt(part.substring(6), 10);
       if (!isNaN(parsedCount)) count = parsedCount;
+    } else if (part.startsWith('except:')) {
+      const dates = part.substring(7).split(' ');
+      for (const d of dates) {
+        if (d.match(/^\d{4}-\d{2}-\d{2}$/)) { exceptDates.push(d); }
+      }
     }
   }
 
   const finalCount = count !== undefined ? count : MAX_OCCURRENCES;
 
-  return { mode, interval, until, count: finalCount };
+  return { mode, interval, until, count: finalCount, exceptDates };
 }
 
 // ─── Main Parser ───────────────────────────────────────────────
@@ -132,7 +137,6 @@ export function parseTmd(text: string): TaskMarkData {
   let inTagsBlock = false;
   let currentDate = '';
   let currentGroup = '';
-  let lastRepeatItem: MarkItem | null = null;
 
   for (let i = 0; i < lines.length; i++) {
     const rawLine = lines[i];
@@ -152,39 +156,29 @@ export function parseTmd(text: string): TaskMarkData {
       continue;
     }
 
-    // 2. Cancel date for the last repeat item
-    const cancelMatch = line.match(CANCEL_REGEX);
-    if (cancelMatch && lastRepeatItem) {
-      if (!lastRepeatItem.cancelDates) { lastRepeatItem.cancelDates = []; }
-      lastRepeatItem.cancelDates.push(cancelMatch[1]);
-      continue;
-    }
-
-    // 3. Date header
+    // 2. Date header
     const dateMatch = line.match(DATE_REGEX);
     if (dateMatch) {
       currentDate = dateMatch[1];
       ensureDay(data.days, currentDate);
       currentGroup = '';
-      lastRepeatItem = null;
       continue;
     }
 
-    // 4. Group header
+    // 3. Group header
     const groupMatch = line.match(GROUP_REGEX);
     if (groupMatch) {
       currentGroup = groupMatch[1].trim();
       continue;
     }
 
-    // 5. Item (schedule or task)
+    // 4. Item (schedule or task)
     const itemMatch = rawLine.match(ITEM_REGEX);
     if (itemMatch && itemMatch[2]) {
       const result = createMarkItem(itemMatch, i, currentDate, currentGroup);
       if (result) {
         data.days[currentDate].items.push(result.item);
         currentGroup = result.newGroup;
-        lastRepeatItem = result.item.repeat ? result.item : null;
       }
     }
   }
@@ -279,7 +273,7 @@ function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDa
     if (opts.until && nextDate > opts.until) break;
 
     const isoDate = toLocaleDateStr(nextDate);
-    if (item.cancelDates?.includes(isoDate)) { continue; }
+    if (opts.exceptDates.includes(isoDate)) { continue; }
 
     ensureDay(expandedDays, isoDate);
     expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${i}`, tags: [...item.tags] });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -78,7 +78,7 @@ interface RepeatOptions {
   interval: number; // days when mode='days', months when mode='months'
   until?: Date;
   count: number;
-  exceptDates: string[];
+  exceptDates: Set<string>;
 }
 
 const MAX_OCCURRENCES = 3650;
@@ -89,7 +89,7 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
   let interval = 7; // default: weekly
   let until: Date | undefined;
   let count: number | undefined;
-  const exceptDates: string[] = [];
+  const exceptDates = new Set<string>();
 
   for (const part of parts) {
     if (part.startsWith('every:')) {
@@ -116,10 +116,9 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
       const parsedCount = parseInt(part.substring(6), 10);
       if (!isNaN(parsedCount)) count = parsedCount;
     } else if (part.startsWith('except:')) {
-      const dates = part.substring(7).split(' ');
-      for (const d of dates) {
-        if (d.match(/^\d{4}-\d{2}-\d{2}$/)) { exceptDates.push(d); }
-      }
+      part.substring(7).split(' ')
+        .filter(d => d.match(/^\d{4}-\d{2}-\d{2}$/))
+        .forEach(d => exceptDates.add(d));
     }
   }
 
@@ -273,7 +272,7 @@ function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDa
     if (opts.until && nextDate > opts.until) break;
 
     const isoDate = toLocaleDateStr(nextDate);
-    if (opts.exceptDates.includes(isoDate)) { continue; }
+    if (opts.exceptDates.has(isoDate)) { continue; }
 
     ensureDay(expandedDays, isoDate);
     expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${i}`, tags: [...item.tags] });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -116,11 +116,9 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
       const parsedCount = parseInt(part.substring(6), 10);
       if (!isNaN(parsedCount)) count = parsedCount;
     } else if (part.startsWith('except:')) {
-      part.substring(7).split(' ')
-        .filter(d => d.match(/^\d{4}-\d{2}-\d{2}$/))
-        .forEach(d => {
-          try { parseLocalDate(d); exceptDates.add(d); } catch { /* ignore invalid dates */ }
-        });
+      for (const d of part.substring(7).split(' ')) {
+        try { parseLocalDate(d); exceptDates.add(d); } catch { /* ignore invalid dates */ }
+      }
     }
   }
 

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -87,18 +87,6 @@ suite('Parser Test Suite', () => {
     assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
   });
 
-  test('parseTmd repeat except still generates count items after skip', () => {
-    const text = `
-# 2026-03-16
-- 10:00-11:00 Weekly Sync @repeat(weekly, count:3, except:2026-03-23)
-`;
-    const data = parseTmd(text);
-    assert.ok(data.days['2026-03-16'], '2026-03-16 should exist (origin)');
-    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
-    assert.ok(data.days['2026-03-30'], '2026-03-30 should exist');
-    assert.ok(data.days['2026-04-06'], '2026-04-06 should exist (count:3 = 2 repeats after origin)');
-  });
-
   test('parseTmd repeat except ignores invalid dates', () => {
     const text = `
 # 2026-03-16

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -87,6 +87,18 @@ suite('Parser Test Suite', () => {
     assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
   });
 
+  test('parseTmd repeat except still generates count items after skip', () => {
+    const text = `
+# 2026-03-16
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:3, except:2026-03-23)
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-16'], '2026-03-16 should exist (origin)');
+    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
+    assert.ok(data.days['2026-03-30'], '2026-03-30 should exist');
+    assert.ok(data.days['2026-04-06'], '2026-04-06 should exist (count:3 = 2 repeats after origin)');
+  });
+
   test('parseTmd repeat except ignores invalid dates', () => {
     const text = `
 # 2026-03-16

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -87,6 +87,16 @@ suite('Parser Test Suite', () => {
     assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
   });
 
+  test('parseTmd repeat except ignores invalid dates', () => {
+    const text = `
+# 2026-03-16
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:3, except:2026-02-30)
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-23'], '2026-03-23 should exist because except date was invalid');
+    assert.ok(data.days['2026-03-30'], '2026-03-30 should exist');
+  });
+
   test('parseTmd repeat except skips multiple specified dates', () => {
     const text = `
 # 2026-03-16

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -75,4 +75,42 @@ suite('Parser Test Suite', () => {
     assert.ok(data.days['2026-03-28']);
     assert.strictEqual(Object.keys(data.days).length, 3, 'Should create 3 days of repeatable task');
   });
+
+  test('parseTmd repeat cancel skips specified date', () => {
+    const text = `
+# 2026-03-16
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:3)
+\\ 2026-03-23
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
+    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be cancelled');
+    assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
+  });
+
+  test('parseTmd repeat cancel skips multiple specified dates', () => {
+    const text = `
+# 2026-03-16
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:4)
+\\ 2026-03-23
+\\ 2026-03-30
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
+    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be cancelled');
+    assert.ok(!data.days['2026-03-30'], '2026-03-30 should be cancelled');
+    assert.ok(data.days['2026-04-06'], '2026-04-06 should still exist');
+  });
+
+  test('parseTmd repeat cancel does not affect non-repeat items', () => {
+    const text = `
+# 2026-03-16
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:3)
+\\ 2026-03-23
+- One-off event
+`;
+    const data = parseTmd(text);
+    const items = data.days['2026-03-16'].items;
+    assert.strictEqual(items.length, 2, 'Both items should exist on origin date');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -76,41 +76,26 @@ suite('Parser Test Suite', () => {
     assert.strictEqual(Object.keys(data.days).length, 3, 'Should create 3 days of repeatable task');
   });
 
-  test('parseTmd repeat cancel skips specified date', () => {
+  test('parseTmd repeat except skips specified date', () => {
     const text = `
 # 2026-03-16
-- 10:00-11:00 Weekly Sync @repeat(weekly, count:3)
-\\ 2026-03-23
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:3, except:2026-03-23)
 `;
     const data = parseTmd(text);
     assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
-    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be cancelled');
+    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
     assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
   });
 
-  test('parseTmd repeat cancel skips multiple specified dates', () => {
+  test('parseTmd repeat except skips multiple specified dates', () => {
     const text = `
 # 2026-03-16
-- 10:00-11:00 Weekly Sync @repeat(weekly, count:4)
-\\ 2026-03-23
-\\ 2026-03-30
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:4, except:2026-03-23 2026-03-30)
 `;
     const data = parseTmd(text);
     assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
-    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be cancelled');
-    assert.ok(!data.days['2026-03-30'], '2026-03-30 should be cancelled');
+    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
+    assert.ok(!data.days['2026-03-30'], '2026-03-30 should be skipped');
     assert.ok(data.days['2026-04-06'], '2026-04-06 should still exist');
-  });
-
-  test('parseTmd repeat cancel does not affect non-repeat items', () => {
-    const text = `
-# 2026-03-16
-- 10:00-11:00 Weekly Sync @repeat(weekly, count:3)
-\\ 2026-03-23
-- One-off event
-`;
-    const data = parseTmd(text);
-    const items = data.days['2026-03-16'].items;
-    assert.strictEqual(items.length, 2, 'Both items should exist on origin date');
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #8

## 概要
リピートスケジュールの特定日付をキャンセルできる `except:` 修飾子を追加しました。既存の `until:` や `count:` と同じ書き方で、1行で完結します。

キャンセルした日付は単純にスキップされます（`count:` の補填は行いません）。キャンセル日に別の予定が必要な場合は、その日付に個別のスケジュールを追加してください。

## 変更内容
- `@repeat()` に `except:YYYY-MM-DD` 修飾子を追加
- スペース区切りで複数日の指定に対応（例: `except:2026-03-23 2026-04-06`）
- 除外日の存在チェックに `parseLocalDate` を使用し `until:` と一貫した検証を実施
- 除外日の検索に `Set<string>` を使用（O(1) ルックアップ）
- パーサーのユニットテストを追加
- READMEの `@repeat` 修飾子一覧と `.tmd` ファイルフォーマット例を更新

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| リピートのキャンセル不可 | `@repeat(weekly, except:2026-03-23)` で特定日をスキップ |

## 備考・次やること
- キャンセル日は完全に無視され、`count:` の補填は行わない仕様
- 複数日のキャンセルにも対応済み