### PR TITLE
v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the "TaskMark" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.3.0] - 2026-04-12
+
+### Added
+- Group task children are now displayed as sub-rows in the Gantt chart (#37).
+
+### Fixed
+- Prevent text selection and stuck grab cursor during Gantt chart drag (#38).
+- Replace `mouseleave` with `e.buttons===0` check to reliably end stuck panning on Gantt.
+- Escape user-supplied content in HTML templates to prevent XSS.
+- Use numeric minute comparison for schedule sort to fix ordering with unpadded hours.
+- Use DST-safe end-of-day calculation (`setDate(+1)`) in date range processing.
+- Add single-quote escaping to `escapeHtml` for completeness.
+
+### Changed
+- Minimum VS Code engine version updated to 1.115.0.
+
 ## [1.2.0] - 2026-03-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Visualize schedule durations and project spans as a Gantt chart.
 - **Zoom** — Use `Ctrl + Mouse Wheel` to zoom in/out (from days to hours)
 - **Progress Bars** — Group task completion rates are displayed visually on the bars
 - **Weekend Colors** — Colored backgrounds corresponding to the calendar view
+- **Sub-rows** — Tasks inside a group are displayed as individual sub-rows beneath the group bar
 - Grouped schedules appear as a single connected bar, while standalone items with the same name appear as separate blocks on the same row
 
 ### 🏷️ Tags & Colors

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "taskmark",
   "displayName": "TaskMark",
   "description": "Schedule and Task Management with Markdown and Calendar/Timeline Views",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "icon": "media/icon.png",
   "publisher": "Yadecode",
   "repository": {


### PR DESCRIPTION
## 概要

- GanttチャートにグループタスクのサブROWを表示する機能を追加 (#37)
- Ganttドラッグ時のテキスト選択・スタック問題を修正 (#38)
- XSS対策・DST安全な終日計算・その他バグ修正
- engines.vscode を 1.115.0 に統一

## 変更内容

### Added
- グループタスクの子タスクをGanttのサブ行として表示 (#37)

### Fixed
- Ganttドラッグ時のテキスト選択およびスタックカーソルを修正 (#38)
- `mouseleave` を `e.buttons===0` チェックに置き換えてパン終了を確実に検出
- HTMLテンプレートでユーザーコンテンツをエスケープしてXSSを防止
- 未パディング時刻の分比較を数値で行いソート順を修正
- `setDate(+1)` でDST安全な終日計算を実装
- `escapeHtml` にシングルクォートのエスケープを追加

### Changed
- engines.vscode の最小バージョンを 1.115.0 に更新

## テスト

- [x] `npm run test:unit` — 30テスト全て合格