### PR TITLE
develop → main: リピートキャンセル・期間指定・0パディング対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Automatically expand recurring schedules. Tasks (`- [ ]` / `- [x]`) manage indep
 
 Options can be combined using commas. If a limit is not explicitly defined, recurrences will continually expand up to a safe maximum of 3650 occurrences (approx. 10 years).
 
+> **Note on `except:`**: Skipped dates are simply removed from the schedule — the total count is not compensated. If you need a different schedule on a cancelled date, add a separate one-off item for that day.
+
 ---
 
 ## `.tmd` File Format

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ Use `# YYYY-MM-DD : YYYY-MM-DD` to define events or tasks that span multiple day
 ```
 
 > **Note:** If the end date is invalid or earlier than the start date, the range is silently ignored and the header is treated as a single date.
+>
+> **Note:** Date range items are always treated as all-day — any time specification (`HH:mm`) is ignored in the Timeline view.
+>
+> **Note:** `@repeat` is ignored when used under a date range header. `endDate` takes priority.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Automatically expand recurring schedules. Tasks (`- [ ]` / `- [x]`) manage indep
 - 09:00-10:00 Monthly Report @repeat(monthly, count:6) #Important
 - 09:00 Morning Stretch @repeat(daily, until:2026-06-30)
 - 14:00 Bi-Weekly 1on1 @repeat(every:2weeks, count:8) #MTG
+- 10:00-11:00 Weekly Sync @repeat(weekly, except:2026-03-23) #MTG
 ```
 
 | Modifier | Description | Example |
@@ -104,6 +105,7 @@ Automatically expand recurring schedules. Tasks (`- [ ]` / `- [x]`) manage indep
 | `every:Nmonths` | Every N months | `@repeat(every:3months)` |
 | `until:YYYY-MM-DD` | End date | `@repeat(weekly, until:2026-06-30)` |
 | `count:N` | Occurrences | `@repeat(monthly, count:6)` |
+| `except:YYYY-MM-DD` | Skip specific dates (space-separated for multiple) | `@repeat(weekly, except:2026-03-23 2026-04-06)` |
 
 Options can be combined using commas. If a limit is not explicitly defined, recurrences will continually expand up to a safe maximum of 3650 occurrences (approx. 10 years).
 
@@ -120,6 +122,7 @@ Options can be combined using commas. If a limit is not explicitly defined, recu
 - HH:mm-HH:mm Schedule item #Tag
 - HH:mm Schedule item with start time only
 - Schedule item @repeat(weekly, until:2026-12-31)
+- Schedule item @repeat(weekly, except:2026-03-23)
 - [ ] Uncompleted task #Tag
 - [x] Completed task
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ Use `# YYYY-MM-DD : YYYY-MM-DD` to define events or tasks that span multiple day
 - [ ] Prepare conference materials #Dev
 ```
 
+> **Note:** If the end date is invalid or earlier than the start date, the range is silently ignored and the header is treated as a single date.
+
 ---
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Options can be combined using commas. If a limit is not explicitly defined, recu
 - [ ] Uncompleted task #Tag
 - [x] Completed task
 
+# YYYY-MM-DD : YYYY-MM-DD
+- Multi-day event spanning date range #Tag
+- [ ] Multi-day task spanning date range
+
 > Group Name
 > - 13:00-15:00 Schedule inside group #Tag
 > - [x] Completed task inside group
@@ -140,6 +144,7 @@ Options can be combined using commas. If a limit is not explicitly defined, recu
 |------|------|------|
 | `@tags` ... `@end` | Tag color definition block | — |
 | `# YYYY-MM-DD` | Date header | — |
+| `# YYYY-MM-DD : YYYY-MM-DD` | Date range header (start : end) | — |
 | `- Text` | Schedule (Event) | — |
 | `- [ ] Text` | Uncompleted task | — |
 | `- [x] Text` | Completed task | — |
@@ -149,6 +154,16 @@ Options can be combined using commas. If a limit is not explicitly defined, recu
 | `@repeat(...)` | Recurring items | Schedules only |
 | `> Group Name` | Group header | — |
 | `> - Item` | Items inside group | Both |
+
+### 📅 Date Range Header
+
+Use `# YYYY-MM-DD : YYYY-MM-DD` to define events or tasks that span multiple days as a **single entry**. Unlike `@repeat`, this does not create separate items for each day — the Timeline renders it as one continuous bar, and all Calendar views show it on every day within the range.
+
+```tmd
+# 2026-03-01 : 2026-03-10
+- Conference Trip #Important
+- [ ] Prepare conference materials #Dev
+```
 
 ---
 

--- a/media/main.js
+++ b/media/main.js
@@ -348,9 +348,20 @@
     return el;
   }
 
-  /** Get day data from the current dataset, with fallback */
+  /** Get day data from the current dataset, including range items that span into dStr */
   function getDayData(dStr) {
-    return currentTaskMarkData.days[dStr] || { items: [] };
+    const dayData = currentTaskMarkData.days[dStr] || { items: [] };
+    const rangeItems = [];
+    Object.entries(currentTaskMarkData.days).forEach(([date, data]) => {
+      if (date >= dStr) return;
+      data.items.forEach(item => {
+        if (item.endDate && item.endDate >= dStr) {
+          rangeItems.push(item);
+        }
+      });
+    });
+    if (rangeItems.length === 0) return dayData;
+    return { ...dayData, items: [...dayData.items, ...rangeItems] };
   }
 
   // ─── Calendar Views ──────────────────────────────────────────
