### PR TITLE
feat: ガントチャートでグループタスクの構成タスクを子行として表示する

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -238,7 +238,7 @@
   // ─── Main Render ─────────────────────────────────────────────
 
   function render() {
-    if (!currentTaskMarkData) return;
+    if (!currentTaskMarkData || !currentGanttData) return;
 
     const year = currentDate.getFullYear();
     const month = currentDate.getMonth() + 1;
@@ -717,10 +717,11 @@
     // Render entity bars
     let yOffset = GANTT_HEADER_HEIGHT;
     entityArray.forEach(entity => {
-      renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, yOffset, totalWidth);
+      const entityYOffset = yOffset;
+      renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
       yOffset += GANTT_ROW_HEIGHT;
       if (entity.isGroup) {
-        renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, yOffset - GANTT_ROW_HEIGHT, totalWidth);
+        renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
         yOffset += GANTT_ROW_HEIGHT * entity.children.length;
       }
     });

--- a/media/main.js
+++ b/media/main.js
@@ -617,7 +617,7 @@
   /** Render child task rows below the group bar */
   function renderGroupChildren(container, entity, startDate, pxPerMs, groupYOffset, totalWidth) {
     entity.children.forEach((child, i) => {
-      const childYOffset = groupYOffset + GANTT_ROW_HEIGHT * (i + 1);
+      const childYOffset = groupYOffset + (GANTT_ROW_HEIGHT + 4) * (i + 1);
 
       // Child row background
       const rowBg = document.createElement('div');
@@ -719,10 +719,10 @@
     entityArray.forEach(entity => {
       const entityYOffset = yOffset;
       renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
-      yOffset += GANTT_ROW_HEIGHT;
+      yOffset += GANTT_ROW_HEIGHT + 4;
       if (entity.isGroup) {
         renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
-        yOffset += GANTT_ROW_HEIGHT * entity.children.length;
+        yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
       }
     });
 

--- a/media/main.js
+++ b/media/main.js
@@ -15,6 +15,7 @@
   let activeView = 'monthly'; // 'monthly' | 'weekly' | 'daily'
   let currentDate = new Date();
   let currentTaskMarkData = null;
+  let currentGanttData = null;
   let ganttZoom = 1; // 1 = 100px per day
   let isPanning = false;
   let startPanX = 0;
@@ -121,6 +122,7 @@
     const message = event.data;
     if (message.type === 'update') {
       currentTaskMarkData = message.data;
+      currentGanttData = message.ganttData;
       render();
     }
   });
@@ -498,81 +500,6 @@
 
   // ─── Gantt / Timeline View ───────────────────────────────────
 
-  /** Collect entities (groups and standalone items) from sorted dates.
-   *  Also returns lastDateStr accounting for endDate ranges to avoid a separate scan. */
-  function collectGanttEntities(sortedDates) {
-    const entities = {};
-    let lastDateStr = sortedDates[sortedDates.length - 1];
-
-    sortedDates.forEach(dStr => {
-      const dayData = currentTaskMarkData.days[dStr];
-      const dayStartMs = parseLocalDate(dStr).getTime();
-
-      dayData.items.forEach(item => {
-        if (item.endDate && item.endDate > lastDateStr) lastDateStr = item.endDate;
-
-        let startMs = dayStartMs;
-        let endMs = item.endDate
-          ? getEndOfDayMs(item.endDate)
-          : getEndOfDayMs(dStr);
-
-        if (itemHasTime(item)) {
-          const parts = item.time.split('-');
-          const sTime = parts[0].trim().split(':');
-          if (sTime.length >= 2) {
-            startMs = dayStartMs + parseInt(sTime[0]) * MS_PER_HOUR + parseInt(sTime[1]) * MS_PER_MINUTE;
-          }
-          if (parts[1]) {
-            const eTime = parts[1].trim().split(':');
-            if (eTime.length >= 2) {
-              endMs = dayStartMs + parseInt(eTime[0]) * MS_PER_HOUR + parseInt(eTime[1]) * MS_PER_MINUTE;
-            }
-          } else {
-            endMs = startMs + MS_PER_HOUR;
-          }
-        }
-
-        const eName = item.group ? `[Group] ${item.group}` : item.text;
-        if (!entities[eName]) {
-          entities[eName] = {
-            name: item.group || item.text,
-            isGroup: !!item.group,
-            minTime: startMs,
-            maxTime: endMs,
-            tags: item.tags || [],
-            tasksTotal: 0,
-            tasksDone: 0,
-            children: []
-          };
-        } else {
-          if (startMs < entities[eName].minTime) entities[eName].minTime = startMs;
-          if (endMs > entities[eName].maxTime) entities[eName].maxTime = endMs;
-        }
-
-        entities[eName].children.push({
-          text: item.text,
-          tags: item.tags || [],
-          startMs,
-          endMs,
-          isTask: item.type === 'task',
-          isDone: item.status === 'done'
-        });
-
-        if (item.type === 'task') {
-          entities[eName].tasksTotal++;
-          if (item.status === 'done') entities[eName].tasksDone++;
-        }
-      });
-    });
-
-    return {
-      entities: Object.values(entities).sort(
-        (a, b) => a.minTime - b.minTime || a.name.localeCompare(b.name)
-      ),
-      lastDateStr
-    };
-  }
-
   /** Render the date axis row and weekend column backgrounds */
   function renderGanttAxis(container, startDate, totalRenderDays, pxPerMs) {
     const axisRow = document.createElement('div');
@@ -763,8 +690,9 @@
     // Clamp zoom
     ganttZoom = Math.max(0.1, Math.min(48, ganttZoom));
 
-    // Collect entities; lastDateStr accounts for endDate ranges (avoids a separate scan)
-    const { entities: entityArray, lastDateStr } = collectGanttEntities(sortedDates);
+    // Use pre-computed entities from the extension (built via buildGanttEntities in gantt.ts)
+    const entityArray = currentGanttData.entities;
+    const lastDateStr = currentGanttData.lastDateStr;
     const endDate = parseLocalDate(lastDateStr);
     endDate.setDate(endDate.getDate() + (6 - endDate.getDay()) + 1);
 

--- a/media/main.js
+++ b/media/main.js
@@ -47,7 +47,7 @@
   /** Parse 'YYYY-MM-DD' string into a local midnight Date */
   function parseLocalDate(dateStr) {
     const p = dateStr.split('-');
-    return new Date(parseInt(p[0]), parseInt(p[1]) - 1, parseInt(p[2]));
+    return new Date(parseInt(p[0], 10), parseInt(p[1], 10) - 1, parseInt(p[2], 10));
   }
 
   /** Get today's date as 'YYYY-MM-DD' */

--- a/media/main.js
+++ b/media/main.js
@@ -542,14 +542,16 @@
             tags: item.tags || [],
             tasksTotal: 0,
             tasksDone: 0,
-            items: []
+            children: []
           };
         } else {
           if (startMs < entities[eName].minTime) entities[eName].minTime = startMs;
           if (endMs > entities[eName].maxTime) entities[eName].maxTime = endMs;
         }
 
