### PR TITLE
feat: developマージ時にstaggedラベルを自動付与するワークフローを追加

### DIFF
--- a/.github/workflows/label-staged.yml
+++ b/.github/workflows/label-staged.yml
@@ -1,0 +1,31 @@
+name: Label Staged Issues
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+jobs:
+  label-staged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*#(\d+)/gi;
+            const issueNumbers = [...body.matchAll(pattern)].map(m => parseInt(m[1]));
+
+            for (const issueNumber of issueNumbers) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['staged']
+              });
+            }


### PR DESCRIPTION
## 関連Issue
なし（運用改善）

## 概要
developブランチにPRがマージされた際、PRの本文に記載された関連Issueに`staged`ラベルを自動付与するGitHub Actionsワークフローを追加します。
修正がdevelopにマージ済みだがまだmainにリリースされていないIssueを一目で識別できるようになります。

## 変更内容
- `.github/workflows/label-staged.yml` を追加
  - `develop`へのPRマージ時に発火
  - PRの本文から `Closes #N` / `Fixes #N` / `Resolves #N` を検出し、対象IssueにGitHub上で作成済みの`staged`ラベルを付与

## 動作確認・テスト
- [ ] developへのPRマージ時にワークフローが発火することを確認した
- [ ] 関連Issueに`staged`ラベルが付与されることを確認した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| - | - |

## 備考・次やること
- mainマージ時にIssueをクローズする運用は既存のまま変更なし