@@ -453,7 +464,9 @@
 
       dayData.items.forEach(item => {
         let startMs = dayStartMs;
-        let endMs = dayStartMs + MS_PER_DAY - 1;
+        let endMs = item.endDate
+          ? parseLocalDate(item.endDate).getTime() + MS_PER_DAY - 1
+          : dayStartMs + MS_PER_DAY - 1;
 
         if (item.time) {
           const parts = item.time.split('-');
@@ -466,7 +479,7 @@
             if (eTime.length >= 2) {
               endMs = dayStartMs + parseInt(eTime[0]) * MS_PER_HOUR + parseInt(eTime[1]) * MS_PER_MINUTE;
             }
-          } else {
+          } else if (!item.endDate) {
             endMs = startMs + MS_PER_HOUR;
           }
         }
@@ -655,10 +668,16 @@
       return;
     }
 
-    // Calculate padded date range (align to week boundaries)
+    // Calculate padded date range (align to week boundaries), accounting for endDate ranges
     const startDate = parseLocalDate(sortedDates[0]);
     startDate.setDate(startDate.getDate() - startDate.getDay());
-    const endDate = parseLocalDate(sortedDates[sortedDates.length - 1]);
+    let lastDateStr = sortedDates[sortedDates.length - 1];
+    sortedDates.forEach(dStr => {
+      currentTaskMarkData.days[dStr].items.forEach(item => {
+        if (item.endDate && item.endDate > lastDateStr) lastDateStr = item.endDate;
+      });
+    });
+    const endDate = parseLocalDate(lastDateStr);
     endDate.setDate(endDate.getDate() + (6 - endDate.getDay()) + 1);
 
     // Clamp zoom

--- a/media/main.js
+++ b/media/main.js
@@ -468,7 +468,7 @@
           ? parseLocalDate(item.endDate).getTime() + MS_PER_DAY - 1
           : dayStartMs + MS_PER_DAY - 1;
 
-        if (item.time) {
+        if (item.time && !item.endDate) {
           const parts = item.time.split('-');
           const sTime = parts[0].trim().split(':');
           if (sTime.length >= 2) {
@@ -479,7 +479,7 @@
             if (eTime.length >= 2) {
               endMs = dayStartMs + parseInt(eTime[0]) * MS_PER_HOUR + parseInt(eTime[1]) * MS_PER_MINUTE;
             }
-          } else if (!item.endDate) {
+          } else {
             endMs = startMs + MS_PER_HOUR;
           }
         }

--- a/media/main.js
+++ b/media/main.js
@@ -263,7 +263,7 @@
         : '';
 
       const cbHtml = item.type === 'task' ? '<span class="tm-checkbox"></span>' : '';
-      const timeHtml = item.time ? `<span class="tm-time">${item.time}</span>` : '';
+      const timeHtml = (item.time && !item.endDate) ? `<span class="tm-time">${item.time}</span>` : '';
       const classNames = `tm-item ${item.type} ${item.status || ''}`;
       const borderColor = getItemBorderColor(item.tags, tagColorsMap);
 

--- a/sample.tmd
+++ b/sample.tmd
@@ -69,3 +69,7 @@
 # 2026-04-01
 - 09:00-09:15 Morning Stretch @repeat(daily, until:2026-04-30) #Private
 - 14:00 Bi-Weekly 1on1 @repeat(every:2weeks, count:8) #MTG
+
+# 2026-04-07 : 2026-04-11
+- Spring Conference #Important
+- [ ] Prepare conference slides #Dev

--- a/sample.tmd
+++ b/sample.tmd
@@ -8,7 +8,8 @@
 @end
 
 # 2026-03-16
-- 10:00-11:00 Weekly Sync @repeat(weekly, until:2026-06-30) #MTG
+- 10:00-11:00 Weekly Sync @repeat(weekly, until:2026-06-30, except:2026-03-30 2026-05-04) #MTG
+- 08:00-08:30 3-Day Standup @repeat(every:3days, count:10) #MTG
 
 # 2026-03-17
 - 09:30-10:00 Morning Stand-up #MTG

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -116,7 +116,7 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
       const parsedCount = parseInt(part.substring(6), 10);
       if (!isNaN(parsedCount)) count = parsedCount;
     } else if (part.startsWith('except:')) {
-      for (const d of part.substring(7).split(' ')) {
+      for (const d of part.substring(7).trim().split(/\s+/).filter(Boolean)) {
         try { parseLocalDate(d); exceptDates.add(d); } catch { /* ignore invalid dates */ }
       }
     }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -28,7 +28,7 @@ export interface MarkItem {
 const TAG_COLOR_REGEX = /^#([^\s:]+)\s*:\s*(.+)$/;
 const DATE_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})(?:\s*:\s*(\d{4}-\d{1,2}-\d{1,2}))?/;
 const GROUP_REGEX = /^>\s*([^-\s].+)$/;
-const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{2})(?:-(\d{1,2}:\d{2}))?)?\s*(.*)$/;
+const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{1,2})(?:-(\d{1,2}:\d{1,2}))?)?\s*(.*)$/;
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
 const TAG_SPLIT_REGEX = /#([^\s#]+)/g;
 const EVERY_REGEX = /^(\d+)(days?|weeks?|months?)$/;
@@ -49,6 +49,20 @@ export function parseLocalDate(dateStr: string): Date {
     throw new Error(`Invalid date: ${dateStr}`);
   }
   return date;
+}
+
+/** Normalize a time part like "9:0" to "9:00" */
+function normalizeTimePart(t: string): string {
+  const [h, m] = t.split(':');
+  return `${h}:${m.padStart(2, '0')}`;
+}
+
+/** Normalize a time string like "9:0-17:0" to "9:00-17:00" */
+function normalizeTimeStr(timeStr: string): string {
+  const parts = timeStr.split('-');
+  return parts.length === 2
+    ? `${normalizeTimePart(parts[0])}-${normalizeTimePart(parts[1])}`
+    : normalizeTimePart(parts[0]);
 }
 
 /** Ensure a day entry exists in the days record, returning it */
