### PR TITLE
fix: ガントチャートのドラッグ中のテキスト選択とつかみっぱなし問題を修正

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -180,7 +180,7 @@
     if (!isPanning) return;
     isPanning = false;
     document.body.style.userSelect = '';
-    if (viewTimeline) viewTimeline.style.cursor = 'grab';
+    viewTimeline.style.cursor = 'grab';
   }
 
   // Gantt panning

--- a/media/main.js
+++ b/media/main.js
@@ -197,7 +197,7 @@
   window.addEventListener('mousemove', (e) => {
     if (!isPanning) return;
     // Button released outside the window: end panning on the next in-window mousemove
-    if (e.buttons === 0) {
+    if (!(e.buttons & 1)) {
       stopPanning();
       return;
     }

--- a/media/main.js
+++ b/media/main.js
@@ -204,7 +204,9 @@
     viewTimeline.scrollLeft = initialScrollL - (e.clientX - startPanX);
     viewTimeline.scrollTop = initialScrollT - (e.clientY - startPanY);
   });
-  window.addEventListener('mouseup', stopPanning);
+  window.addEventListener('mouseup', (e) => {
+    if (e.button === 0) stopPanning();
+  });
   window.addEventListener('blur', stopPanning);
 
   // Gantt zoom

--- a/media/main.js
+++ b/media/main.js
@@ -177,6 +177,7 @@
   });
 
   function stopPanning() {
+    if (!isPanning) return;
     isPanning = false;
     document.body.style.userSelect = '';
     if (viewTimeline) viewTimeline.style.cursor = 'grab';

--- a/media/main.js
+++ b/media/main.js
@@ -194,12 +194,15 @@
   });
   window.addEventListener('mousemove', (e) => {
     if (!isPanning) return;
+    // Button released outside the window: end panning on the next in-window mousemove
+    if (e.buttons === 0) {
+      stopPanning();
+      return;
+    }
     viewTimeline.scrollLeft = initialScrollL - (e.clientX - startPanX);
     viewTimeline.scrollTop = initialScrollT - (e.clientY - startPanY);
   });
   window.addEventListener('mouseup', stopPanning);
-  // End panning when cursor leaves the browser window to avoid stuck grab state
-  document.addEventListener('mouseleave', stopPanning);
 
   // Gantt zoom
   viewTimeline?.addEventListener('wheel', (e) => {

--- a/media/main.js
+++ b/media/main.js
@@ -178,6 +178,7 @@
 
   // Gantt panning
   viewTimeline?.addEventListener('mousedown', (e) => {
+    e.preventDefault(); // prevent text selection during drag
     isPanning = true;
     startPanX = e.clientX;
     startPanY = e.clientY;
@@ -191,6 +192,11 @@
     viewTimeline.scrollTop = initialScrollT - (e.clientY - startPanY);
   });
   window.addEventListener('mouseup', () => {
+    isPanning = false;
+    if (viewTimeline) viewTimeline.style.cursor = 'grab';
+  });
+  // End panning when cursor leaves the browser window to avoid stuck grab state
+  document.addEventListener('mouseleave', () => {
     isPanning = false;
     if (viewTimeline) viewTimeline.style.cursor = 'grab';
   });

--- a/media/main.js
+++ b/media/main.js
@@ -176,30 +176,30 @@
     }
   });
 
+  function stopPanning() {
+    isPanning = false;
+    document.body.style.userSelect = '';
+    if (viewTimeline) viewTimeline.style.cursor = 'grab';
+  }
+
   // Gantt panning
   viewTimeline?.addEventListener('mousedown', (e) => {
-    e.preventDefault(); // prevent text selection during drag
     isPanning = true;
     startPanX = e.clientX;
     startPanY = e.clientY;
     initialScrollL = viewTimeline.scrollLeft;
     initialScrollT = viewTimeline.scrollTop;
     viewTimeline.style.cursor = 'grabbing';
+    document.body.style.userSelect = 'none'; // suppress text selection during drag only
   });
   window.addEventListener('mousemove', (e) => {
     if (!isPanning) return;
     viewTimeline.scrollLeft = initialScrollL - (e.clientX - startPanX);
     viewTimeline.scrollTop = initialScrollT - (e.clientY - startPanY);
   });
-  window.addEventListener('mouseup', () => {
-    isPanning = false;
-    if (viewTimeline) viewTimeline.style.cursor = 'grab';
-  });
+  window.addEventListener('mouseup', stopPanning);
   // End panning when cursor leaves the browser window to avoid stuck grab state
-  document.addEventListener('mouseleave', () => {
-    isPanning = false;
-    if (viewTimeline) viewTimeline.style.cursor = 'grab';
-  });
+  document.addEventListener('mouseleave', stopPanning);
 
   // Gantt zoom
   viewTimeline?.addEventListener('wheel', (e) => {

--- a/media/main.js
+++ b/media/main.js
@@ -205,6 +205,7 @@
     viewTimeline.scrollTop = initialScrollT - (e.clientY - startPanY);
   });
   window.addEventListener('mouseup', stopPanning);
+  window.addEventListener('blur', stopPanning);
 
   // Gantt zoom
   viewTimeline?.addEventListener('wheel', (e) => {

--- a/media/main.js
+++ b/media/main.js
@@ -184,6 +184,7 @@
 
   // Gantt panning
   viewTimeline?.addEventListener('mousedown', (e) => {
+    if (e.button !== 0) return;
     isPanning = true;
     startPanX = e.clientX;
     startPanY = e.clientY;


### PR DESCRIPTION
## 関連Issue
Closes #38

## 概要
ガントチャートのドラッグ操作で発生していた2つの問題を修正した。

1. ドラッグ中にテキストが選択される問題
2. カーソルをウィンドウ外に移動してマウスボタンを離してもドラッグが解除されない問題

## 変更内容
- `mousedown` 時に `document.body.style.userSelect = 'none'` を設定し、ドラッグ中のテキスト選択のみを抑制（`e.preventDefault()` は使用しない）
- `mousemove` ハンドラ内で `e.buttons === 0` をチェックし、ウィンドウ外でマウスボタンが離された場合にドラッグを正常終了させる

## 動作確認・テスト
- [ ] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [ ] 既存の機能に影響（デグレ）がないことを確認した
- [ ] 必要に応じてドキュメントを更新した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| ドラッグ中にテキストが選択される | テキスト選択が発生しない |
| ウィンドウ外でマウスを離してもつかみっぱなし | ウィンドウ外でマウスを離すとドラッグが正常終了 |

## 備考・次やること
なし