### PR TITLE
feat: パースエラー時にWebviewにエラーバナーを表示する

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -25,6 +25,7 @@
   let initialScrollT = 0;
 
   // ─── DOM References ──────────────────────────────────────────
+  const errorBanner = document.getElementById('tm-parse-error-banner');
   const btnCalendar = document.getElementById('btn-calendar');
   const btnTimeline = document.getElementById('btn-timeline');
   const btnMonthly = document.getElementById('btn-monthly');
@@ -124,7 +125,16 @@
     if (message.type === 'update') {
       currentTaskMarkData = message.data;
       currentGanttData = message.ganttData;
+      if (errorBanner) {
+        errorBanner.textContent = '';
+        errorBanner.classList.add('hidden');
+      }
       render();
+    } else if (message.type === 'parseError') {
+      if (errorBanner) {
+        errorBanner.textContent = `Parse error: ${message.message}`;
+        errorBanner.classList.remove('hidden');
+      }
     }
   });
 

--- a/media/style.css
+++ b/media/style.css
@@ -61,12 +61,15 @@ body {
 
 /* ─── Parse Error Banner ────────────────────────────────────── */
 .tm-error-banner {
+  position: relative;
   background: var(--vscode-inputValidation-errorBackground, rgba(180, 30, 30, 0.9));
   color: var(--vscode-inputValidation-errorForeground, #fff);
   border-bottom: 1px solid var(--vscode-inputValidation-errorBorder, #be1100);
   padding: 8px 24px;
   font-size: 13px;
   font-family: var(--tm-font);
+  white-space: pre-wrap;
+  word-break: break-word;
   z-index: 20;
 }
 

--- a/media/style.css
+++ b/media/style.css
@@ -59,6 +59,17 @@ body {
   display: none !important;
 }
 
+/* ─── Parse Error Banner ────────────────────────────────────── */
+.tm-error-banner {
+  background: var(--vscode-inputValidation-errorBackground, rgba(180, 30, 30, 0.9));
+  color: var(--vscode-inputValidation-errorForeground, #fff);
+  border-bottom: 1px solid var(--vscode-inputValidation-errorBorder, #be1100);
+  padding: 8px 24px;
+  font-size: 13px;
+  font-family: var(--tm-font);
+  z-index: 20;
+}
+
 /* ─── Header & Controls ─────────────────────────────────────── */
 .tm-header {
   padding: 16px 24px;

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -10,6 +10,11 @@ export interface TaskMarkUpdateMessage {
   ganttData: GanttData;
 }
 
+export interface TaskMarkErrorMessage {
+  type: 'parseError';
+  message: string;
+}
+
 export class TaskmarkPanel {
   public static currentPanel: TaskmarkPanel | undefined;
   public static readonly viewType = 'taskmark';
@@ -115,12 +120,11 @@ export class TaskmarkPanel {
       };
       this._panel.webview.postMessage(message);
     } catch (e) {
+      const errorText = e instanceof Error ? e.message : String(e);
       console.error("TaskMark parse error", e);
-      if (e instanceof Error) {
-        vscode.window.showErrorMessage(`TaskMark parse error: ${e.message}`);
-      } else {
-        vscode.window.showErrorMessage(`TaskMark parse error: ${String(e)}`);
-      }
+      vscode.window.showErrorMessage(`TaskMark parse error: ${errorText}`);
+      const errorMessage: TaskMarkErrorMessage = { type: 'parseError', message: errorText };
+      this._panel.webview.postMessage(errorMessage);
     }
   }
 

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -122,7 +122,6 @@ export class TaskmarkPanel {
     } catch (e) {
       const errorText = e instanceof Error ? e.message : String(e);
       console.error("TaskMark parse error", e);
-      vscode.window.showErrorMessage(`TaskMark parse error: ${errorText}`);
       const errorMessage: TaskMarkErrorMessage = { type: 'parseError', message: errorText };
       this._panel.webview.postMessage(errorMessage);
     }

--- a/src/template.ts
+++ b/src/template.ts
@@ -10,6 +10,7 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri): st
         <link href="${stylesUri}" rel="stylesheet">
       </head>
       <body>
+        <div id="tm-parse-error-banner" class="tm-error-banner hidden"></div>
         <div class="tm-header">
           <div class="tm-toggle-container">
             <button class="tm-view-toggle active" id="btn-calendar">Calendar</button>

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -1,0 +1,22 @@
+import * as assert from 'assert';
+import { TaskMarkUpdateMessage, TaskMarkErrorMessage } from '../../TaskmarkPanel';
+
+suite('TaskmarkPanel message types', () => {
+  test('TaskMarkUpdateMessage has type "update"', () => {
+    const msg: TaskMarkUpdateMessage = {
+      type: 'update',
+      data: { tagColors: {}, days: {} },
+      ganttData: { entities: [], lastDateStr: '' }
+    };
+    assert.strictEqual(msg.type, 'update');
+  });
+
+  test('TaskMarkErrorMessage has type "parseError" and a message field', () => {
+    const msg: TaskMarkErrorMessage = {
+      type: 'parseError',
+      message: 'unexpected token at line 3'
+    };
+    assert.strictEqual(msg.type, 'parseError');
+    assert.strictEqual(msg.message, 'unexpected token at line 3');
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #50

## 概要
`.tmd` ファイルのパースに失敗した際、Webview 上部にエラーバナーを表示するようにした。ファイルが正常にパースされた際はバナーが自動的に消える。

## 変更内容
- `src/TaskmarkPanel.ts`: `TaskMarkErrorMessage` インターフェースを追加し、パースエラー時に Webview へエラーメッセージを送信。`vscode.window.showErrorMessage` は削除（編集のたびにポップアップが出て作業の妨げになるため）
- `src/template.ts`: エラーバナー用の `<div id="tm-parse-error-banner">` を追加
- `media/main.js`: `parseError` メッセージを受信してバナーを表示し、`update` メッセージ受信時にバナーを非表示にする処理を追加
- `media/style.css`: `.tm-error-banner` スタイルを追加。`position: relative` を付与して `z-index` を有効化。`white-space: pre-wrap` と `word-break: break-word` で長いエラーメッセージにも対応
- `src/test/suite/TaskmarkPanel.test.ts`: `TaskMarkErrorMessage` インターフェースのテストを追加

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した
- [x] `npm run lint` がパスすることを確認した
- [x] `npm run test:unit` 全40テストがパスすることを確認した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| パースエラー時はポップアップのみ | Webview上部にエラーバナーが表示され、エラー内容を確認できる |

## 備考・次やること
- パーサーが不正な行を無視する挙動を警告として収集・表示する改善は #60 で対応予定