@@ -216,7 +230,7 @@ function createMarkItem(
 
   const hasCheckbox = itemMatch[3];
   const checkMark = itemMatch[4];
-  const timeString = itemMatch[5];
+  const timeString = itemMatch[5] ? normalizeTimeStr(itemMatch[5]) : undefined;
   let content = itemMatch[8] || '';
 
   const type: ItemType = hasCheckbox ? 'task' : 'schedule';

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -118,7 +118,9 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
     } else if (part.startsWith('except:')) {
       part.substring(7).split(' ')
         .filter(d => d.match(/^\d{4}-\d{2}-\d{2}$/))
-        .forEach(d => exceptDates.add(d));
+        .forEach(d => {
+          try { parseLocalDate(d); exceptDates.add(d); } catch { /* ignore invalid dates */ }
+        });
     }
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -165,7 +165,7 @@ export function parseTmd(text: string): TaskMarkData {
       if (dateMatch[2]) {
         try {
           parseLocalDate(dateMatch[2]);
-          currentEndDate = dateMatch[2];
+          if (dateMatch[2] >= currentDate) { currentEndDate = dateMatch[2]; }
         } catch { /* ignore invalid end date */ }
       }
       ensureDay(data.days, currentDate);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -256,9 +256,7 @@ function expandRepeats(data: TaskMarkData): TaskMarkData {
 function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDays: Record<string, DayData>) {
   const origin = parseLocalDate(originDateStr);
   const opts = parseRepeatOptions(item.repeat!);
-  let generated = 0;
-  let i = 1;
-  while (generated < opts.count - 1) {
+  for (let i = 1; i < opts.count; i++) {
     const nextDate = new Date(origin);
 
     if (opts.mode === 'months') {
@@ -271,15 +269,12 @@ function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDa
       nextDate.setDate(origin.getDate() + opts.interval * i);
     }
 
-    i++;
-
     if (opts.until && nextDate > opts.until) break;
 
     const isoDate = toLocaleDateStr(nextDate);
     if (opts.exceptDates.has(isoDate)) { continue; }
 
     ensureDay(expandedDays, isoDate);
-    expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${generated + 1}`, tags: [...item.tags] });
-    generated++;
+    expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${i}`, tags: [...item.tags] });
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -256,7 +256,9 @@ function expandRepeats(data: TaskMarkData): TaskMarkData {
 function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDays: Record<string, DayData>) {
   const origin = parseLocalDate(originDateStr);
   const opts = parseRepeatOptions(item.repeat!);
-  for (let i = 1; i < opts.count; i++) {
+  let generated = 0;
+  let i = 1;
+  while (generated < opts.count - 1) {
     const nextDate = new Date(origin);
 
     if (opts.mode === 'months') {
@@ -269,12 +271,15 @@ function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDa
       nextDate.setDate(origin.getDate() + opts.interval * i);
     }
 
+    i++;
+
     if (opts.until && nextDate > opts.until) break;
 
     const isoDate = toLocaleDateStr(nextDate);
     if (opts.exceptDates.has(isoDate)) { continue; }
 
     ensureDay(expandedDays, isoDate);
-    expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${i}`, tags: [...item.tags] });
+    expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${generated + 1}`, tags: [...item.tags] });
+    generated++;
   }
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -19,6 +19,7 @@ export interface MarkItem {
   tags: string[];
   status?: TaskStatus;
   repeat?: string;
+  cancelDates?: string[];
   group?: string;
   rawLine: number;
 }
@@ -31,6 +32,7 @@ const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{2})(?:-(
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
 const TAG_SPLIT_REGEX = /#([^\s#]+)/g;
 const EVERY_REGEX = /^(\d+)(days?|weeks?|months?)$/;
+const CANCEL_REGEX = /^\\\s+(\d{4}-\d{2}-\d{2})$/;
 
 function toLocaleDateStr(d: Date): string {
   const y = d.getFullYear();
@@ -130,6 +132,7 @@ export function parseTmd(text: string): TaskMarkData {
   let inTagsBlock = false;
   let currentDate = '';
   let currentGroup = '';
+  let lastRepeatItem: MarkItem | null = null;
 
   for (let i = 0; i < lines.length; i++) {
     const rawLine = lines[i];
@@ -149,29 +152,39 @@ export function parseTmd(text: string): TaskMarkData {
       continue;
     }
 
-    // 2. Date header
+    // 2. Cancel date for the last repeat item
+    const cancelMatch = line.match(CANCEL_REGEX);
+    if (cancelMatch && lastRepeatItem) {
+      if (!lastRepeatItem.cancelDates) { lastRepeatItem.cancelDates = []; }
+      lastRepeatItem.cancelDates.push(cancelMatch[1]);
+      continue;
+    }
+
+    // 3. Date header
     const dateMatch = line.match(DATE_REGEX);
     if (dateMatch) {
       currentDate = dateMatch[1];
       ensureDay(data.days, currentDate);
       currentGroup = '';
+      lastRepeatItem = null;
       continue;
     }
 
-    // 3. Group header
+    // 4. Group header
     const groupMatch = line.match(GROUP_REGEX);
     if (groupMatch) {
       currentGroup = groupMatch[1].trim();
       continue;
     }
 
-    // 4. Item (schedule or task)
+    // 5. Item (schedule or task)
     const itemMatch = rawLine.match(ITEM_REGEX);
     if (itemMatch && itemMatch[2]) {
       const result = createMarkItem(itemMatch, i, currentDate, currentGroup);
       if (result) {
         data.days[currentDate].items.push(result.item);
         currentGroup = result.newGroup;
+        lastRepeatItem = result.item.repeat ? result.item : null;
       }
     }
   }
@@ -266,6 +279,8 @@ function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDa
     if (opts.until && nextDate > opts.until) break;
 
     const isoDate = toLocaleDateStr(nextDate);
+    if (item.cancelDates?.includes(isoDate)) { continue; }
+
     ensureDay(expandedDays, isoDate);
     expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${i}`, tags: [...item.tags] });
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -19,7 +19,6 @@ export interface MarkItem {
   tags: string[];
   status?: TaskStatus;
   repeat?: string;
-  cancelDates?: string[];
   group?: string;
   rawLine: number;
 }
@@ -32,7 +31,6 @@ const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{2})(?:-(
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
 const TAG_SPLIT_REGEX = /#([^\s#]+)/g;
 const EVERY_REGEX = /^(\d+)(days?|weeks?|months?)$/;
-const CANCEL_REGEX = /^\\\s+(\d{4}-\d{2}-\d{2})$/;
 
 function toLocaleDateStr(d: Date): string {
   const y = d.getFullYear();
@@ -80,6 +78,7 @@ interface RepeatOptions {
   interval: number; // days when mode='days', months when mode='months'
   until?: Date;
   count: number;
+  exceptDates: string[];
 }
 
 const MAX_OCCURRENCES = 3650;
@@ -90,6 +89,7 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
   let interval = 7; // default: weekly
   let until: Date | undefined;
   let count: number | undefined;
+  const exceptDates: string[] = [];
 
   for (const part of parts) {
     if (part.startsWith('every:')) {
@@ -115,12 +115,17 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
     } else if (part.startsWith('count:')) {
       const parsedCount = parseInt(part.substring(6), 10);
       if (!isNaN(parsedCount)) count = parsedCount;
+    } else if (part.startsWith('except:')) {
+      const dates = part.substring(7).split(' ');
+      for (const d of dates) {
+        if (d.match(/^\d{4}-\d{2}-\d{2}$/)) { exceptDates.push(d); }
+      }
     }
   }
 
   const finalCount = count !== undefined ? count : MAX_OCCURRENCES;
 
-  return { mode, interval, until, count: finalCount };
+  return { mode, interval, until, count: finalCount, exceptDates };
 }
 
 // ─── Main Parser ───────────────────────────────────────────────
@@ -132,7 +137,6 @@ export function parseTmd(text: string): TaskMarkData {
   let inTagsBlock = false;
   let currentDate = '';
   let currentGroup = '';
-  let lastRepeatItem: MarkItem | null = null;
 
   for (let i = 0; i < lines.length; i++) {
     const rawLine = lines[i];
@@ -152,39 +156,29 @@ export function parseTmd(text: string): TaskMarkData {
       continue;
     }
 
-    // 2. Cancel date for the last repeat item
-    const cancelMatch = line.match(CANCEL_REGEX);
-    if (cancelMatch && lastRepeatItem) {
-      if (!lastRepeatItem.cancelDates) { lastRepeatItem.cancelDates = []; }
-      lastRepeatItem.cancelDates.push(cancelMatch[1]);
-      continue;
-    }
-
-    // 3. Date header
+    // 2. Date header
     const dateMatch = line.match(DATE_REGEX);
     if (dateMatch) {
       currentDate = dateMatch[1];
       ensureDay(data.days, currentDate);
       currentGroup = '';
-      lastRepeatItem = null;
       continue;
     }
 
-    // 4. Group header
+    // 3. Group header
     const groupMatch = line.match(GROUP_REGEX);
     if (groupMatch) {
       currentGroup = groupMatch[1].trim();
       continue;
     }
 
-    // 5. Item (schedule or task)
+    // 4. Item (schedule or task)
     const itemMatch = rawLine.match(ITEM_REGEX);
     if (itemMatch && itemMatch[2]) {
       const result = createMarkItem(itemMatch, i, currentDate, currentGroup);
       if (result) {
         data.days[currentDate].items.push(result.item);
         currentGroup = result.newGroup;
-        lastRepeatItem = result.item.repeat ? result.item : null;
       }
     }
   }
@@ -279,7 +273,7 @@ function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDa
     if (opts.until && nextDate > opts.until) break;
 
     const isoDate = toLocaleDateStr(nextDate);
-    if (item.cancelDates?.includes(isoDate)) { continue; }
+    if (opts.exceptDates.includes(isoDate)) { continue; }
 
     ensureDay(expandedDays, isoDate);
     expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${i}`, tags: [...item.tags] });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -26,7 +26,7 @@ export interface MarkItem {
 
 // ─── Regex Patterns ────────────────────────────────────────────
 const TAG_COLOR_REGEX = /^#([^\s:]+)\s*:\s*(.+)$/;
-const DATE_REGEX = /^#\s+(\d{4}-\d{2}-\d{2})(?:\s*:\s*(\d{4}-\d{2}-\d{2}))?/;
+const DATE_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})(?:\s*:\s*(\d{4}-\d{1,2}-\d{1,2}))?/;
 const GROUP_REGEX = /^>\s*([^-\s].+)$/;
 const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{2})(?:-(\d{1,2}:\d{2}))?)?\s*(.*)$/;
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
@@ -160,12 +160,18 @@ export function parseTmd(text: string): TaskMarkData {
     // 2. Date header
     const dateMatch = line.match(DATE_REGEX);
     if (dateMatch) {
-      currentDate = dateMatch[1];
+      try {
+        currentDate = toLocaleDateStr(parseLocalDate(dateMatch[1]));
+      } catch {
+        currentDate = '';
+        continue;
+      }
       currentEndDate = '';
       if (dateMatch[2]) {
         try {
-          parseLocalDate(dateMatch[2]);
-          if (dateMatch[2] >= currentDate) { currentEndDate = dateMatch[2]; }
+          const parsedEnd = parseLocalDate(dateMatch[2]);
+          const normalizedEnd = toLocaleDateStr(parsedEnd);
+          if (normalizedEnd >= currentDate) { currentEndDate = normalizedEnd; }
         } catch { /* ignore invalid end date */ }
       }
       ensureDay(data.days, currentDate);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -255,7 +255,7 @@ function expandRepeats(data: TaskMarkData): TaskMarkData {
 
   Object.values(data.days).forEach(day => {
     day.items.forEach(item => {
-      if (!item.repeat || item.type === 'task') return;
+      if (!item.repeat || item.type === 'task' || item.endDate) return;
 
       generateRepeatedItems(item, day.date, expandedDays);
     });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -78,7 +78,7 @@ interface RepeatOptions {
   interval: number; // days when mode='days', months when mode='months'
   until?: Date;
   count: number;
-  exceptDates: string[];
+  exceptDates: Set<string>;
 }
 
 const MAX_OCCURRENCES = 3650;
@@ -89,7 +89,7 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
   let interval = 7; // default: weekly
   let until: Date | undefined;
   let count: number | undefined;
-  const exceptDates: string[] = [];
+  const exceptDates = new Set<string>();
 
   for (const part of parts) {
     if (part.startsWith('every:')) {
@@ -116,10 +116,9 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
       const parsedCount = parseInt(part.substring(6), 10);
       if (!isNaN(parsedCount)) count = parsedCount;
     } else if (part.startsWith('except:')) {
-      const dates = part.substring(7).split(' ');
-      for (const d of dates) {
-        if (d.match(/^\d{4}-\d{2}-\d{2}$/)) { exceptDates.push(d); }
-      }
+      part.substring(7).split(' ')
+        .filter(d => d.match(/^\d{4}-\d{2}-\d{2}$/))
+        .forEach(d => exceptDates.add(d));
     }
   }
 
@@ -273,7 +272,7 @@ function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDa
     if (opts.until && nextDate > opts.until) break;
 
     const isoDate = toLocaleDateStr(nextDate);
-    if (opts.exceptDates.includes(isoDate)) { continue; }
+    if (opts.exceptDates.has(isoDate)) { continue; }
 
     ensureDay(expandedDays, isoDate);
     expandedDays[isoDate].items.push({ ...item, id: `${item.id}-rep${i}`, tags: [...item.tags] });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -21,11 +21,12 @@ export interface MarkItem {
   repeat?: string;
   group?: string;
   rawLine: number;
+  endDate?: string;
 }
 
 // ─── Regex Patterns ────────────────────────────────────────────
 const TAG_COLOR_REGEX = /^#([^\s:]+)\s*:\s*(.+)$/;
-const DATE_REGEX = /^#\s+(\d{4}-\d{2}-\d{2})/;
+const DATE_REGEX = /^#\s+(\d{4}-\d{2}-\d{2})(?:\s*:\s*(\d{4}-\d{2}-\d{2}))?/;
 const GROUP_REGEX = /^>\s*([^-\s].+)$/;
 const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{2})(?:-(\d{1,2}:\d{2}))?)?\s*(.*)$/;
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
@@ -135,6 +136,7 @@ export function parseTmd(text: string): TaskMarkData {
 
   let inTagsBlock = false;
   let currentDate = '';
+  let currentEndDate = '';
   let currentGroup = '';
 
   for (let i = 0; i < lines.length; i++) {
@@ -159,6 +161,13 @@ export function parseTmd(text: string): TaskMarkData {
     const dateMatch = line.match(DATE_REGEX);
     if (dateMatch) {
       currentDate = dateMatch[1];
+      currentEndDate = '';
+      if (dateMatch[2]) {
+        try {
+          parseLocalDate(dateMatch[2]);
+          currentEndDate = dateMatch[2];
+        } catch { /* ignore invalid end date */ }
+      }
       ensureDay(data.days, currentDate);
       currentGroup = '';
       continue;
@@ -174,7 +183,7 @@ export function parseTmd(text: string): TaskMarkData {
     // 4. Item (schedule or task)
     const itemMatch = rawLine.match(ITEM_REGEX);
     if (itemMatch && itemMatch[2]) {
-      const result = createMarkItem(itemMatch, i, currentDate, currentGroup);
+      const result = createMarkItem(itemMatch, i, currentDate, currentGroup, currentEndDate);
       if (result) {
         data.days[currentDate].items.push(result.item);
         currentGroup = result.newGroup;
@@ -190,6 +199,7 @@ function createMarkItem(
   lineIndex: number,
   currentDate: string,
   currentGroup: string,
+  endDate = '',
 ): { item: MarkItem; newGroup: string } | null {
   if (!currentDate) {
     return null;
@@ -228,7 +238,8 @@ function createMarkItem(
     status,
     repeat: repeatStr,
     group: newGroup || undefined,
-    rawLine: lineIndex
+    rawLine: lineIndex,
+    endDate: endDate || undefined,
   };
 
   return { item, newGroup };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -132,7 +132,7 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
       if (!isNaN(parsedCount)) count = parsedCount;
     } else if (part.startsWith('except:')) {
       for (const d of part.substring(7).trim().split(/\s+/).filter(Boolean)) {
-        try { parseLocalDate(d); exceptDates.add(d); } catch { /* ignore invalid dates */ }
+        try { exceptDates.add(toLocaleDateStr(parseLocalDate(d))); } catch { /* ignore invalid dates */ }
       }
     }
   }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -116,11 +116,9 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
       const parsedCount = parseInt(part.substring(6), 10);
       if (!isNaN(parsedCount)) count = parsedCount;
     } else if (part.startsWith('except:')) {
-      part.substring(7).split(' ')
-        .filter(d => d.match(/^\d{4}-\d{2}-\d{2}$/))
-        .forEach(d => {
-          try { parseLocalDate(d); exceptDates.add(d); } catch { /* ignore invalid dates */ }
-        });
+      for (const d of part.substring(7).split(' ')) {
+        try { parseLocalDate(d); exceptDates.add(d); } catch { /* ignore invalid dates */ }
+      }
     }
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -62,6 +62,15 @@ function normalizeTimeStr(timeStr: string): string {
   return timeStr.split('-').map(normalizeTimePart).join('-');
 }
 
+/** Parse and normalize a date string to 'YYYY-MM-DD'. Returns null if invalid. */
+function tryNormalizeDate(dateStr: string): string | null {
+  try {
+    return toLocaleDateStr(parseLocalDate(dateStr));
+  } catch {
+    return null;
+  }
+}
+
 /** Ensure a day entry exists in the days record, returning it */
 function ensureDay(days: Record<string, DayData>, dateStr: string): DayData {
   if (!days[dateStr]) {
@@ -129,7 +138,8 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
       if (!isNaN(parsedCount)) count = parsedCount;
     } else if (part.startsWith('except:')) {
       for (const d of part.substring(7).trim().split(/\s+/).filter(Boolean)) {
-        try { exceptDates.add(toLocaleDateStr(parseLocalDate(d))); } catch { /* ignore invalid dates */ }
+        const normalized = tryNormalizeDate(d);
+        if (normalized) { exceptDates.add(normalized); }
       }
     }
   }
@@ -171,19 +181,13 @@ export function parseTmd(text: string): TaskMarkData {
     // 2. Date header
     const dateMatch = line.match(DATE_REGEX);
     if (dateMatch) {
-      try {
-        currentDate = toLocaleDateStr(parseLocalDate(dateMatch[1]));
-      } catch {
-        currentDate = '';
-        continue;
-      }
+      const normalizedStart = tryNormalizeDate(dateMatch[1]);
+      if (!normalizedStart) { currentDate = ''; continue; }
+      currentDate = normalizedStart;
       currentEndDate = '';
       if (dateMatch[2]) {
-        try {
-          const parsedEnd = parseLocalDate(dateMatch[2]);
-          const normalizedEnd = toLocaleDateStr(parsedEnd);
-          if (normalizedEnd >= currentDate) { currentEndDate = normalizedEnd; }
-        } catch { /* ignore invalid end date */ }
+        const normalizedEnd = tryNormalizeDate(dateMatch[2]);
+        if (normalizedEnd && normalizedEnd >= currentDate) { currentEndDate = normalizedEnd; }
       }
       ensureDay(data.days, currentDate);
       currentGroup = '';

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -59,10 +59,7 @@ function normalizeTimePart(t: string): string {
 
 /** Normalize a time string like "9:0-17:0" to "9:00-17:00" */
 function normalizeTimeStr(timeStr: string): string {
-  const parts = timeStr.split('-');
-  return parts.length === 2
-    ? `${normalizeTimePart(parts[0])}-${normalizeTimePart(parts[1])}`
-    : normalizeTimePart(parts[0]);
+  return timeStr.split('-').map(normalizeTimePart).join('-');
 }
 
 /** Ensure a day entry exists in the days record, returning it */

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -87,18 +87,6 @@ suite('Parser Test Suite', () => {
     assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
   });
 
-  test('parseTmd repeat except still generates count items after skip', () => {
-    const text = `
-# 2026-03-16
-- 10:00-11:00 Weekly Sync @repeat(weekly, count:3, except:2026-03-23)
-`;
-    const data = parseTmd(text);
-    assert.ok(data.days['2026-03-16'], '2026-03-16 should exist (origin)');
-    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
-    assert.ok(data.days['2026-03-30'], '2026-03-30 should exist');
-    assert.ok(data.days['2026-04-06'], '2026-04-06 should exist (count:3 = 2 repeats after origin)');
-  });
-
   test('parseTmd repeat except ignores invalid dates', () => {
     const text = `
 # 2026-03-16

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -167,4 +167,15 @@ suite('Parser Test Suite', () => {
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0].endDate, undefined);
   });
+
+  test('parseTmd endDate takes priority over @repeat: repeat is not expanded', () => {
+    const text = `
+# 2026-03-01 : 2026-03-10
+- Daily standup @repeat(daily, count:5)
+`;
+    const data = parseTmd(text);
+    assert.strictEqual(Object.keys(data.days).length, 1, 'Only start day should exist');
+    assert.ok(data.days['2026-03-01'], 'Start day should exist');
+    assert.ok(!data.days['2026-03-02'], 'Repeat should not expand when endDate is set');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -208,4 +208,26 @@ suite('Parser Test Suite', () => {
     const data = parseTmd(text);
     assert.strictEqual(Object.keys(data.days).length, 0, 'Invalid date header should be ignored');
   });
+
+  test('parseTmd time with unpadded minutes is normalized', () => {
+    const text = `
+# 2026-03-01
+- 9:0-17:0 Conference
+`;
+    const data = parseTmd(text);
+    const items = data.days['2026-03-01'].items;
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].time, '9:00-17:00');
+  });
+
+  test('parseTmd start time only with unpadded minutes is normalized', () => {
+    const text = `
+# 2026-03-01
+- 9:0 Meeting
+`;
+    const data = parseTmd(text);
+    const items = data.days['2026-03-01'].items;
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].time, '9:00');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -87,6 +87,18 @@ suite('Parser Test Suite', () => {
     assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
   });
 
+  test('parseTmd repeat except still generates count items after skip', () => {
+    const text = `
+# 2026-03-16
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:3, except:2026-03-23)
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-16'], '2026-03-16 should exist (origin)');
+    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
+    assert.ok(data.days['2026-03-30'], '2026-03-30 should exist');
+    assert.ok(data.days['2026-04-06'], '2026-04-06 should exist (count:3 = 2 repeats after origin)');
+  });
+
   test('parseTmd repeat except ignores invalid dates', () => {
     const text = `
 # 2026-03-16

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -87,6 +87,16 @@ suite('Parser Test Suite', () => {
     assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
   });
 
+  test('parseTmd repeat except ignores invalid dates', () => {
+    const text = `
+# 2026-03-16
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:3, except:2026-02-30)
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-23'], '2026-03-23 should exist because except date was invalid');
+    assert.ok(data.days['2026-03-30'], '2026-03-30 should exist');
+  });
+
   test('parseTmd repeat except skips multiple specified dates', () => {
     const text = `
 # 2026-03-16

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -156,4 +156,15 @@ suite('Parser Test Suite', () => {
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0].endDate, undefined);
   });
+
+  test('parseTmd date range where end date is before start date is ignored', () => {
+    const text = `
+# 2026-03-10 : 2026-03-01
+- Conference
+`;
+    const data = parseTmd(text);
+    const items = data.days['2026-03-10'].items;
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].endDate, undefined);
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -178,4 +178,34 @@ suite('Parser Test Suite', () => {
     assert.ok(data.days['2026-03-01'], 'Start day should exist');
     assert.ok(!data.days['2026-03-02'], 'Repeat should not expand when endDate is set');
   });
+
+  test('parseTmd date header without zero-padding is normalized and parsed', () => {
+    const text = `
+# 2026-3-1
+- Meeting
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-01'], 'Day should be stored with zero-padded key');
+    assert.strictEqual(data.days['2026-03-01'].items.length, 1);
+    assert.strictEqual(data.days['2026-03-01'].items[0].text, 'Meeting');
+  });
+
+  test('parseTmd date range end date without zero-padding is normalized', () => {
+    const text = `
+# 2026-3-1 : 2026-3-10
+- Conference
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-01'], 'Start day should be zero-padded');
+    assert.strictEqual(data.days['2026-03-01'].items[0].endDate, '2026-03-10');
+  });
+
+  test('parseTmd date header with invalid month is ignored', () => {
+    const text = `
+# 2026-13-1
+- Meeting
+`;
+    const data = parseTmd(text);
+    assert.strictEqual(Object.keys(data.days).length, 0, 'Invalid date header should be ignored');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -230,4 +230,15 @@ suite('Parser Test Suite', () => {
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0].time, '9:00');
   });
+
+  test('parseTmd repeat except with unpadded date skips the correct day', () => {
+    const text = `
+# 2026-03-16
+- Weekly Sync @repeat(weekly, count:3, except:2026-3-23)
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
+    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
+    assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -108,4 +108,52 @@ suite('Parser Test Suite', () => {
     assert.ok(!data.days['2026-03-30'], '2026-03-30 should be skipped');
     assert.ok(data.days['2026-04-06'], '2026-04-06 should still exist');
   });
+
+  test('parseTmd date range header sets endDate on items', () => {
+    const text = `
+# 2026-03-01 : 2026-03-10
+- Conference #Work
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-01'], 'Start day should exist');
+    assert.ok(!data.days['2026-03-10'], 'End day should NOT be a separate entry');
+
+    const items = data.days['2026-03-01'].items;
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].endDate, '2026-03-10');
+  });
+
+  test('parseTmd single date header does not set endDate', () => {
+    const text = `
+# 2026-03-01
+- Regular item
+`;
+    const data = parseTmd(text);
+    const items = data.days['2026-03-01'].items;
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].endDate, undefined);
+  });
+
+  test('parseTmd date range with task sets endDate', () => {
+    const text = `
+# 2026-03-01 : 2026-03-05
+- [ ] Multi-day task
+`;
+    const data = parseTmd(text);
+    const items = data.days['2026-03-01'].items;
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].type, 'task');
+    assert.strictEqual(items[0].endDate, '2026-03-05');
+  });
+
+  test('parseTmd date range with invalid end date falls back to single date', () => {
+    const text = `
+# 2026-03-01 : 2026-02-30
+- Conference
+`;
+    const data = parseTmd(text);
+    const items = data.days['2026-03-01'].items;
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].endDate, undefined);
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -75,4 +75,42 @@ suite('Parser Test Suite', () => {
     assert.ok(data.days['2026-03-28']);
     assert.strictEqual(Object.keys(data.days).length, 3, 'Should create 3 days of repeatable task');
   });
+
+  test('parseTmd repeat cancel skips specified date', () => {
+    const text = `
+# 2026-03-16
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:3)
+\\ 2026-03-23
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
+    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be cancelled');
+    assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
+  });
+
+  test('parseTmd repeat cancel skips multiple specified dates', () => {
+    const text = `
+# 2026-03-16
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:4)
+\\ 2026-03-23
+\\ 2026-03-30
+`;
+    const data = parseTmd(text);
+    assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
+    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be cancelled');
+    assert.ok(!data.days['2026-03-30'], '2026-03-30 should be cancelled');
+    assert.ok(data.days['2026-04-06'], '2026-04-06 should still exist');
+  });
+
+  test('parseTmd repeat cancel does not affect non-repeat items', () => {
+    const text = `
+# 2026-03-16
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:3)
+\\ 2026-03-23
+- One-off event
+`;
+    const data = parseTmd(text);
+    const items = data.days['2026-03-16'].items;
+    assert.strictEqual(items.length, 2, 'Both items should exist on origin date');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -76,41 +76,26 @@ suite('Parser Test Suite', () => {
     assert.strictEqual(Object.keys(data.days).length, 3, 'Should create 3 days of repeatable task');
   });
 
-  test('parseTmd repeat cancel skips specified date', () => {
+  test('parseTmd repeat except skips specified date', () => {
     const text = `
 # 2026-03-16
-- 10:00-11:00 Weekly Sync @repeat(weekly, count:3)
-\\ 2026-03-23
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:3, except:2026-03-23)
 `;
     const data = parseTmd(text);
     assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
-    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be cancelled');
+    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
     assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
   });
 
-  test('parseTmd repeat cancel skips multiple specified dates', () => {
+  test('parseTmd repeat except skips multiple specified dates', () => {
     const text = `
 # 2026-03-16
-- 10:00-11:00 Weekly Sync @repeat(weekly, count:4)
-\\ 2026-03-23
-\\ 2026-03-30
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:4, except:2026-03-23 2026-03-30)
 `;
     const data = parseTmd(text);
     assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
-    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be cancelled');
-    assert.ok(!data.days['2026-03-30'], '2026-03-30 should be cancelled');
+    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
+    assert.ok(!data.days['2026-03-30'], '2026-03-30 should be skipped');
     assert.ok(data.days['2026-04-06'], '2026-04-06 should still exist');
-  });
-
-  test('parseTmd repeat cancel does not affect non-repeat items', () => {
-    const text = `
-# 2026-03-16
-- 10:00-11:00 Weekly Sync @repeat(weekly, count:3)
-\\ 2026-03-23
-- One-off event
-`;
-    const data = parseTmd(text);
-    const items = data.days['2026-03-16'].items;
-    assert.strictEqual(items.length, 2, 'Both items should exist on origin date');
   });
 });

--- a/syntaxes/tmd.tmLanguage.json
+++ b/syntaxes/tmd.tmLanguage.json
@@ -3,7 +3,7 @@
   "name": "TaskMark",
   "patterns": [
     {
-      "match": "^#\\s+(\\d{4}-\\d{2}-\\d{2})(?:\\s*:\\s*(\\d{4}-\\d{2}-\\d{2}))?",
+      "match": "^#\\s+(\\d{4}-\\d{1,2}-\\d{1,2})(?:\\s*:\\s*(\\d{4}-\\d{1,2}-\\d{1,2}))?",
       "captures": {
         "1": { "name": "constant.numeric.date.tmd" },
         "2": { "name": "constant.numeric.date.tmd" }

--- a/syntaxes/tmd.tmLanguage.json
+++ b/syntaxes/tmd.tmLanguage.json
@@ -3,14 +3,14 @@
   "name": "TaskMark",
   "patterns": [
     {
-      "include": "source.markdown"
-    },
-    {
       "match": "^#\\s+(\\d{4}-\\d{2}-\\d{2})(?:\\s*:\\s*(\\d{4}-\\d{2}-\\d{2}))?",
       "captures": {
         "1": { "name": "constant.numeric.date.tmd" },
         "2": { "name": "constant.numeric.date.tmd" }
       }
+    },
+    {
+      "include": "source.markdown"
     },
     {
       "begin": "^\\s*@tags\\s*$",

--- a/syntaxes/tmd.tmLanguage.json
+++ b/syntaxes/tmd.tmLanguage.json
@@ -6,6 +6,13 @@
       "include": "source.markdown"
     },
     {
+      "match": "^#\\s+(\\d{4}-\\d{2}-\\d{2})(?:\\s*:\\s*(\\d{4}-\\d{2}-\\d{2}))?",
+      "captures": {
+        "1": { "name": "constant.numeric.date.tmd" },
+        "2": { "name": "constant.numeric.date.tmd" }
+      }
+    },
+    {
       "begin": "^\\s*@tags\\s*$",
       "end": "^\\s*@end\\s*$",
       "name": "meta.tag-definitions.tmd",


### PR DESCRIPTION
## 概要
developブランチの変更をmainへマージします。

## 含まれる主な変更

### feat: リピート機能のキャンセル (closes #8)
- `except:` 修飾子で特定日付をリピートからスキップ可能に

### feat: 期間指定による予定・タスクのサポート (closes #17)
- `# YYYY-MM-DD : YYYY-MM-DD` 構文で複数日にまたがる単一の予定・タスクを作成可能に
- タイムラインでは1本の連続したバーとして表示
- カレンダービューではレンジ内の全日付セルに表示
- 終日イベント専用（time指定は無視）
- repeatオプションはendDateが優先されスキップ
- シンタックスハイライト対応

### fix: 日付・時刻の0パディングなし入力を受け付けて正規化 (closes #28)
- `# 2026-3-1` → `2026-03-01` として正規化
- `- 9:0-17:0` → `9:00-17:00` として正規化
- repeatオプションの `except:` 日付も正規化
- 無効な日付（月13など）は従来通り無視

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| 複数日の予定はrepeatで大量の行が出る | `# 2026-03-01 : 2026-03-10` で1本のバーとして表示 |
| `# 2026-3-1` が無視される | 正常に解析される |