### PR TITLE
fix: 日付の0パディングなし入力を受け付けて正規化する

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -28,7 +28,7 @@ export interface MarkItem {
 const TAG_COLOR_REGEX = /^#([^\s:]+)\s*:\s*(.+)$/;
 const DATE_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})(?:\s*:\s*(\d{4}-\d{1,2}-\d{1,2}))?/;
 const GROUP_REGEX = /^>\s*([^-\s].+)$/;
-const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{2})(?:-(\d{1,2}:\d{2}))?)?\s*(.*)$/;
+const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{1,2})(?:-(\d{1,2}:\d{1,2}))?)?\s*(.*)$/;
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
 const TAG_SPLIT_REGEX = /#([^\s#]+)/g;
 const EVERY_REGEX = /^(\d+)(days?|weeks?|months?)$/;
@@ -49,6 +49,20 @@ export function parseLocalDate(dateStr: string): Date {
     throw new Error(`Invalid date: ${dateStr}`);
   }
   return date;
+}
+
+/** Normalize a time part like "9:0" to "9:00" */
+function normalizeTimePart(t: string): string {
+  const [h, m] = t.split(':');
+  return `${h}:${m.padStart(2, '0')}`;
+}
+
+/** Normalize a time string like "9:0-17:0" to "9:00-17:00" */
+function normalizeTimeStr(timeStr: string): string {
+  const parts = timeStr.split('-');
+  return parts.length === 2
+    ? `${normalizeTimePart(parts[0])}-${normalizeTimePart(parts[1])}`
+    : normalizeTimePart(parts[0]);
 }
 
 /** Ensure a day entry exists in the days record, returning it */
@@ -216,7 +230,7 @@ function createMarkItem(
 
   const hasCheckbox = itemMatch[3];
   const checkMark = itemMatch[4];
-  const timeString = itemMatch[5];
+  const timeString = itemMatch[5] ? normalizeTimeStr(itemMatch[5]) : undefined;
   let content = itemMatch[8] || '';
 
   const type: ItemType = hasCheckbox ? 'task' : 'schedule';

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -26,7 +26,7 @@ export interface MarkItem {
 
 // ─── Regex Patterns ────────────────────────────────────────────
 const TAG_COLOR_REGEX = /^#([^\s:]+)\s*:\s*(.+)$/;
-const DATE_REGEX = /^#\s+(\d{4}-\d{2}-\d{2})(?:\s*:\s*(\d{4}-\d{2}-\d{2}))?/;
+const DATE_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})(?:\s*:\s*(\d{4}-\d{1,2}-\d{1,2}))?/;
 const GROUP_REGEX = /^>\s*([^-\s].+)$/;
 const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{2})(?:-(\d{1,2}:\d{2}))?)?\s*(.*)$/;
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
@@ -160,12 +160,18 @@ export function parseTmd(text: string): TaskMarkData {
     // 2. Date header
     const dateMatch = line.match(DATE_REGEX);
     if (dateMatch) {
-      currentDate = dateMatch[1];
+      try {
+        currentDate = toLocaleDateStr(parseLocalDate(dateMatch[1]));
+      } catch {
+        currentDate = '';
+        continue;
+      }
       currentEndDate = '';
       if (dateMatch[2]) {
         try {
-          parseLocalDate(dateMatch[2]);
-          if (dateMatch[2] >= currentDate) { currentEndDate = dateMatch[2]; }
+          const parsedEnd = parseLocalDate(dateMatch[2]);
+          const normalizedEnd = toLocaleDateStr(parsedEnd);
+          if (normalizedEnd >= currentDate) { currentEndDate = normalizedEnd; }
         } catch { /* ignore invalid end date */ }
       }
       ensureDay(data.days, currentDate);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -132,7 +132,7 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
       if (!isNaN(parsedCount)) count = parsedCount;
     } else if (part.startsWith('except:')) {
       for (const d of part.substring(7).trim().split(/\s+/).filter(Boolean)) {
-        try { parseLocalDate(d); exceptDates.add(d); } catch { /* ignore invalid dates */ }
+        try { exceptDates.add(toLocaleDateStr(parseLocalDate(d))); } catch { /* ignore invalid dates */ }
       }
     }
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -59,10 +59,7 @@ function normalizeTimePart(t: string): string {
 
 /** Normalize a time string like "9:0-17:0" to "9:00-17:00" */
 function normalizeTimeStr(timeStr: string): string {
-  const parts = timeStr.split('-');
-  return parts.length === 2
-    ? `${normalizeTimePart(parts[0])}-${normalizeTimePart(parts[1])}`
-    : normalizeTimePart(parts[0]);
+  return timeStr.split('-').map(normalizeTimePart).join('-');
 }
 
 /** Ensure a day entry exists in the days record, returning it */

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -208,4 +208,26 @@ suite('Parser Test Suite', () => {
     const data = parseTmd(text);
     assert.strictEqual(Object.keys(data.days).length, 0, 'Invalid date header should be ignored');
   });
+
+  test('parseTmd time with unpadded minutes is normalized', () => {
+    const text = `
+# 2026-03-01
+- 9:0-17:0 Conference
+`;
+    const data = parseTmd(text);
+    const items = data.days['2026-03-01'].items;
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].time, '9:00-17:00');
+  });
+
+  test('parseTmd start time only with unpadded minutes is normalized', () => {
+    const text = `
+# 2026-03-01
+- 9:0 Meeting
+`;
+    const data = parseTmd(text);
+    const items = data.days['2026-03-01'].items;
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].time, '9:00');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -178,4 +178,34 @@ suite('Parser Test Suite', () => {
     assert.ok(data.days['2026-03-01'], 'Start day should exist');
     assert.ok(!data.days['2026-03-02'], 'Repeat should not expand when endDate is set');
   });