-        entities[eName].items.push({
+        entities[eName].children.push({
+          text: item.text,
+          tags: item.tags || [],
           startMs,
           endMs,
           isTask: item.type === 'task',
@@ -663,16 +665,16 @@
   }
 
   function renderStandaloneBars(container, entity, startDate, pxPerMs, yOffset, bgColor) {
-    entity.items.forEach(itemObj => {
-      const left = (itemObj.startMs - startDate.getTime()) * pxPerMs;
-      const width = Math.max((itemObj.endMs - itemObj.startMs) * pxPerMs, GANTT_MIN_BAR_WIDTH);
+    entity.children.forEach(child => {
+      const left = (child.startMs - startDate.getTime()) * pxPerMs;
+      const width = Math.max((child.endMs - child.startMs) * pxPerMs, GANTT_MIN_BAR_WIDTH);
 
       const bar = createGanttBar(left, yOffset, width, bgColor);
 
       const pBar = document.createElement('div');
       pBar.className = 'tm-gantt-progress';
-      if (itemObj.isTask) {
-        pBar.style.width = itemObj.isDone ? '100%' : '0%';
+      if (child.isTask) {
+        pBar.style.width = child.isDone ? '100%' : '0%';
       } else {
         pBar.style.width = '100%';
       }
@@ -682,6 +684,41 @@
 
       // Label (outside bar, to the right)
       container.appendChild(createGanttLabel(entity.name, left + width, yOffset));
+    });
+  }
+
+  /** Render child task rows below the group bar */
+  function renderGroupChildren(container, entity, startDate, pxPerMs, groupYOffset, totalWidth) {
+    entity.children.forEach((child, i) => {
+      const childYOffset = groupYOffset + GANTT_ROW_HEIGHT * (i + 1);
+
+      // Child row background
+      const rowBg = document.createElement('div');
+      rowBg.className = 'tm-gantt-row-bg tm-gantt-child-row-bg';
+      rowBg.style.top = childYOffset + 'px';
+      rowBg.style.width = totalWidth + 'px';
+      container.appendChild(rowBg);
+
+      const childColor = getItemBorderColor(child.tags, currentTaskMarkData.tagColors);
+      const left = (child.startMs - startDate.getTime()) * pxPerMs;
+      const width = Math.max((child.endMs - child.startMs) * pxPerMs, GANTT_MIN_BAR_WIDTH);
+
+      const bar = createGanttBar(left, childYOffset, width, childColor);
+      bar.classList.add('tm-gantt-child-bar');
+
+      const pBar = document.createElement('div');
+      pBar.className = 'tm-gantt-progress';
+      if (child.isTask) {
+        pBar.style.width = child.isDone ? '100%' : '0%';
+      } else {
+        pBar.style.width = '100%';
+      }
+      pBar.style.backgroundColor = childColor;
+      bar.appendChild(pBar);
+      container.appendChild(bar);
+
+      // Label (outside bar, to the right)
+      container.appendChild(createGanttLabel(child.text, left + width, childYOffset));
     });
   }
 
@@ -741,7 +778,10 @@
     const ganttContainer = document.createElement('div');
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
-    ganttContainer.style.height = (entityArray.length * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
+    const totalRowCount = entityArray.reduce((sum, e) => {
+      return sum + 1 + (e.isGroup ? e.children.length : 0);
+    }, 0);
+    ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
 
     // Render axis and column backgrounds
     renderGanttAxis(ganttContainer, startDate, totalRenderDays, pxPerMs);
@@ -751,6 +791,10 @@
     entityArray.forEach(entity => {
       renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, yOffset, totalWidth);
       yOffset += GANTT_ROW_HEIGHT;
+      if (entity.isGroup) {
+        renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, yOffset - GANTT_ROW_HEIGHT, totalWidth);
+        yOffset += GANTT_ROW_HEIGHT * entity.children.length;
+      }
     });
 
     viewTimeline.appendChild(ganttContainer);

--- a/media/style.css
+++ b/media/style.css
@@ -498,3 +498,13 @@ body {
   white-space: nowrap;
   pointer-events: none;
 }
+
+/* Child rows (group task members) */
+.tm-gantt-child-row-bg {
+  border-left: 2px solid var(--tm-card-border);
+  margin-left: 16px;
+}
+
+.tm-gantt-child-bar {
+  opacity: 0.8;
+}

--- a/media/style.css
+++ b/media/style.css
@@ -502,7 +502,6 @@ body {
 /* Child rows (group task members) */
 .tm-gantt-child-row-bg {
   border-left: 2px solid var(--tm-card-border);
-  margin-left: 16px;
 }
 
 .tm-gantt-child-bar {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
-    "test:unit": "npm run compile && mocha --ui tdd out/test/suite/parser.test.js"
+    "test:unit": "npm run compile && mocha --ui tdd out/test/suite/parser.test.js out/test/suite/gantt.test.js"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -1,10 +1,17 @@
 import * as vscode from 'vscode';
 import { parseTmd, TaskMarkData } from './parser';
+import { buildGanttEntities, GanttEntity } from './gantt';
 import { getWebviewHtml } from './template';
+
+export interface GanttData {
+  entities: GanttEntity[];
+  lastDateStr: string;
+}
 
 export interface TaskMarkUpdateMessage {
   type: 'update';
   data: TaskMarkData;
+  ganttData: GanttData;
 }
 
 export class TaskmarkPanel {
@@ -101,7 +108,8 @@ export class TaskmarkPanel {
       parsedData.tagColors = { ...configColors, ...parsedData.tagColors };
       const message: TaskMarkUpdateMessage = {
         type: 'update',
-        data: parsedData
+        data: parsedData,
+        ganttData: buildGanttEntities(parsedData)
       };
       this._panel.webview.postMessage(message);
     } catch (e) {

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -1,12 +1,7 @@
 import * as vscode from 'vscode';
 import { parseTmd, TaskMarkData } from './parser';
-import { buildGanttEntities, GanttEntity } from './gantt';
+import { buildGanttEntities, GanttData } from './gantt';
 import { getWebviewHtml } from './template';
-
-export interface GanttData {
-  entities: GanttEntity[];
-  lastDateStr: string;
-}
 
 export interface TaskMarkUpdateMessage {
   type: 'update';

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -25,7 +25,7 @@ export interface GanttEntity {
 
 function parseLocalDate(dateStr: string): Date {
   const p = dateStr.split('-');
-  return new Date(parseInt(p[0]), parseInt(p[1]) - 1, parseInt(p[2]));
+  return new Date(parseInt(p[0], 10), parseInt(p[1], 10) - 1, parseInt(p[2], 10));
 }
 
 function getEndOfDayMs(dateStr: string): number {
@@ -66,12 +66,12 @@ export function buildGanttEntities(
         const parts = item.time!.split('-');
         const sTime = parts[0].trim().split(':');
         if (sTime.length >= 2) {
-          startMs = dayStartMs + parseInt(sTime[0]) * MS_PER_HOUR + parseInt(sTime[1]) * MS_PER_MINUTE;
+          startMs = dayStartMs + parseInt(sTime[0], 10) * MS_PER_HOUR + parseInt(sTime[1], 10) * MS_PER_MINUTE;
         }
         if (parts[1]) {
           const eTime = parts[1].trim().split(':');
           if (eTime.length >= 2) {
-            endMs = dayStartMs + parseInt(eTime[0]) * MS_PER_HOUR + parseInt(eTime[1]) * MS_PER_MINUTE;
+            endMs = dayStartMs + parseInt(eTime[0], 10) * MS_PER_HOUR + parseInt(eTime[1], 10) * MS_PER_MINUTE;
           }
         } else {
           endMs = startMs + MS_PER_HOUR;

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -1,4 +1,4 @@
-import { TaskMarkData } from './parser';
+import { TaskMarkData, parseLocalDate } from './parser';
 
 const MS_PER_MINUTE = 60000;
 const MS_PER_HOUR = 3600000;
@@ -23,11 +23,6 @@ export interface GanttEntity {
   children: GanttChildItem[];
 }
 
-function parseLocalDate(dateStr: string): Date {
-  const p = dateStr.split('-');
-  return new Date(parseInt(p[0], 10), parseInt(p[1], 10) - 1, parseInt(p[2], 10));
-}
-
 function getEndOfDayMs(dateStr: string): number {
   const d = parseLocalDate(dateStr);
   d.setDate(d.getDate() + 1);
@@ -38,9 +33,12 @@ function itemHasTime(item: { time?: string; endDate?: string }): boolean {
   return !!(item.time && !item.endDate);
 }
 
-export function buildGanttEntities(
-  data: TaskMarkData
-): { entities: GanttEntity[]; lastDateStr: string } {
+export interface GanttData {
+  entities: GanttEntity[];
+  lastDateStr: string;
+}
+
+export function buildGanttEntities(data: TaskMarkData): GanttData {
   const sortedDates = Object.keys(data.days).sort();
 
   if (sortedDates.length === 0) {
@@ -85,7 +83,7 @@ export function buildGanttEntities(
           isGroup: !!item.group,
           minTime: startMs,
           maxTime: endMs,
-          tags: item.tags || [],
+          tags: item.tags,
           tasksTotal: 0,
           tasksDone: 0,
           children: []
@@ -97,7 +95,7 @@ export function buildGanttEntities(
 
       entities[eName].children.push({
         text: item.text,
-        tags: item.tags || [],
+        tags: item.tags,
         startMs,
         endMs,
         isTask: item.type === 'task',

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -45,7 +45,8 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
     return { entities: [], lastDateStr: '' };
   }
 
-  const entities: Record<string, GanttEntity> = {};
+  const groupEntities: Record<string, GanttEntity> = {};
+  const standaloneEntities: Record<string, GanttEntity> = {};
   let lastDateStr = sortedDates[sortedDates.length - 1];
 
   sortedDates.forEach(dStr => {
@@ -76,10 +77,11 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
         }
       }
 
-      const eName = item.group ? `[Group] ${item.group}` : item.text;
-      if (!entities[eName]) {
-        entities[eName] = {
-          name: item.group || item.text,
+      const bucket = item.group ? groupEntities : standaloneEntities;
+      const key = item.group ?? item.text;
+      if (!bucket[key]) {
+        bucket[key] = {
+          name: key,
           isGroup: !!item.group,
           minTime: startMs,
           maxTime: endMs,
@@ -89,11 +91,11 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
           children: []
         };
       } else {
-        if (startMs < entities[eName].minTime) { entities[eName].minTime = startMs; }
-        if (endMs > entities[eName].maxTime) { entities[eName].maxTime = endMs; }
+        if (startMs < bucket[key].minTime) { bucket[key].minTime = startMs; }
+        if (endMs > bucket[key].maxTime) { bucket[key].maxTime = endMs; }
       }
 
-      entities[eName].children.push({
+      bucket[key].children.push({
         text: item.text,
         tags: item.tags,
         startMs,
@@ -103,15 +105,18 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
       });
 
       if (item.type === 'task') {
-        entities[eName].tasksTotal++;
+        bucket[key].tasksTotal++;
         if (item.status === 'done') {
-          entities[eName].tasksDone++;
+          bucket[key].tasksDone++;
         }
       }
     });
   });
 
-  const entityArray = Object.values(entities).sort(
+  const entityArray = [
+    ...Object.values(groupEntities),
+    ...Object.values(standaloneEntities)
+  ].sort(
     (a, b) => a.minTime - b.minTime || a.name.localeCompare(b.name)
   );
 

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -1,0 +1,121 @@
+import { TaskMarkData } from './parser';
+
+const MS_PER_MINUTE = 60000;
+const MS_PER_HOUR = 3600000;
+
+export interface GanttChildItem {
+  text: string;
+  tags: string[];
+  startMs: number;
+  endMs: number;
+  isTask: boolean;
+  isDone: boolean;
+}
+
+export interface GanttEntity {
+  name: string;
+  isGroup: boolean;
+  minTime: number;
+  maxTime: number;
+  tags: string[];
+  tasksTotal: number;
+  tasksDone: number;
+  children: GanttChildItem[];
+}
+
+function parseLocalDate(dateStr: string): Date {
+  const p = dateStr.split('-');
+  return new Date(parseInt(p[0]), parseInt(p[1]) - 1, parseInt(p[2]));
+}
+
+function getEndOfDayMs(dateStr: string): number {
+  const d = parseLocalDate(dateStr);
+  d.setDate(d.getDate() + 1);
+  return d.getTime() - 1;
+}
+
+function itemHasTime(item: { time?: string; endDate?: string }): boolean {
+  return !!(item.time && !item.endDate);
+}
+
+export function buildGanttEntities(
+  data: TaskMarkData
+): { entities: GanttEntity[]; lastDateStr: string } {
+  const sortedDates = Object.keys(data.days).sort();
+
+  if (sortedDates.length === 0) {
+    return { entities: [], lastDateStr: '' };
+  }
+
+  const entities: Record<string, GanttEntity> = {};
+  let lastDateStr = sortedDates[sortedDates.length - 1];
+
+  sortedDates.forEach(dStr => {
+    const dayData = data.days[dStr];
+    const dayStartMs = parseLocalDate(dStr).getTime();
+
+    dayData.items.forEach(item => {
+      if (item.endDate && item.endDate > lastDateStr) {
+        lastDateStr = item.endDate;
+      }
+
+      let startMs = dayStartMs;
+      let endMs = item.endDate ? getEndOfDayMs(item.endDate) : getEndOfDayMs(dStr);
+
+      if (itemHasTime(item)) {
+        const parts = item.time!.split('-');
+        const sTime = parts[0].trim().split(':');
+        if (sTime.length >= 2) {
+          startMs = dayStartMs + parseInt(sTime[0]) * MS_PER_HOUR + parseInt(sTime[1]) * MS_PER_MINUTE;
+        }
+        if (parts[1]) {
+          const eTime = parts[1].trim().split(':');
+          if (eTime.length >= 2) {
+            endMs = dayStartMs + parseInt(eTime[0]) * MS_PER_HOUR + parseInt(eTime[1]) * MS_PER_MINUTE;
+          }
+        } else {
+          endMs = startMs + MS_PER_HOUR;
+        }
+      }
+
+      const eName = item.group ? `[Group] ${item.group}` : item.text;
+      if (!entities[eName]) {
+        entities[eName] = {
+          name: item.group || item.text,
+          isGroup: !!item.group,
+          minTime: startMs,
+          maxTime: endMs,
+          tags: item.tags || [],
+          tasksTotal: 0,
+          tasksDone: 0,
+          children: []
+        };
+      } else {
+        if (startMs < entities[eName].minTime) { entities[eName].minTime = startMs; }
+        if (endMs > entities[eName].maxTime) { entities[eName].maxTime = endMs; }
+      }
+
+      entities[eName].children.push({
+        text: item.text,
+        tags: item.tags || [],
+        startMs,
+        endMs,
+        isTask: item.type === 'task',
+        isDone: item.status === 'done'
+      });
+
+      if (item.type === 'task') {
+        entities[eName].tasksTotal++;
+        if (item.status === 'done') {
+          entities[eName].tasksDone++;
+        }
+      }
+    });
+  });
+
+  const entityArray = Object.values(entities).sort(
+    (a, b) => a.minTime - b.minTime || a.name.localeCompare(b.name)
+  );
+
+  return { entities: entityArray, lastDateStr };
+}

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -85,7 +85,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
           isGroup: !!item.group,
           minTime: startMs,
           maxTime: endMs,
-          tags: item.tags,
+          tags: [...item.tags],
           tasksTotal: 0,
           tasksDone: 0,
           children: []
@@ -97,7 +97,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
 
       bucket[key].children.push({
         text: item.text,
-        tags: item.tags,
+        tags: [...item.tags],
         startMs,
         endMs,
         isTask: item.type === 'task',

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -94,6 +94,33 @@ suite('Gantt Test Suite', () => {
     assert.strictEqual(groupB!.children[0].isDone, true);
   });
 
+  test('schedule item inside group is included in children but not counted as task', () => {
+    const data = parseTmd(`
+# 2026-03-01
+> Sprint
+> - [ ] Task Item
+> - Schedule Item
+`);
+    const { entities } = buildGanttEntities(data);
+    const group = entities[0];
+    assert.strictEqual(group.children.length, 2);
+    assert.strictEqual(group.tasksTotal, 1, 'only the task should count toward tasksTotal');
+    assert.strictEqual(group.children[1].isTask, false);
+    assert.strictEqual(group.children[1].text, 'Schedule Item');
+  });
+
+  test('lastDateStr is the last date when no endDate ranges are present', () => {
+    const data = parseTmd(`
+# 2026-03-01
+- [ ] First Task
+
+# 2026-03-10
+- [ ] Last Task
+`);
+    const { lastDateStr } = buildGanttEntities(data);
+    assert.strictEqual(lastDateStr, '2026-03-10');
+  });
+
   test('group minTime and maxTime span all child items', () => {
     const data = parseTmd(`
 # 2026-03-01

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -121,6 +121,25 @@ suite('Gantt Test Suite', () => {
     assert.strictEqual(lastDateStr, '2026-03-10');
   });
 
+  test('group name and standalone task with the same name do not collide', () => {
+    const data = parseTmd(`
+# 2026-03-01
+> Sprint
+> - [ ] Task A
+
+- [ ] Sprint
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 2, 'group and standalone task with the same name must be separate entities');
+
+    const group = entities.find(e => e.isGroup);
+    const standalone = entities.find(e => !e.isGroup);
+    assert.ok(group, 'group entity should exist');
+    assert.ok(standalone, 'standalone entity should exist');
+    assert.strictEqual(group!.name, 'Sprint');
+    assert.strictEqual(standalone!.name, 'Sprint');
+  });
+
   test('group minTime and maxTime span all child items', () => {
     const data = parseTmd(`
 # 2026-03-01

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -1,0 +1,115 @@
+import * as assert from 'assert';
+import { buildGanttEntities } from '../../gantt';
+import { parseTmd } from '../../parser';
+
+suite('Gantt Test Suite', () => {
+  test('group entity has children with text and tags', () => {
+    const data = parseTmd(`# 2026-03-01
+> Sprint 1
+> - [ ] Task A #work
+> - [x] Task B
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 1);
+
+    const group = entities[0];
+    assert.strictEqual(group.isGroup, true);
+    assert.strictEqual(group.name, 'Sprint 1');
+    assert.strictEqual(group.children.length, 2);
+
+    assert.strictEqual(group.children[0].text, 'Task A');
+    assert.strictEqual(group.children[0].isTask, true);
+    assert.strictEqual(group.children[0].isDone, false);
+    assert.deepStrictEqual(group.children[0].tags, ['work']);
+
+    assert.strictEqual(group.children[1].text, 'Task B');
+    assert.strictEqual(group.children[1].isTask, true);
+    assert.strictEqual(group.children[1].isDone, true);
+  });
+
+  test('standalone task entity has a children array with one entry', () => {
+    const data = parseTmd(`
+# 2026-03-01
+- [ ] Standalone Task
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 1);
+
+    const entity = entities[0];
+    assert.strictEqual(entity.isGroup, false);
+    assert.strictEqual(entity.name, 'Standalone Task');
+    assert.strictEqual(entity.children.length, 1);
+    assert.strictEqual(entity.children[0].text, 'Standalone Task');
+    assert.strictEqual(entity.children[0].isTask, true);
+  });
+
+  test('group entity tracks task completion counters', () => {
+    const data = parseTmd(`
+# 2026-03-01
+> Group
+> - [ ] Open Task
+> - [x] Done Task
+`);
+    const { entities } = buildGanttEntities(data);
+    const group = entities[0];
+    assert.strictEqual(group.tasksTotal, 2);
+    assert.strictEqual(group.tasksDone, 1);
+  });
+
+  test('empty data returns empty entities and empty lastDateStr', () => {
+    const { entities, lastDateStr } = buildGanttEntities({ tagColors: {}, days: {} });
+    assert.strictEqual(entities.length, 0);
+    assert.strictEqual(lastDateStr, '');
+  });
+
+  test('lastDateStr accounts for endDate ranges', () => {
+    const data = parseTmd(`
+# 2026-03-01 : 2026-03-15
+- Conference
+`);
+    const { lastDateStr } = buildGanttEntities(data);
+    assert.strictEqual(lastDateStr, '2026-03-15');
+  });
+
+  test('multiple groups produce one entity per group', () => {
+    const data = parseTmd(`
+# 2026-03-01
+> Group A
+> - [ ] Task 1
+> - [ ] Task 2
+
+> Group B
+> - [x] Task 3
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 2);
+
+    const groupA = entities.find(e => e.name === 'Group A');
+    assert.ok(groupA, 'Group A should exist');
+    assert.strictEqual(groupA!.children.length, 2);
+
+    const groupB = entities.find(e => e.name === 'Group B');
+    assert.ok(groupB, 'Group B should exist');
+    assert.strictEqual(groupB!.children.length, 1);
+    assert.strictEqual(groupB!.children[0].isDone, true);
+  });
+
+  test('group minTime and maxTime span all child items', () => {
+    const data = parseTmd(`
+# 2026-03-01
+> Sprint
+> - [ ] 9:00-10:00 Morning Task
+
+# 2026-03-03
+> Sprint
+> - [ ] 14:00-15:00 Afternoon Task
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 1);
+
+    const sprint = entities[0];
+    assert.strictEqual(sprint.children.length, 2);
+    assert.ok(sprint.minTime < sprint.maxTime, 'minTime should be before maxTime');
+    assert.ok(sprint.children[0].startMs < sprint.children[1].startMs, 'children should be in chronological order');
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #37

## 概要
ガントチャートでグループタスクを展開し、構成タスクを子行として表示できるようにした。グループバーの下に各構成タスクのバーが表示されることで、グループ全体の期間と個別タスクのスケジュールを同時に把握できる。

## 変更内容
- `src/gantt.ts` を新規作成し、`buildGanttEntities` 関数をテスト可能な純粋関数として分離した
- `media/main.js`: `collectGanttEntities` の各アイテムに `text` / `tags` を追加し、`items` を `children` に改名
- `media/main.js`: `renderGroupChildren` 関数を追加し、グループバーの下に子タスク行を描画
- `media/main.js`: `renderTimeline` の高さ計算をグループの子行数を考慮した式に更新
- `media/style.css`: 子行背景 (`.tm-gantt-child-row-bg`) と子バー (`.tm-gantt-child-bar`) のスタイルを追加
- `package.json`: `test:unit` スクリプトに `gantt.test.js` を追加

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した
- [x] `npm run lint` および `npm run test:unit` (27件) がすべてパスすることを確認した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| グループバーのみ表示（構成タスクは非表示） | グループバーの下に各構成タスクの子行バーを表示 |

## 備考・次やること
なし