### PR TITLE
chore: fix package-lock.json engines.vscode to 1.115.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "vscode": "^1.90.0"
+        "vscode": "^1.115.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {


### PR DESCRIPTION
## Summary

- `package-lock.json` の `engines.vscode` が `^1.90.0` のまま残っていたため、`npm install` を実行して `^1.115.0` に修正

## Test plan

- [ ] `package-lock.json` L23 が `^1.115.0` であることを確認
- [ ] CI がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)