### PR TITLE
feat: グループタスクの子タスクをクリックで展開/折りたたみ可能にする

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -847,6 +847,8 @@
 
   /** Main timeline (Gantt) renderer */
   function renderTimeline() {
+    const savedScrollLeft = viewTimeline.scrollLeft;
+    const savedScrollTop = viewTimeline.scrollTop;
     viewTimeline.innerHTML = '';
     viewTimeline.className = 'tm-gantt-view';
 
@@ -902,6 +904,8 @@
     });
 
     viewTimeline.appendChild(ganttContainer);
+    viewTimeline.scrollLeft = savedScrollLeft;
+    viewTimeline.scrollTop = savedScrollTop;
   }
 
 })();

--- a/media/main.js
+++ b/media/main.js
@@ -212,6 +212,14 @@
   });
   window.addEventListener('blur', stopPanning);
 
+  // Keep group toggles visible at the left edge while scrolling horizontally
+  viewTimeline?.addEventListener('scroll', () => {
+    const sl = viewTimeline.scrollLeft;
+    viewTimeline.querySelectorAll('.tm-gantt-group-toggle').forEach(el => {
+      el.style.left = (sl + 4) + 'px';
+    });
+  });
+
   // Gantt zoom
   viewTimeline?.addEventListener('wheel', (e) => {
     if (e.ctrlKey) {
@@ -907,6 +915,12 @@
     });
 
     viewTimeline.appendChild(ganttContainer);
+
+    // Align toggle buttons to current scroll position
+    const sl = viewTimeline.scrollLeft;
+    ganttContainer.querySelectorAll('.tm-gantt-group-toggle').forEach(el => {
+      el.style.left = (sl + 4) + 'px';
+    });
   }
 
 })();

--- a/media/main.js
+++ b/media/main.js
@@ -17,6 +17,7 @@
   let currentTaskMarkData = null;
   let currentGanttData = null;
   let ganttZoom = 1; // 1 = 100px per day
+  let collapsedGroups = new Set();
   let isPanning = false;
   let startPanX = 0;
   let startPanY = 0;
@@ -714,6 +715,23 @@
     rowBg.className = 'tm-gantt-row-bg';
     rowBg.style.top = yOffset + 'px';
     rowBg.style.width = totalWidth + 'px';
+
+    if (entity.isGroup) {
+      const toggle = document.createElement('span');
+      toggle.className = 'tm-gantt-group-toggle';
+      toggle.textContent = collapsedGroups.has(entity.name) ? '▶' : '▼';
+      toggle.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (collapsedGroups.has(entity.name)) {
+          collapsedGroups.delete(entity.name);
+        } else {
+          collapsedGroups.add(entity.name);
+        }
+        renderTimeline();
+      });
+      rowBg.appendChild(toggle);
+    }
+
     container.appendChild(rowBg);
 
     const bgColor = getItemBorderColor(entity.tags, currentTaskMarkData.tagColors);
@@ -868,7 +886,8 @@
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
     const totalRowCount = entityArray.reduce((sum, e) => {
-      return sum + 1 + (e.isGroup ? e.children.length : 0);
+      const childCount = e.isGroup && !collapsedGroups.has(e.name) ? e.children.length : 0;
+      return sum + 1 + childCount;
     }, 0);
     ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
 
@@ -881,7 +900,7 @@
       const entityYOffset = yOffset;
       renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
       yOffset += GANTT_ROW_HEIGHT + 4;