+
+  test('parseTmd date header without zero-padding is normalized and parsed', () => {
+    const text = `
+# 2026-3-1
+- Meeting
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-01'], 'Day should be stored with zero-padded key');
+    assert.strictEqual(data.days['2026-03-01'].items.length, 1);
+    assert.strictEqual(data.days['2026-03-01'].items[0].text, 'Meeting');
+  });
+
+  test('parseTmd date range end date without zero-padding is normalized', () => {
+    const text = `
+# 2026-3-1 : 2026-3-10
+- Conference
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-01'], 'Start day should be zero-padded');
+    assert.strictEqual(data.days['2026-03-01'].items[0].endDate, '2026-03-10');
+  });
+
+  test('parseTmd date header with invalid month is ignored', () => {
+    const text = `
+# 2026-13-1
+- Meeting
+`;
+    const data = parseTmd(text);
+    assert.strictEqual(Object.keys(data.days).length, 0, 'Invalid date header should be ignored');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -230,4 +230,15 @@ suite('Parser Test Suite', () => {
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0].time, '9:00');
   });
+
+  test('parseTmd repeat except with unpadded date skips the correct day', () => {
+    const text = `
+# 2026-03-16
+- Weekly Sync @repeat(weekly, count:3, except:2026-3-23)
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
+    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
+    assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
+  });
 });


### PR DESCRIPTION
## 関連Issue
Closes #28

## 概要
日付・時刻で0パディングを省略して記述した場合にサイレントに無視されていた問題を修正。1〜2桁の月・日・分を受け付け、内部で0パディング済みの形式に正規化するようにした。

## 変更内容
- `DATE_REGEX` の月・日を `\d{2}` から `\d{1,2}` に緩和
- 開始日を `parseLocalDate` + `toLocaleDateStr` で正規化（無効な日付は従来通り無視）
- 終了日も同様に正規化（文字列比較の信頼性向上）
- `ITEM_REGEX` の時刻の分を `\d{2}` から `\d{1,2}` に緩和
- 時刻文字列を `normalizeTimeStr` で正規化（例: `9:0-17:0` → `9:00-17:00`）
- `@repeat` の `except:` 日付も正規化し、0パディングなしで書いた場合もスキップが正しく機能するよう修正

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| `# 2026-3-1` が無視される | `2026-03-01` として正常に解析される |
| `- 9:0-17:0` が時刻として認識されない | `9:00-17:00` として正常に解析される |
| `except:2026-3-23` がスキップされない | 正しくスキップされる |

## 備考・次やること
特になし