### PR TITLE
chore: bump version to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to the "TaskMark" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.2.0] - 2026-03-28
+
+### Added
+- Date range support for events and tasks (e.g., `2026-04-01 ~ 2026-04-03`) (#17).
+- Syntax highlighting for date range headers.
+- `except:` modifier to cancel specific occurrences of a repeat schedule.
+
+### Fixed
+- Accept unpadded dates and times and normalize to zero-padded format (#28).
+- `except:` dates in repeat options are now normalized for correct skip matching.
+- Date range end date now takes priority over `@repeat` and time fields.
+- Time display is hidden for date range items in calendar view.
+- Date range with end date before start date is now rejected.
+- Date header highlight rule priority corrected to prevent override by Markdown scope.
+
 ## [1.1.0] - 2026-03-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "taskmark",
   "displayName": "TaskMark",
   "description": "Schedule and Task Management with Markdown and Calendar/Timeline Views",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "icon": "media/icon.png",
   "publisher": "Yadecode",
   "repository": {


### PR DESCRIPTION
## Summary
- `package.json` のバージョンを `1.1.0` → `1.2.0` に更新
- `CHANGELOG.md` に v1.2.0 のエントリを追加（日付範囲サポート、`except:` modifier、unpadded date/time 正規化などを記載）

## Changes since v1.1.0

### Added
- Date range support for events and tasks (#17)
- Syntax highlighting for date range headers
- `except:` modifier to cancel specific occurrences of a repeat schedule

### Fixed
- Accept unpadded dates and times and normalize to zero-padded format (#28)
- `except:` dates in repeat options are now normalized for correct skip matching
- Date range end date now takes priority over `@repeat` and time fields
- Time display is hidden for date range items in calendar view
- Date range with end date before start date is now rejected
- Date header highlight rule priority corrected to prevent override by Markdown scope

## Test plan
- [x] バージョン表示が 1.2.0 になっていることを確認
- [x] CHANGELOG の内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)