-      if (entity.isGroup) {
+      if (entity.isGroup && !collapsedGroups.has(entity.name)) {
         renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
         yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
       }

--- a/media/main.js
+++ b/media/main.js
@@ -748,6 +748,11 @@
     pBar.style.backgroundColor = bgColor;
     bar.appendChild(pBar);
 
+    const indicator = document.createElement('span');
+    indicator.className = 'tm-gantt-group-indicator';
+    indicator.textContent = expandedGroups.has(entity.name) ? '▼' : '▶';
+    bar.appendChild(indicator);
+
     bar.addEventListener('click', (e) => {
       e.stopPropagation();
       if (expandedGroups.has(entity.name)) {

--- a/media/main.js
+++ b/media/main.js
@@ -715,11 +715,13 @@
     rowBg.className = 'tm-gantt-row-bg';
     rowBg.style.top = yOffset + 'px';
     rowBg.style.width = totalWidth + 'px';
+    container.appendChild(rowBg);
 
     if (entity.isGroup) {
       const toggle = document.createElement('span');
       toggle.className = 'tm-gantt-group-toggle';
       toggle.textContent = collapsedGroups.has(entity.name) ? '▶' : '▼';
+      toggle.style.top = (yOffset + 4) + 'px';
       toggle.addEventListener('click', (e) => {
         e.stopPropagation();
         if (collapsedGroups.has(entity.name)) {
@@ -729,10 +731,8 @@
         }
         renderTimeline();
       });
-      rowBg.appendChild(toggle);
+      container.appendChild(toggle);
     }
-
-    container.appendChild(rowBg);
 
     const bgColor = getItemBorderColor(entity.tags, currentTaskMarkData.tagColors);
 

--- a/media/main.js
+++ b/media/main.js
@@ -17,7 +17,7 @@
   let currentTaskMarkData = null;
   let currentGanttData = null;
   let ganttZoom = 1; // 1 = 100px per day
-  let collapsedGroups = new Set();
+  let expandedGroups = new Set();
   let isPanning = false;
   let startPanX = 0;
   let startPanY = 0;
@@ -211,14 +211,6 @@
     if (e.button === 0) stopPanning();
   });
   window.addEventListener('blur', stopPanning);
-
-  // Keep group toggles visible at the left edge while scrolling horizontally
-  viewTimeline?.addEventListener('scroll', () => {
-    const sl = viewTimeline.scrollLeft;
-    viewTimeline.querySelectorAll('.tm-gantt-group-toggle').forEach(el => {
-      el.style.left = (sl + 4) + 'px';
-    });
-  });
 
   // Gantt zoom
   viewTimeline?.addEventListener('wheel', (e) => {
@@ -725,23 +717,6 @@
     rowBg.style.width = totalWidth + 'px';
     container.appendChild(rowBg);
 
-    if (entity.isGroup) {
-      const toggle = document.createElement('span');
-      toggle.className = 'tm-gantt-group-toggle';
-      toggle.textContent = collapsedGroups.has(entity.name) ? '▶' : '▼';
-      toggle.style.top = (yOffset + 4) + 'px';
-      toggle.addEventListener('click', (e) => {
-        e.stopPropagation();
-        if (collapsedGroups.has(entity.name)) {
-          collapsedGroups.delete(entity.name);
-        } else {
-          collapsedGroups.add(entity.name);
-        }
-        renderTimeline();
-      });
-      container.appendChild(toggle);
-    }
-
     const bgColor = getItemBorderColor(entity.tags, currentTaskMarkData.tagColors);
 
     if (entity.isGroup) {
@@ -756,6 +731,7 @@
     const width = Math.max((entity.maxTime - entity.minTime) * pxPerMs, GANTT_MIN_BAR_WIDTH);
 
     const bar = createGanttBar(left, yOffset, width, bgColor);
+    bar.classList.add('tm-gantt-group-bar');
 
     // Progress fill
     const pBar = document.createElement('div');
@@ -771,6 +747,17 @@
     }
     pBar.style.backgroundColor = bgColor;
     bar.appendChild(pBar);
+
+    bar.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (expandedGroups.has(entity.name)) {
+        expandedGroups.delete(entity.name);
+      } else {
+        expandedGroups.add(entity.name);
+      }
+      renderTimeline();
+    });
+
     container.appendChild(bar);
 
     // Label (outside bar, to the right)
@@ -894,7 +881,7 @@
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
     const totalRowCount = entityArray.reduce((sum, e) => {
-      const childCount = e.isGroup && !collapsedGroups.has(e.name) ? e.children.length : 0;
+      const childCount = e.isGroup && expandedGroups.has(e.name) ? e.children.length : 0;
       return sum + 1 + childCount;
     }, 0);
     ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
@@ -908,19 +895,13 @@
       const entityYOffset = yOffset;
       renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
       yOffset += GANTT_ROW_HEIGHT + 4;
-      if (entity.isGroup && !collapsedGroups.has(entity.name)) {
+      if (entity.isGroup && expandedGroups.has(entity.name)) {
         renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
         yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
       }
     });
 
     viewTimeline.appendChild(ganttContainer);
-
-    // Align toggle buttons to current scroll position
-    const sl = viewTimeline.scrollLeft;
-    ganttContainer.querySelectorAll('.tm-gantt-group-toggle').forEach(el => {
-      el.style.left = (sl + 4) + 'px';
-    });
   }
 
 })();

