### PR TITLE
feat: 範囲指定イベントをカレンダー上で連続バンドとして表示する

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -416,30 +416,43 @@
    * Collect range events overlapping [weekStartStr, weekEndStr] and assign band rows
    * to prevent visual overlap. Returns an array of band descriptors.
    */
-  function collectWeekBands(weekStartStr, weekEndStr) {
+  /** Collect all range items from the dataset (items with endDate). */
+  function collectAllRangeItems() {
+    const rangeItems = [];
+    Object.entries(currentTaskMarkData.days).forEach(([date, dayData]) => {
+      dayData.items.forEach(item => {
+        if (item.endDate) rangeItems.push({ date, item });
+      });
+    });
+    return rangeItems;
+  }
+
+  /** Count day difference between two dates using calendar arithmetic (DST-safe). */
+  function dayDiff(fromDate, toDate) {
+    const a = new Date(fromDate.getFullYear(), fromDate.getMonth(), fromDate.getDate());
+    const b = new Date(toDate.getFullYear(), toDate.getMonth(), toDate.getDate());
+    return Math.round((b - a) / MS_PER_DAY);
+  }
+
+  function collectWeekBands(weekStartStr, weekEndStr, rangeItems) {
     const weekStartDate = parseLocalDate(weekStartStr);
     const events = [];
 
-    Object.entries(currentTaskMarkData.days).forEach(([date, dayData]) => {
-      dayData.items.forEach(item => {
-        if (!item.endDate) return;
-        if (date > weekEndStr || item.endDate < weekStartStr) return;
+    rangeItems.forEach(({ date, item }) => {
+      if (date > weekEndStr || item.endDate < weekStartStr) return;
 
-        const clippedStart = date < weekStartStr ? weekStartStr : date;
-        const clippedEnd = item.endDate > weekEndStr ? weekEndStr : item.endDate;
+      const clippedStart = date < weekStartStr ? weekStartStr : date;
+      const clippedEnd = item.endDate > weekEndStr ? weekEndStr : item.endDate;
 
-        const startDate = parseLocalDate(clippedStart);
-        const endDate = parseLocalDate(clippedEnd);
-        const colStart = Math.round((startDate - weekStartDate) / MS_PER_DAY) + 1;
-        const colEnd = Math.round((endDate - weekStartDate) / MS_PER_DAY) + 2;
+      const colStart = dayDiff(weekStartDate, parseLocalDate(clippedStart)) + 1;
+      const colEnd = dayDiff(weekStartDate, parseLocalDate(clippedEnd)) + 2;
 
-        events.push({
-          item,
-          colStart,
-          colEnd,
-          isStart: date >= weekStartStr,
-          isEnd: item.endDate <= weekEndStr,
-        });
+      events.push({
+        item,
+        colStart,
+        colEnd,
+        isStart: date >= weekStartStr,
+        isEnd: item.endDate <= weekEndStr,
       });
     });
 
@@ -570,13 +583,14 @@
     }
 
     // Render week by week: band segments inside each cell
+    const rangeItems = collectAllRangeItems();
     const numWeeks = cells.length / 7;
     for (let w = 0; w < numWeeks; w++) {
       const weekCells = cells.slice(w * 7, (w + 1) * 7);
       const weekStartStr = weekCells[0].dStr;
       const weekEndStr = weekCells[6].dStr;
 
-      const weekBands = collectWeekBands(weekStartStr, weekEndStr);
+      const weekBands = collectWeekBands(weekStartStr, weekEndStr, rangeItems);
       const { map: bandMap, maxRow } = buildCellBandMap(weekBands);
 
       weekCells.forEach((cell, i) => {
@@ -606,7 +620,8 @@
     weekEndDate.setDate(weekEndDate.getDate() + 6);
     const weekEndStr = formatDateStr(weekEndDate.getFullYear(), weekEndDate.getMonth() + 1, weekEndDate.getDate());
 
-    const weekBands = collectWeekBands(weekStartStr, weekEndStr);
+    const rangeItems = collectAllRangeItems();
+    const weekBands = collectWeekBands(weekStartStr, weekEndStr, rangeItems);
     const { map: bandMap, maxRow } = buildCellBandMap(weekBands);
 
     for (let i = 0; i < 7; i++) {

--- a/media/main.js
+++ b/media/main.js
@@ -412,10 +412,6 @@
 
   // ─── Multi-Day Band Rendering ────────────────────────────────
 
-  /**
-   * Collect range events overlapping [weekStartStr, weekEndStr] and assign band rows
-   * to prevent visual overlap. Returns an array of band descriptors.
-   */
   /** Collect all range items from the dataset (items with endDate). */
   function collectAllRangeItems() {
     const rangeItems = [];
@@ -434,6 +430,10 @@
     return Math.round((b - a) / MS_PER_DAY);
   }
 
+  /**
+   * Collect range events overlapping [weekStartStr, weekEndStr] and assign band rows
+   * to prevent visual overlap. Returns an array of band descriptors.
+   */
   function collectWeekBands(weekStartStr, weekEndStr, rangeItems) {
     const weekStartDate = parseLocalDate(weekStartStr);
     const events = [];

--- a/media/main.js
+++ b/media/main.js
@@ -488,7 +488,7 @@
 
   /** Create HTML for band segments inside a single cell */
   function createCellBandsHtml(cellBands, maxRow, tagColorsMap) {
-    if (maxRow < 0) return '';
+    if (maxRow < 0 || !cellBands || cellBands.length === 0) return '';
 
     const rowMap = {};
     if (cellBands) cellBands.forEach(b => { rowMap[b.bandRow] = b; });

--- a/media/main.js
+++ b/media/main.js
@@ -495,6 +495,7 @@
           bandRow: band.bandRow,
           isStart: band.isStart && col === band.colStart,
           isEnd: band.isEnd && col === band.colEnd - 1,
+          showLabel: col === band.colStart,
           item: band.item
         });
       }
@@ -517,7 +518,7 @@
         if (band.isStart) classes.push('band-start');
         if (band.isEnd) classes.push('band-end');
         const color = getItemBorderColor(band.item.tags, tagColorsMap);
-        const text = band.isStart ? escapeHtml(band.item.text) : '';
+        const text = band.showLabel ? escapeHtml(band.item.text) : '';
         html += `<div class="${classes.join(' ')}" style="background-color: ${color}">${text}</div>`;
       } else {
         html += '<div class="tm-cell-band-spacer"></div>';

--- a/media/main.js
+++ b/media/main.js
@@ -423,11 +423,9 @@
     return rangeItems;
   }
 
-  /** Count day difference between two dates using calendar arithmetic (DST-safe). */
+  /** Count day difference between two local-midnight Date objects (DST-safe via Math.round). */
   function dayDiff(fromDate, toDate) {
-    const a = new Date(fromDate.getFullYear(), fromDate.getMonth(), fromDate.getDate());
-    const b = new Date(toDate.getFullYear(), toDate.getMonth(), toDate.getDate());
-    return Math.round((b - a) / MS_PER_DAY);
+    return Math.round((toDate - fromDate) / MS_PER_DAY);
   }
 
   /**

--- a/media/main.js
+++ b/media/main.js
@@ -443,6 +443,9 @@
       });
     });
 
+    // Sort by start column, then longer spans first for stable top-down placement
+    events.sort((a, b) => a.colStart - b.colStart || (b.colEnd - b.colStart) - (a.colEnd - a.colStart));
+
     // Assign band rows to avoid visual overlap within the same week
     const rowEnds = [];
     events.forEach(event => {
@@ -491,7 +494,7 @@
     if (maxRow < 0 || !cellBands || cellBands.length === 0) return '';
 
     const rowMap = {};
-    if (cellBands) cellBands.forEach(b => { rowMap[b.bandRow] = b; });
+    cellBands.forEach(b => { rowMap[b.bandRow] = b; });
 
     let html = '<div class="tm-cell-bands">';
     for (let r = 0; r <= maxRow; r++) {
@@ -578,8 +581,8 @@
 
       weekCells.forEach((cell, i) => {
         const colIndex = i + 1;
-        const dayData = getDayData(cell.dStr);
-        const regularItems = dayData.items.filter(item => !item.endDate);
+        const dayItems = (currentTaskMarkData.days[cell.dStr] || { items: [] }).items;
+        const regularItems = dayItems.filter(item => !item.endDate);
         const el = createCell(cell.dayNo, cell.isOtherMonth, cell.isToday, cell.dayOfWeek, cell.dStr);
         el.innerHTML += createCellBandsHtml(bandMap[colIndex], maxRow, tagColors);
         el.innerHTML += createItemsHtml(regularItems, tagColors, true);
@@ -610,8 +613,8 @@
       const dStr = formatDateStr(d.getFullYear(), d.getMonth() + 1, d.getDate());
       const dayOfWeek = d.getDay();
       const colIndex = i + 1;
-      const dayData = getDayData(dStr);
-      const regularItems = dayData.items.filter(item => !item.endDate);
+      const dayItems = (currentTaskMarkData.days[dStr] || { items: [] }).items;
+      const regularItems = dayItems.filter(item => !item.endDate);
       const cell = createCell(d.getDate(), false, dStr === todayStr, dayOfWeek, dStr);
       cell.style.flex = '1';
       cell.innerHTML += createCellBandsHtml(bandMap[colIndex], maxRow, tagColors);

--- a/media/main.js
+++ b/media/main.js
@@ -410,6 +410,94 @@
     return { ...dayData, items: [...dayData.items, ...rangeItems] };
   }
 
+  // ─── Multi-Day Band Rendering ────────────────────────────────
+
+  /**
+   * Collect range events overlapping [weekStartStr, weekEndStr] and assign band rows
+   * to prevent visual overlap. Returns an array of band descriptors.
+   */
+  function collectWeekBands(weekStartStr, weekEndStr) {
+    const weekStartDate = parseLocalDate(weekStartStr);
+    const events = [];
+
+    Object.entries(currentTaskMarkData.days).forEach(([date, dayData]) => {
+      dayData.items.forEach(item => {
+        if (!item.endDate) return;
+        if (date > weekEndStr || item.endDate < weekStartStr) return;
+
+        const clippedStart = date < weekStartStr ? weekStartStr : date;
+        const clippedEnd = item.endDate > weekEndStr ? weekEndStr : item.endDate;
+
+        const startDate = parseLocalDate(clippedStart);
+        const endDate = parseLocalDate(clippedEnd);
+        const colStart = Math.round((startDate - weekStartDate) / MS_PER_DAY) + 1;
+        const colEnd = Math.round((endDate - weekStartDate) / MS_PER_DAY) + 2;
+
+        events.push({
+          item,
+          colStart,
+          colEnd,
+          isStart: date >= weekStartStr,
+          isEnd: item.endDate <= weekEndStr,
+        });
+      });
+    });
+
+    // Assign band rows to avoid visual overlap within the same week
+    const rowEnds = [];
+    events.forEach(event => {
+      let assigned = false;
+      for (let r = 0; r < rowEnds.length; r++) {
+        if (rowEnds[r] <= event.colStart) {
+          event.bandRow = r;
+          rowEnds[r] = event.colEnd;
+          assigned = true;
+          break;
+        }
+      }
+      if (!assigned) {
+        event.bandRow = rowEnds.length;
+        rowEnds.push(event.colEnd);
+      }
+    });
+
+    return events;
+  }
+
+  /**
+   * Create a bands container element for one week row.
+   * Returns null if there are no range events for the given week.
+   */
+  function createWeekBandsElement(weekStartStr, weekEndStr) {
+    const bands = collectWeekBands(weekStartStr, weekEndStr);
+    if (bands.length === 0) return null;
+
+    const container = document.createElement('div');
+    container.className = 'tm-week-bands';
+    container.style.gridColumn = '1 / -1';
+
+    bands.forEach(band => {
+      const el = document.createElement('div');
+      const classes = ['tm-multi-day-band'];
+      if (band.isStart) classes.push('band-start');
+      if (band.isEnd) classes.push('band-end');
+      el.className = classes.join(' ');
+      el.style.gridColumn = `${band.colStart} / ${band.colEnd}`;
+      el.style.gridRow = `${band.bandRow + 1}`;
+
+      const color = getItemBorderColor(band.item.tags, currentTaskMarkData.tagColors);
+      el.style.backgroundColor = color;
+
+      if (band.isStart) {
+        el.textContent = band.item.text;
+      }
+
+      container.appendChild(el);
+    });
+
+    return container;
+  }
+
   // ─── Calendar Views ──────────────────────────────────────────
 
   function renderCalendar(year, monthIndex) {
@@ -424,34 +512,64 @@
     const todayStr = getTodayStr();
     const tagColors = currentTaskMarkData.tagColors;
 
-    // Previous month padding
+    // Build full cell list (prev padding + current month + next padding) as complete weeks
+    const cells = [];
+
     const prevDateObj = new Date(year, monthIndex, 0);
-    const prevMonthLastDay = prevDateObj.getDate();
     for (let i = startPadding - 1; i >= 0; i--) {
-      const d = prevMonthLastDay - i;
-      const dayOfWeek = new Date(prevDateObj.getFullYear(), prevDateObj.getMonth(), d).getDay();
-      const dStr = formatDateStr(prevDateObj.getFullYear(), prevDateObj.getMonth() + 1, d);
-      viewCalendar.appendChild(createCell(d, true, false, dayOfWeek, dStr));
+      const d = prevDateObj.getDate() - i;
+      const dObj = new Date(prevDateObj.getFullYear(), prevDateObj.getMonth(), d);
+      cells.push({
+        dayNo: d,
+        isOtherMonth: true,
+        isToday: false,
+        dayOfWeek: dObj.getDay(),
+        dStr: formatDateStr(dObj.getFullYear(), dObj.getMonth() + 1, d)
+      });
     }
 
-    // Current month days
     for (let i = 1; i <= totalDays; i++) {
       const dStr = formatDateStr(year, monthIndex + 1, i);
-      const dayOfWeek = new Date(year, monthIndex, i).getDay();
-      const dayData = getDayData(dStr);
-      const cell = createCell(i, false, dStr === todayStr, dayOfWeek, dStr);
-      cell.innerHTML += createItemsHtml(dayData.items, tagColors, true);
-      viewCalendar.appendChild(cell);
+      cells.push({
+        dayNo: i,
+        isOtherMonth: false,
+        isToday: dStr === todayStr,
+        dayOfWeek: new Date(year, monthIndex, i).getDay(),
+        dStr
+      });
     }
 
-    // Next month padding
     const totalCells = startPadding + totalDays;
     const endPadding = totalCells % 7 === 0 ? 0 : 7 - (totalCells % 7);
     const nextDateObj = new Date(year, monthIndex + 1, 1);
     for (let i = 1; i <= endPadding; i++) {
-      const dayOfWeek = new Date(nextDateObj.getFullYear(), nextDateObj.getMonth(), i).getDay();
-      const dStr = formatDateStr(nextDateObj.getFullYear(), nextDateObj.getMonth() + 1, i);
-      viewCalendar.appendChild(createCell(i, true, false, dayOfWeek, dStr));
+      const dObj = new Date(nextDateObj.getFullYear(), nextDateObj.getMonth(), i);
+      cells.push({
+        dayNo: i,
+        isOtherMonth: true,
+        isToday: false,
+        dayOfWeek: dObj.getDay(),
+        dStr: formatDateStr(dObj.getFullYear(), dObj.getMonth() + 1, i)
+      });
+    }
+
+    // Render week by week: optional bands row + 7 day cells
+    const numWeeks = cells.length / 7;
+    for (let w = 0; w < numWeeks; w++) {
+      const weekCells = cells.slice(w * 7, (w + 1) * 7);
+      const weekStartStr = weekCells[0].dStr;
+      const weekEndStr = weekCells[6].dStr;
+
+      const bandsEl = createWeekBandsElement(weekStartStr, weekEndStr);
+      if (bandsEl) viewCalendar.appendChild(bandsEl);
+
+      weekCells.forEach(cell => {
+        const dayData = getDayData(cell.dStr);
+        const regularItems = dayData.items.filter(item => !item.endDate);
+        const el = createCell(cell.dayNo, cell.isOtherMonth, cell.isToday, cell.dayOfWeek, cell.dStr);
+        el.innerHTML += createItemsHtml(regularItems, tagColors, true);
+        viewCalendar.appendChild(el);
+      });
     }
   }
 
@@ -465,13 +583,22 @@
     const todayStr = getTodayStr();
     const tagColors = currentTaskMarkData.tagColors;
 
+    const weekStartStr = formatDateStr(d.getFullYear(), d.getMonth() + 1, d.getDate());
+    const weekEndDate = new Date(d);
+    weekEndDate.setDate(weekEndDate.getDate() + 6);
+    const weekEndStr = formatDateStr(weekEndDate.getFullYear(), weekEndDate.getMonth() + 1, weekEndDate.getDate());
+
+    const bandsEl = createWeekBandsElement(weekStartStr, weekEndStr);
+    if (bandsEl) viewCalendar.appendChild(bandsEl);
+
     for (let i = 0; i < 7; i++) {
       const dStr = formatDateStr(d.getFullYear(), d.getMonth() + 1, d.getDate());
       const dayOfWeek = d.getDay();
       const dayData = getDayData(dStr);
+      const regularItems = dayData.items.filter(item => !item.endDate);
       const cell = createCell(d.getDate(), false, dStr === todayStr, dayOfWeek, dStr);
       cell.style.flex = '1';
-      cell.innerHTML += createItemsHtml(dayData.items, tagColors);
+      cell.innerHTML += createItemsHtml(regularItems, tagColors);
       viewCalendar.appendChild(cell);
       d.setDate(d.getDate() + 1);
     }

--- a/media/main.js
+++ b/media/main.js
@@ -465,37 +465,50 @@
   }
 
   /**
-   * Create a bands container element for one week row.
-   * Returns null if there are no range events for the given week.
+   * Build a per-column map from week band data.
+   * Returns { map: { colIndex -> [{bandRow, isStart, isEnd, item}] }, maxRow: number }
    */
-  function createWeekBandsElement(weekStartStr, weekEndStr) {
-    const bands = collectWeekBands(weekStartStr, weekEndStr);
-    if (bands.length === 0) return null;
-
-    const container = document.createElement('div');
-    container.className = 'tm-week-bands';
-    container.style.gridColumn = '1 / -1';
-
-    bands.forEach(band => {
-      const el = document.createElement('div');
-      const classes = ['tm-multi-day-band'];
-      if (band.isStart) classes.push('band-start');
-      if (band.isEnd) classes.push('band-end');
-      el.className = classes.join(' ');
-      el.style.gridColumn = `${band.colStart} / ${band.colEnd}`;
-      el.style.gridRow = `${band.bandRow + 1}`;
-
-      const color = getItemBorderColor(band.item.tags, currentTaskMarkData.tagColors);
-      el.style.backgroundColor = color;
-
-      if (band.isStart) {
-        el.textContent = band.item.text;
+  function buildCellBandMap(weekBands) {
+    const map = {};
+    let maxRow = -1;
+    weekBands.forEach(band => {
+      if (band.bandRow > maxRow) maxRow = band.bandRow;
+      for (let col = band.colStart; col < band.colEnd; col++) {
+        if (!map[col]) map[col] = [];
+        map[col].push({
+          bandRow: band.bandRow,
+          isStart: band.isStart && col === band.colStart,
+          isEnd: band.isEnd && col === band.colEnd - 1,
+          item: band.item
+        });
       }
-
-      container.appendChild(el);
     });
+    return { map, maxRow };
+  }
 
-    return container;
+  /** Create HTML for band segments inside a single cell */
+  function createCellBandsHtml(cellBands, maxRow, tagColorsMap) {
+    if (maxRow < 0) return '';
+
+    const rowMap = {};
+    if (cellBands) cellBands.forEach(b => { rowMap[b.bandRow] = b; });
+
+    let html = '<div class="tm-cell-bands">';
+    for (let r = 0; r <= maxRow; r++) {
+      const band = rowMap[r];
+      if (band) {
+        const classes = ['tm-cell-band'];
+        if (band.isStart) classes.push('band-start');
+        if (band.isEnd) classes.push('band-end');
+        const color = getItemBorderColor(band.item.tags, tagColorsMap);
+        const text = band.isStart ? escapeHtml(band.item.text) : '';
+        html += `<div class="${classes.join(' ')}" style="background-color: ${color}">${text}</div>`;
+      } else {
+        html += '<div class="tm-cell-band-spacer"></div>';
+      }
+    }
+    html += '</div>';
+    return html;
   }
 
   // ─── Calendar Views ──────────────────────────────────────────
@@ -553,20 +566,22 @@
       });
     }
 
-    // Render week by week: optional bands row + 7 day cells
+    // Render week by week: band segments inside each cell
     const numWeeks = cells.length / 7;
     for (let w = 0; w < numWeeks; w++) {
       const weekCells = cells.slice(w * 7, (w + 1) * 7);
       const weekStartStr = weekCells[0].dStr;
       const weekEndStr = weekCells[6].dStr;
 
-      const bandsEl = createWeekBandsElement(weekStartStr, weekEndStr);
-      if (bandsEl) viewCalendar.appendChild(bandsEl);
+      const weekBands = collectWeekBands(weekStartStr, weekEndStr);
+      const { map: bandMap, maxRow } = buildCellBandMap(weekBands);
 
-      weekCells.forEach(cell => {
+      weekCells.forEach((cell, i) => {
+        const colIndex = i + 1;
         const dayData = getDayData(cell.dStr);
         const regularItems = dayData.items.filter(item => !item.endDate);
         const el = createCell(cell.dayNo, cell.isOtherMonth, cell.isToday, cell.dayOfWeek, cell.dStr);
+        el.innerHTML += createCellBandsHtml(bandMap[colIndex], maxRow, tagColors);
         el.innerHTML += createItemsHtml(regularItems, tagColors, true);
         viewCalendar.appendChild(el);
       });
@@ -588,16 +603,18 @@
     weekEndDate.setDate(weekEndDate.getDate() + 6);
     const weekEndStr = formatDateStr(weekEndDate.getFullYear(), weekEndDate.getMonth() + 1, weekEndDate.getDate());
 
-    const bandsEl = createWeekBandsElement(weekStartStr, weekEndStr);
-    if (bandsEl) viewCalendar.appendChild(bandsEl);
+    const weekBands = collectWeekBands(weekStartStr, weekEndStr);
+    const { map: bandMap, maxRow } = buildCellBandMap(weekBands);
 
     for (let i = 0; i < 7; i++) {
       const dStr = formatDateStr(d.getFullYear(), d.getMonth() + 1, d.getDate());
       const dayOfWeek = d.getDay();
+      const colIndex = i + 1;
       const dayData = getDayData(dStr);
       const regularItems = dayData.items.filter(item => !item.endDate);
       const cell = createCell(d.getDate(), false, dStr === todayStr, dayOfWeek, dStr);
       cell.style.flex = '1';
+      cell.innerHTML += createCellBandsHtml(bandMap[colIndex], maxRow, tagColors);
       cell.innerHTML += createItemsHtml(regularItems, tagColors);
       viewCalendar.appendChild(cell);
       d.setDate(d.getDate() + 1);

--- a/media/style.css
+++ b/media/style.css
@@ -149,16 +149,50 @@ body {
   height: 100%;
 }
 
+/* Monthly & Weekly: compact grid with 1px lines via background trick */
+.tm-calendar-grid.monthly,
+.tm-calendar-grid.weekly {
+  gap: 1px;
+  background-color: var(--tm-card-border);
+  border-radius: var(--tm-radius);
+  overflow: hidden;
+}
+
 .tm-calendar-grid.weekly {
   grid-template-rows: max-content auto 1fr;
+}
+
+.tm-calendar-grid.monthly .tm-day-header,
+.tm-calendar-grid.weekly .tm-day-header {
+  background-color: var(--tm-bg);
+  padding: 10px 0 8px;
+}
+
+.tm-calendar-grid.monthly .tm-cal-cell,
+.tm-calendar-grid.weekly .tm-cal-cell {
+  border: none;
+  border-radius: 0;
+}
+
+.tm-calendar-grid.monthly .tm-cal-cell:hover,
+.tm-calendar-grid.weekly .tm-cal-cell:hover {
+  box-shadow: inset 0 0 0 2px var(--tm-accent);
+}
+
+.tm-calendar-grid.monthly .tm-cal-cell.today,
+.tm-calendar-grid.weekly .tm-cal-cell.today {
+  border: none;
+  box-shadow: inset 0 0 0 2px var(--tm-accent);
 }
 
 /* ─── Multi-Day Bands ────────────────────────────────────────── */
 .tm-week-bands {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  gap: 12px;
-  row-gap: 3px;
+  column-gap: 1px;
+  row-gap: 2px;
+  padding: 3px 0;
+  background-color: var(--tm-bg);
 }
 
 .tm-multi-day-band {
@@ -172,21 +206,21 @@ body {
   white-space: nowrap;
   color: #fff;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
-  border-radius: 0;
+  border-radius: 4px;
   opacity: 0.9;
 }
 
 .tm-multi-day-band.band-start {
-  border-radius: 11px 0 0 11px;
-  padding-left: 10px;
+  border-radius: 4px 0 0 4px;
+  padding-left: 8px;
 }
 
 .tm-multi-day-band.band-end {
-  border-radius: 0 11px 11px 0;
+  border-radius: 0 4px 4px 0;
 }
 
 .tm-multi-day-band.band-start.band-end {
-  border-radius: 11px;
+  border-radius: 4px;
 }
 
 .tm-calendar-grid.daily {

--- a/media/style.css
+++ b/media/style.css
@@ -159,7 +159,7 @@ body {
 }
 
 .tm-calendar-grid.weekly {
-  grid-template-rows: max-content auto 1fr;
+  grid-template-rows: max-content 1fr;
 }
 
 .tm-calendar-grid.monthly .tm-day-header,
@@ -185,42 +185,46 @@ body {
   box-shadow: inset 0 0 0 2px var(--tm-accent);
 }
 
-/* ─── Multi-Day Bands ────────────────────────────────────────── */
-.tm-week-bands {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  column-gap: 1px;
-  row-gap: 2px;
-  padding: 3px 0;
-  background-color: var(--tm-bg);
+/* ─── Multi-Day Bands (inside cells) ─────────────────────────── */
+.tm-cell-bands {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex-shrink: 0;
 }
 
-.tm-multi-day-band {
-  height: 22px;
-  line-height: 22px;
-  font-size: 12px;
+.tm-cell-band {
+  height: 20px;
+  line-height: 20px;
+  font-size: 11px;
   font-weight: 600;
-  padding: 0 6px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: #fff;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
-  border-radius: 4px;
+  border-radius: 0;
   opacity: 0.9;
 }
 
-.tm-multi-day-band.band-start {
+.tm-cell-band.band-start {
   border-radius: 4px 0 0 4px;
-  padding-left: 8px;
+  margin-left: 3px;
+  padding-left: 6px;
 }
 
-.tm-multi-day-band.band-end {
+.tm-cell-band.band-end {
   border-radius: 0 4px 4px 0;
+  margin-right: 3px;
 }
 
-.tm-multi-day-band.band-start.band-end {
+.tm-cell-band.band-start.band-end {
   border-radius: 4px;
+  margin: 0 3px;
+}
+
+.tm-cell-band-spacer {
+  height: 20px;
 }
 
 .tm-calendar-grid.daily {

--- a/media/style.css
+++ b/media/style.css
@@ -150,7 +150,43 @@ body {
 }
 
 .tm-calendar-grid.weekly {
-  grid-template-rows: max-content 1fr;
+  grid-template-rows: max-content auto 1fr;
+}
+
+/* ─── Multi-Day Bands ────────────────────────────────────────── */
+.tm-week-bands {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 12px;
+  row-gap: 3px;
+}
+
+.tm-multi-day-band {
+  height: 22px;
+  line-height: 22px;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 0 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  border-radius: 0;
+  opacity: 0.9;
+}
+
+.tm-multi-day-band.band-start {
+  border-radius: 11px 0 0 11px;
+  padding-left: 10px;
+}
+
+.tm-multi-day-band.band-end {
+  border-radius: 0 11px 11px 0;
+}
+
+.tm-multi-day-band.band-start.band-end {
+  border-radius: 11px;
 }
 
 .tm-calendar-grid.daily {

--- a/media/style.css
+++ b/media/style.css
@@ -176,13 +176,18 @@ body {
 
 .tm-calendar-grid.monthly .tm-cal-cell:hover,
 .tm-calendar-grid.weekly .tm-cal-cell:hover {
-  box-shadow: inset 0 0 0 2px var(--tm-accent);
+  box-shadow: inset 0 0 0 2px var(--tm-accent-hover);
 }
 
 .tm-calendar-grid.monthly .tm-cal-cell.today,
 .tm-calendar-grid.weekly .tm-cal-cell.today {
   border: none;
   box-shadow: inset 0 0 0 2px var(--tm-accent);
+}
+
+.tm-calendar-grid.monthly .tm-cal-cell.today:hover,
+.tm-calendar-grid.weekly .tm-cal-cell.today:hover {
+  box-shadow: inset 0 0 0 3px var(--tm-accent-hover);
 }
 
 /* ─── Multi-Day Bands (inside cells) ─────────────────────────── */

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -158,4 +158,44 @@ suite('Gantt Test Suite', () => {
     assert.ok(sprint.minTime < sprint.maxTime, 'minTime should be before maxTime');
     assert.ok(sprint.children[0].startMs < sprint.children[1].startMs, 'children should be in chronological order');
   });
+
+  test('range item child spans correct time in gantt entity', () => {
+    const data = parseTmd(`
+# 2026-03-01 : 2026-03-05
+- Conference
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 1);
+
+    const entity = entities[0];
+    assert.strictEqual(entity.name, 'Conference');
+    assert.strictEqual(entity.children.length, 1);
+
+    const child = entity.children[0];
+    const expectedStart = new Date(2026, 2, 1).getTime();
+    const expectedEnd = new Date(2026, 2, 6).getTime() - 1;
+
+    assert.strictEqual(child.startMs, expectedStart);
+    assert.strictEqual(child.endMs, expectedEnd);
+    assert.strictEqual(entity.minTime, expectedStart);
+    assert.strictEqual(entity.maxTime, expectedEnd);
+  });
+
+  test('range items from different weeks each produce a separate child in gantt', () => {
+    const data = parseTmd(`
+# 2026-03-01 : 2026-03-03
+- Workshop A
+
+# 2026-03-10 : 2026-03-12
+- Workshop B
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 2);
+
+    const workshopA = entities.find(e => e.name === 'Workshop A');
+    const workshopB = entities.find(e => e.name === 'Workshop B');
+    assert.ok(workshopA, 'Workshop A entity should exist');
+    assert.ok(workshopB, 'Workshop B entity should exist');
+    assert.ok(workshopA!.minTime < workshopB!.minTime, 'Workshop A should start before Workshop B');
+  });
 });


### PR DESCRIPTION
## 関連Issue
Closes #36

## 概要
範囲指定（開始日〜終了日）で作成した予定を、カレンダーの月表示・週表示において開始日から終了日にまたがる1つの連続したバンドとして表示するように変更した。
従来は各日に個別のアイテムとして重複表示されていたが、本変更によりGoogleカレンダーのような帯状表示が実現される。

## 変更内容
- `media/main.js`: `collectWeekBands()` 関数を追加し、週ごとに範囲イベントを収集・行割り当てするロジックを実装
- `media/main.js`: `createWeekBandsElement()` 関数を追加し、週のバンド行DOM要素を生成
- `media/main.js`: `renderCalendar()` を週単位のレンダリングに変更し、各週の前にバンド行を挿入
- `media/main.js`: `renderWeekly()` を修正し、日セル前にバンド行を追加
- `media/main.js`: 月・週ビューの日セルから範囲アイテムを除外（バンドとして表示するため）
- `media/style.css`: `.tm-week-bands` と `.tm-multi-day-band` のスタイルを追加
- `src/test/suite/gantt.test.ts`: 複数日範囲アイテムのganttエンティティに関するテストを2件追加

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] `npm run lint` パス（既存の警告のみ、新規エラーなし）
- [x] `npm run test:unit` 32件全パス

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| 範囲指定イベントが各日に個別アイテムとして表示 | 開始〜終了日に渡る色付きバンドとして表示 |

## 備考・次やること
- 日ビュー（Daily）では範囲アイテムは引き続き通常アイテムとして表示される（詳細確認のため）