--- a/media/style.css
+++ b/media/style.css
@@ -580,18 +580,19 @@ body {
 
 /* Group row toggle button */
 .tm-gantt-group-toggle {
-  position: sticky;
+  position: absolute;
   left: 4px;
   display: inline-flex;
   align-items: center;
-  height: 100%;
+  justify-content: center;
+  width: 20px;
+  height: 32px;
   font-size: 10px;
   color: var(--tm-fg);
   cursor: pointer;
   user-select: none;
-  opacity: 0.5;
-  z-index: 3;
-  padding-right: 4px;
+  opacity: 0.6;
+  z-index: 8;
 }
 
 .tm-gantt-group-toggle:hover {

--- a/media/style.css
+++ b/media/style.css
@@ -578,6 +578,26 @@ body {
   pointer-events: none;
 }
 
+/* Group row toggle button */
+.tm-gantt-group-toggle {
+  position: sticky;
+  left: 4px;
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  font-size: 10px;
+  color: var(--tm-fg);
+  cursor: pointer;
+  user-select: none;
+  opacity: 0.5;
+  z-index: 3;
+  padding-right: 4px;
+}
+
+.tm-gantt-group-toggle:hover {
+  opacity: 1;
+}
+
 /* Child rows (group task members) */
 .tm-gantt-child-row-bg {
   border-left: 2px solid var(--tm-card-border);

--- a/media/style.css
+++ b/media/style.css
@@ -552,6 +552,10 @@ body {
   transition: transform 0.1s, filter 0.1s;
 }
 
+.tm-gantt-group-bar {
+  cursor: pointer;
+}
+
 .tm-gantt-absolute-bar:hover {
   transform: translateY(-2px);
   filter: brightness(1.1);
@@ -576,27 +580,6 @@ body {
   font-weight: bold;
   white-space: nowrap;
   pointer-events: none;
-}
-
-/* Group row toggle button */
-.tm-gantt-group-toggle {
-  position: absolute;
-  left: 4px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 32px;
-  font-size: 10px;
-  color: var(--tm-fg);
-  cursor: pointer;
-  user-select: none;
-  opacity: 0.6;
-  z-index: 8;
-}
-
-.tm-gantt-group-toggle:hover {
-  opacity: 1;
 }
 
 /* Child rows (group task members) */

--- a/media/style.css
+++ b/media/style.css
@@ -556,6 +556,15 @@ body {
   cursor: pointer;
 }
 
+.tm-gantt-group-indicator {
+  position: relative;
+  z-index: 2;
+  padding: 0 6px;
+  font-size: 9px;
+  color: var(--tm-fg);
+  pointer-events: none;
+}
+
 .tm-gantt-absolute-bar:hover {
   transform: translateY(-2px);
   filter: brightness(1.1);


### PR DESCRIPTION
## 関連Issue
Closes #52

## 概要
グループタスクの子タスクをデフォルトで折りたたんだ状態にし、グループバー（オブジェクト）をクリックすることで展開/折りたたみを切り替えられるようにした。これにより、タスク数が多い場合のガントチャートの縦の高さを削減し、全体のスケジュール感を把握しやすくする。

## 変更内容
- `media/main.js`: `expandedGroups`（`Set`）でグループごとの展開状態を管理。デフォルトは空のため全グループが折りたたみ状態で表示される
- `media/main.js`: グループバーにクリックハンドラを追加し、クリックで`expandedGroups`を更新後`renderTimeline()`を再実行
- `media/main.js`: 高さ計算とレンダリングループを`expandedGroups`の状態に対応
- `media/style.css`: `.tm-gantt-group-bar`クラスを追加し、グループバーに`cursor: pointer`を設定

## 採用した解決策
Issue記載の選択肢のうち「クリックで展開/折りたたみ（アコーディオン形式）」を採用。
- ホバーツールチップ案はタスク数が多いと視認性が低く、ガントバーと重なる問題があった
- グローバルトグルボタン案は個別のグループ制御ができない
- グループバー自体をクリック対象にすることで、余分なUIパーツなしに直感的な操作を実現

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| 全グループの子タスクが常に展開表示 | デフォルト折りたたみ、グループバーをクリックで展開/折りたたみ切り替え |

## 備考・次やること
- 展開状態（`expandedGroups`）はページリロード（データ更新）後にリセットされる。永続化が必要な場合は別Issueで対応