### PR TITLE
release: v1.3.1

### DIFF
--- a/.github/workflows/label-staged.yml
+++ b/.github/workflows/label-staged.yml
@@ -1,0 +1,31 @@
+name: Label Staged Issues
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+jobs:
+  label-staged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*#(\d+)/gi;
+            const issueNumbers = [...body.matchAll(pattern)].map(m => parseInt(m[1]));
+
+            for (const issueNumber of issueNumbers) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['staged']
+              });
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the "TaskMark" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.3.1] - 2026-04-12
+
+### Added
+- Date range events are now displayed as continuous multi-day bands in Calendar (Monthly/Weekly) views (#55).
+- Group task rows in the Gantt chart are now collapsible; click the group bar to toggle child visibility (#56).
+- Parse error and warning banners now appear in the Webview when a `.tmd` file has issues (#59, #61).
+
+### Changed
+- Document update is now debounced for improved rendering performance (#57).
+
 ## [1.3.0] - 2026-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Switch between three granularity levels to check your schedule.
 - `<` `>` Buttons → Navigate forward and backward in time
 - `Today` Button → Return to the current date
 - Saturdays are highlighted in blue, Sundays in red
+- Date range events are displayed as continuous multi-day bands spanning across cells
 
 ### 📊 Timeline View (Gantt Chart)
 
@@ -67,7 +68,7 @@ Visualize schedule durations and project spans as a Gantt chart.
 - **Zoom** — Use `Ctrl + Mouse Wheel` to zoom in/out (from days to hours)
 - **Progress Bars** — Group task completion rates are displayed visually on the bars
 - **Weekend Colors** — Colored backgrounds corresponding to the calendar view
-- **Sub-rows** — Tasks inside a group are displayed as individual sub-rows beneath the group bar
+- **Sub-rows** — Tasks inside a group are displayed as individual sub-rows beneath the group bar; click the group bar to collapse or expand them
 - Grouped schedules appear as a single connected bar, while standalone items with the same name appear as separate blocks on the same row
 
 ### 🏷️ Tags & Colors

--- a/media/main.js
+++ b/media/main.js
@@ -416,30 +416,43 @@
    * Collect range events overlapping [weekStartStr, weekEndStr] and assign band rows
    * to prevent visual overlap. Returns an array of band descriptors.
    */
-  function collectWeekBands(weekStartStr, weekEndStr) {
+  /** Collect all range items from the dataset (items with endDate). */
+  function collectAllRangeItems() {
+    const rangeItems = [];
+    Object.entries(currentTaskMarkData.days).forEach(([date, dayData]) => {
+      dayData.items.forEach(item => {
+        if (item.endDate) rangeItems.push({ date, item });
+      });
+    });
+    return rangeItems;
+  }
+
+  /** Count day difference between two dates using calendar arithmetic (DST-safe). */
+  function dayDiff(fromDate, toDate) {
+    const a = new Date(fromDate.getFullYear(), fromDate.getMonth(), fromDate.getDate());
+    const b = new Date(toDate.getFullYear(), toDate.getMonth(), toDate.getDate());
+    return Math.round((b - a) / MS_PER_DAY);
+  }
+
+  function collectWeekBands(weekStartStr, weekEndStr, rangeItems) {
     const weekStartDate = parseLocalDate(weekStartStr);
     const events = [];
 
-    Object.entries(currentTaskMarkData.days).forEach(([date, dayData]) => {
-      dayData.items.forEach(item => {
-        if (!item.endDate) return;
-        if (date > weekEndStr || item.endDate < weekStartStr) return;
+    rangeItems.forEach(({ date, item }) => {
+      if (date > weekEndStr || item.endDate < weekStartStr) return;
 
-        const clippedStart = date < weekStartStr ? weekStartStr : date;
-        const clippedEnd = item.endDate > weekEndStr ? weekEndStr : item.endDate;
+      const clippedStart = date < weekStartStr ? weekStartStr : date;
+      const clippedEnd = item.endDate > weekEndStr ? weekEndStr : item.endDate;
 
-        const startDate = parseLocalDate(clippedStart);
-        const endDate = parseLocalDate(clippedEnd);
-        const colStart = Math.round((startDate - weekStartDate) / MS_PER_DAY) + 1;
-        const colEnd = Math.round((endDate - weekStartDate) / MS_PER_DAY) + 2;
+      const colStart = dayDiff(weekStartDate, parseLocalDate(clippedStart)) + 1;
+      const colEnd = dayDiff(weekStartDate, parseLocalDate(clippedEnd)) + 2;
 
-        events.push({
-          item,
-          colStart,
-          colEnd,
-          isStart: date >= weekStartStr,
-          isEnd: item.endDate <= weekEndStr,
-        });
+      events.push({
+        item,
+        colStart,
+        colEnd,
+        isStart: date >= weekStartStr,
+        isEnd: item.endDate <= weekEndStr,
       });
     });
 
@@ -570,13 +583,14 @@
     }
 
     // Render week by week: band segments inside each cell
+    const rangeItems = collectAllRangeItems();
     const numWeeks = cells.length / 7;
     for (let w = 0; w < numWeeks; w++) {
       const weekCells = cells.slice(w * 7, (w + 1) * 7);
       const weekStartStr = weekCells[0].dStr;
       const weekEndStr = weekCells[6].dStr;
 
-      const weekBands = collectWeekBands(weekStartStr, weekEndStr);
+      const weekBands = collectWeekBands(weekStartStr, weekEndStr, rangeItems);
       const { map: bandMap, maxRow } = buildCellBandMap(weekBands);
 
       weekCells.forEach((cell, i) => {
@@ -606,7 +620,8 @@
     weekEndDate.setDate(weekEndDate.getDate() + 6);
     const weekEndStr = formatDateStr(weekEndDate.getFullYear(), weekEndDate.getMonth() + 1, weekEndDate.getDate());
 
-    const weekBands = collectWeekBands(weekStartStr, weekEndStr);
+    const rangeItems = collectAllRangeItems();
+    const weekBands = collectWeekBands(weekStartStr, weekEndStr, rangeItems);
     const { map: bandMap, maxRow } = buildCellBandMap(weekBands);
 
     for (let i = 0; i < 7; i++) {

--- a/media/main.js
+++ b/media/main.js
@@ -847,6 +847,8 @@
 
   /** Main timeline (Gantt) renderer */
   function renderTimeline() {
+    const savedScrollLeft = viewTimeline.scrollLeft;
+    const savedScrollTop = viewTimeline.scrollTop;
     viewTimeline.innerHTML = '';
     viewTimeline.className = 'tm-gantt-view';
 
@@ -902,6 +904,8 @@
     });
 
     viewTimeline.appendChild(ganttContainer);
+    viewTimeline.scrollLeft = savedScrollLeft;
+    viewTimeline.scrollTop = savedScrollTop;
   }
 
 })();

--- a/media/main.js
+++ b/media/main.js
@@ -412,10 +412,6 @@
 
   // ─── Multi-Day Band Rendering ────────────────────────────────
 
-  /**
-   * Collect range events overlapping [weekStartStr, weekEndStr] and assign band rows
-   * to prevent visual overlap. Returns an array of band descriptors.
-   */
   /** Collect all range items from the dataset (items with endDate). */
   function collectAllRangeItems() {
     const rangeItems = [];
@@ -434,6 +430,10 @@
     return Math.round((b - a) / MS_PER_DAY);
   }
 
+  /**
+   * Collect range events overlapping [weekStartStr, weekEndStr] and assign band rows
+   * to prevent visual overlap. Returns an array of band descriptors.
+   */
   function collectWeekBands(weekStartStr, weekEndStr, rangeItems) {
     const weekStartDate = parseLocalDate(weekStartStr);
     const events = [];

--- a/media/main.js
+++ b/media/main.js
@@ -488,7 +488,7 @@
 
   /** Create HTML for band segments inside a single cell */
   function createCellBandsHtml(cellBands, maxRow, tagColorsMap) {
-    if (maxRow < 0) return '';
+    if (maxRow < 0 || !cellBands || cellBands.length === 0) return '';
 
     const rowMap = {};
     if (cellBands) cellBands.forEach(b => { rowMap[b.bandRow] = b; });

--- a/media/main.js
+++ b/media/main.js
@@ -14,8 +14,10 @@
   let baseView = 'calendar'; // 'calendar' | 'timeline'
   let activeView = 'monthly'; // 'monthly' | 'weekly' | 'daily'
   let currentDate = new Date();
+  let currentUri = null;
   let currentTaskMarkData = null;
   let currentGanttData = null;
+  let rangeItemIndex = null; // Pre-built index: date string -> range items spanning that date
   let ganttZoom = 1; // 1 = 100px per day
   let expandedGroups = new Set();
   let isPanning = false;
@@ -126,13 +128,49 @@
     return d.getTime() - 1;
   }
 
+  /** Build an index mapping each date to range items that span into it.
+   *  Called once per data update so getDayData can do O(1) lookups. */
+  function buildRangeItemIndex(taskMarkData) {
+    if (!taskMarkData) return {};
+    const index = {};
+    Object.entries(taskMarkData.days).forEach(([startDate, data]) => {
+      data.items.forEach(item => {
+        if (!item.endDate || item.endDate <= startDate) return;
+        // Add this item to every date after startDate through endDate
+        const start = parseLocalDate(startDate);
+        const end = parseLocalDate(item.endDate);
+        const cursor = new Date(start);
+        cursor.setDate(cursor.getDate() + 1);
+        while (cursor <= end) {
+          const key = cursor.getFullYear() + '-' +
+            String(cursor.getMonth() + 1).padStart(2, '0') + '-' +
+            String(cursor.getDate()).padStart(2, '0');
+          if (!index[key]) index[key] = [];
+          index[key].push(item);
+          cursor.setDate(cursor.getDate() + 1);
+        }
+      });
+    });
+    return index;
+  }
+
   // ─── Message Handling ────────────────────────────────────────
 
   window.addEventListener('message', event => {
     const message = event.data;
     if (message.type === 'update') {
+      if (message.uri && message.uri !== currentUri) {
+        currentUri = message.uri;
+        expandedGroups = new Set();
+        ganttZoom = 1;
+        if (viewTimeline) {
+          viewTimeline.scrollLeft = 0;
+          viewTimeline.scrollTop = 0;
+        }
+      }
       currentTaskMarkData = message.data;
       currentGanttData = message.ganttData;
+      rangeItemIndex = buildRangeItemIndex(currentTaskMarkData);
       if (errorBanner) {
         errorBanner.textContent = '';
         errorBanner.classList.add('hidden');
@@ -261,11 +299,16 @@
   // Date navigation
   function navigateDate(direction) {
     if (baseView === 'timeline' || activeView === 'monthly') {
-      currentDate.setMonth(currentDate.getMonth() + direction);
+      const y = currentDate.getFullYear();
+      const m = currentDate.getMonth() + direction;
+      // Clamp day to last day of target month to avoid overflow (e.g. Jan 31 + 1 month = Feb 28)
+      const maxDay = new Date(y, m + 1, 0).getDate();
+      const d = Math.min(currentDate.getDate(), maxDay);
+      currentDate = new Date(y, m, d);
     } else if (activeView === 'weekly') {
-      currentDate.setDate(currentDate.getDate() + 7 * direction);
+      currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate() + 7 * direction);
     } else if (activeView === 'daily') {
-      currentDate.setDate(currentDate.getDate() + direction);
+      currentDate = new Date(currentDate.getFullYear(), currentDate.getMonth(), currentDate.getDate() + direction);
     }
     render();
   }
@@ -435,17 +478,9 @@
   /** Get day data from the current dataset, including range items that span into dStr */
   function getDayData(dStr) {
     const dayData = currentTaskMarkData.days[dStr] || { items: [] };
-    const rangeItems = [];
-    Object.entries(currentTaskMarkData.days).forEach(([date, data]) => {
-      if (date >= dStr) return;
-      data.items.forEach(item => {
-        if (item.endDate && item.endDate >= dStr) {
-          rangeItems.push(item);
-        }
-      });
-    });
-    if (rangeItems.length === 0) return dayData;
-    return { ...dayData, items: [...dayData.items, ...rangeItems] };
+    const spanning = rangeItemIndex && rangeItemIndex[dStr];
+    if (!spanning || spanning.length === 0) return dayData;
+    return { ...dayData, items: [...dayData.items, ...spanning] };
   }
 
   // ─── Multi-Day Band Rendering ────────────────────────────────

--- a/media/main.js
+++ b/media/main.js
@@ -495,6 +495,7 @@
           bandRow: band.bandRow,
           isStart: band.isStart && col === band.colStart,
           isEnd: band.isEnd && col === band.colEnd - 1,
+          showLabel: col === band.colStart,
           item: band.item
         });
       }
@@ -517,7 +518,7 @@
         if (band.isStart) classes.push('band-start');
         if (band.isEnd) classes.push('band-end');
         const color = getItemBorderColor(band.item.tags, tagColorsMap);
-        const text = band.isStart ? escapeHtml(band.item.text) : '';
+        const text = band.showLabel ? escapeHtml(band.item.text) : '';
         html += `<div class="${classes.join(' ')}" style="background-color: ${color}">${text}</div>`;
       } else {
         html += '<div class="tm-cell-band-spacer"></div>';

--- a/media/main.js
+++ b/media/main.js
@@ -212,6 +212,14 @@
   });
   window.addEventListener('blur', stopPanning);
 
+  // Keep group toggles visible at the left edge while scrolling horizontally
+  viewTimeline?.addEventListener('scroll', () => {
+    const sl = viewTimeline.scrollLeft;
+    viewTimeline.querySelectorAll('.tm-gantt-group-toggle').forEach(el => {
+      el.style.left = (sl + 4) + 'px';
+    });
+  });
+
   // Gantt zoom
   viewTimeline?.addEventListener('wheel', (e) => {
     if (e.ctrlKey) {
@@ -907,6 +915,12 @@
     });
 
     viewTimeline.appendChild(ganttContainer);
+
+    // Align toggle buttons to current scroll position
+    const sl = viewTimeline.scrollLeft;
+    ganttContainer.querySelectorAll('.tm-gantt-group-toggle').forEach(el => {
+      el.style.left = (sl + 4) + 'px';
+    });
   }
 
 })();

--- a/media/main.js
+++ b/media/main.js
@@ -142,9 +142,7 @@
         const cursor = new Date(start);
         cursor.setDate(cursor.getDate() + 1);
         while (cursor <= end) {
-          const key = cursor.getFullYear() + '-' +
-            String(cursor.getMonth() + 1).padStart(2, '0') + '-' +
-            String(cursor.getDate()).padStart(2, '0');
+          const key = formatDateStr(cursor.getFullYear(), cursor.getMonth() + 1, cursor.getDate());
           if (!index[key]) index[key] = [];
           index[key].push(item);
           cursor.setDate(cursor.getDate() + 1);

--- a/media/main.js
+++ b/media/main.js
@@ -423,11 +423,9 @@
     return rangeItems;
   }
 
-  /** Count day difference between two dates using calendar arithmetic (DST-safe). */
+  /** Count day difference between two local-midnight Date objects (DST-safe via Math.round). */
   function dayDiff(fromDate, toDate) {
-    const a = new Date(fromDate.getFullYear(), fromDate.getMonth(), fromDate.getDate());
-    const b = new Date(toDate.getFullYear(), toDate.getMonth(), toDate.getDate());
-    return Math.round((b - a) / MS_PER_DAY);
+    return Math.round((toDate - fromDate) / MS_PER_DAY);
   }
 
   /**

--- a/media/main.js
+++ b/media/main.js
@@ -26,6 +26,7 @@
 
   // ─── DOM References ──────────────────────────────────────────
   const errorBanner = document.getElementById('tm-parse-error-banner');
+  const warningBanner = document.getElementById('tm-warning-banner');
   const btnCalendar = document.getElementById('btn-calendar');
   const btnTimeline = document.getElementById('btn-timeline');
   const btnMonthly = document.getElementById('btn-monthly');
@@ -129,11 +130,24 @@
         errorBanner.textContent = '';
         errorBanner.classList.add('hidden');
       }
+      if (warningBanner) {
+        if (message.warnings && message.warnings.length > 0) {
+          warningBanner.textContent = message.warnings.join('\n');
+          warningBanner.classList.remove('hidden');
+        } else {
+          warningBanner.textContent = '';
+          warningBanner.classList.add('hidden');
+        }
+      }
       render();
     } else if (message.type === 'parseError') {
       if (errorBanner) {
         errorBanner.textContent = `Parse error: ${message.message}`;
         errorBanner.classList.remove('hidden');
+      }
+      if (warningBanner) {
+        warningBanner.textContent = '';
+        warningBanner.classList.add('hidden');
       }
     }
   });

--- a/media/main.js
+++ b/media/main.js
@@ -443,6 +443,9 @@
       });
     });
 
+    // Sort by start column, then longer spans first for stable top-down placement
+    events.sort((a, b) => a.colStart - b.colStart || (b.colEnd - b.colStart) - (a.colEnd - a.colStart));
+
     // Assign band rows to avoid visual overlap within the same week
     const rowEnds = [];
     events.forEach(event => {
@@ -491,7 +494,7 @@
     if (maxRow < 0 || !cellBands || cellBands.length === 0) return '';
 
     const rowMap = {};
-    if (cellBands) cellBands.forEach(b => { rowMap[b.bandRow] = b; });
+    cellBands.forEach(b => { rowMap[b.bandRow] = b; });
 
     let html = '<div class="tm-cell-bands">';
     for (let r = 0; r <= maxRow; r++) {
@@ -578,8 +581,8 @@
 
       weekCells.forEach((cell, i) => {
         const colIndex = i + 1;
-        const dayData = getDayData(cell.dStr);
-        const regularItems = dayData.items.filter(item => !item.endDate);
+        const dayItems = (currentTaskMarkData.days[cell.dStr] || { items: [] }).items;
+        const regularItems = dayItems.filter(item => !item.endDate);
         const el = createCell(cell.dayNo, cell.isOtherMonth, cell.isToday, cell.dayOfWeek, cell.dStr);
         el.innerHTML += createCellBandsHtml(bandMap[colIndex], maxRow, tagColors);
         el.innerHTML += createItemsHtml(regularItems, tagColors, true);
@@ -610,8 +613,8 @@
       const dStr = formatDateStr(d.getFullYear(), d.getMonth() + 1, d.getDate());
       const dayOfWeek = d.getDay();
       const colIndex = i + 1;
-      const dayData = getDayData(dStr);
-      const regularItems = dayData.items.filter(item => !item.endDate);
+      const dayItems = (currentTaskMarkData.days[dStr] || { items: [] }).items;
+      const regularItems = dayItems.filter(item => !item.endDate);
       const cell = createCell(d.getDate(), false, dStr === todayStr, dayOfWeek, dStr);
       cell.style.flex = '1';
       cell.innerHTML += createCellBandsHtml(bandMap[colIndex], maxRow, tagColors);

--- a/media/main.js
+++ b/media/main.js
@@ -19,6 +19,7 @@
   let ganttZoom = 1; // 1 = 100px per day
   let expandedGroups = new Set();
   let isPanning = false;
+  let hasDragged = false;
   let startPanX = 0;
   let startPanY = 0;
   let initialScrollL = 0;
@@ -66,10 +67,16 @@
     return '';
   }
 
+  // Keep in sync with VALID_CSS_COLOR_REGEX in src/parser.ts
+  const VALID_CSS_COLOR_RE = /^(?:#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|(?:rgb|hsl)a?\(\s*\d[\d.]*%?(?:\s*[,/\s]\s*\d[\d.]*%?){2,3}\s*\)|[a-zA-Z]{1,30})$/;
+
   /** Deterministic color from tag name, or explicit color from map */
   function getTagColor(tagName, tagColorsMap) {
     if (tagColorsMap && tagColorsMap[tagName]) {
-      return tagColorsMap[tagName];
+      if (VALID_CSS_COLOR_RE.test(tagColorsMap[tagName])) {
+        return tagColorsMap[tagName];
+      }
+      console.warn(`[TaskMark] Invalid color value for tag "${tagName}": "${tagColorsMap[tagName]}", using fallback`);
     }
     let hash = 0;
     for (let i = 0; i < tagName.length; i++) {
@@ -214,6 +221,7 @@
   viewTimeline?.addEventListener('mousedown', (e) => {
     if (e.button !== 0) return;
     isPanning = true;
+    hasDragged = false;
     startPanX = e.clientX;
     startPanY = e.clientY;
     initialScrollL = viewTimeline.scrollLeft;
@@ -227,6 +235,11 @@
     if (!(e.buttons & 1)) {
       stopPanning();
       return;
+    }
+    if (!hasDragged) {
+      const dx = e.clientX - startPanX;
+      const dy = e.clientY - startPanY;
+      if (dx * dx + dy * dy > 9) hasDragged = true;
     }
     viewTimeline.scrollLeft = initialScrollL - (e.clientX - startPanX);
     viewTimeline.scrollTop = initialScrollT - (e.clientY - startPanY);
@@ -779,6 +792,7 @@
 
     bar.addEventListener('click', (e) => {
       e.stopPropagation();
+      if (hasDragged) return;
       if (expandedGroups.has(entity.name)) {
         expandedGroups.delete(entity.name);
       } else {

--- a/media/main.js
+++ b/media/main.js
@@ -25,6 +25,7 @@
   let initialScrollT = 0;
 
   // ─── DOM References ──────────────────────────────────────────
+  const errorBanner = document.getElementById('tm-parse-error-banner');
   const btnCalendar = document.getElementById('btn-calendar');
   const btnTimeline = document.getElementById('btn-timeline');
   const btnMonthly = document.getElementById('btn-monthly');
@@ -124,7 +125,16 @@
     if (message.type === 'update') {
       currentTaskMarkData = message.data;
       currentGanttData = message.ganttData;
+      if (errorBanner) {
+        errorBanner.textContent = '';
+        errorBanner.classList.add('hidden');
+      }
       render();
+    } else if (message.type === 'parseError') {
+      if (errorBanner) {
+        errorBanner.textContent = `Parse error: ${message.message}`;
+        errorBanner.classList.remove('hidden');
+      }
     }
   });
 

--- a/media/main.js
+++ b/media/main.js
@@ -410,6 +410,94 @@
     return { ...dayData, items: [...dayData.items, ...rangeItems] };
   }
 
+  // ─── Multi-Day Band Rendering ────────────────────────────────
+
+  /**
+   * Collect range events overlapping [weekStartStr, weekEndStr] and assign band rows
+   * to prevent visual overlap. Returns an array of band descriptors.
+   */
+  function collectWeekBands(weekStartStr, weekEndStr) {
+    const weekStartDate = parseLocalDate(weekStartStr);
+    const events = [];
+
+    Object.entries(currentTaskMarkData.days).forEach(([date, dayData]) => {
+      dayData.items.forEach(item => {
+        if (!item.endDate) return;
+        if (date > weekEndStr || item.endDate < weekStartStr) return;
+
+        const clippedStart = date < weekStartStr ? weekStartStr : date;
+        const clippedEnd = item.endDate > weekEndStr ? weekEndStr : item.endDate;
+
+        const startDate = parseLocalDate(clippedStart);
+        const endDate = parseLocalDate(clippedEnd);
+        const colStart = Math.round((startDate - weekStartDate) / MS_PER_DAY) + 1;
+        const colEnd = Math.round((endDate - weekStartDate) / MS_PER_DAY) + 2;
+
+        events.push({
+          item,
+          colStart,
+          colEnd,
+          isStart: date >= weekStartStr,
+          isEnd: item.endDate <= weekEndStr,
+        });
+      });
+    });
+
+    // Assign band rows to avoid visual overlap within the same week
+    const rowEnds = [];
+    events.forEach(event => {
+      let assigned = false;
+      for (let r = 0; r < rowEnds.length; r++) {
+        if (rowEnds[r] <= event.colStart) {
+          event.bandRow = r;
+          rowEnds[r] = event.colEnd;
+          assigned = true;
+          break;
+        }
+      }
+      if (!assigned) {
+        event.bandRow = rowEnds.length;
+        rowEnds.push(event.colEnd);
+      }
+    });
+
+    return events;
+  }
+
+  /**
+   * Create a bands container element for one week row.
+   * Returns null if there are no range events for the given week.
+   */
+  function createWeekBandsElement(weekStartStr, weekEndStr) {
+    const bands = collectWeekBands(weekStartStr, weekEndStr);
+    if (bands.length === 0) return null;
+
+    const container = document.createElement('div');
+    container.className = 'tm-week-bands';
+    container.style.gridColumn = '1 / -1';
+
+    bands.forEach(band => {
+      const el = document.createElement('div');
+      const classes = ['tm-multi-day-band'];
+      if (band.isStart) classes.push('band-start');
+      if (band.isEnd) classes.push('band-end');
+      el.className = classes.join(' ');
+      el.style.gridColumn = `${band.colStart} / ${band.colEnd}`;
+      el.style.gridRow = `${band.bandRow + 1}`;
+
+      const color = getItemBorderColor(band.item.tags, currentTaskMarkData.tagColors);
+      el.style.backgroundColor = color;
+
+      if (band.isStart) {
+        el.textContent = band.item.text;
+      }
+
+      container.appendChild(el);
+    });
+
+    return container;
+  }
+
   // ─── Calendar Views ──────────────────────────────────────────
 
   function renderCalendar(year, monthIndex) {
@@ -424,34 +512,64 @@
     const todayStr = getTodayStr();
     const tagColors = currentTaskMarkData.tagColors;
 
-    // Previous month padding
+    // Build full cell list (prev padding + current month + next padding) as complete weeks
+    const cells = [];
+
     const prevDateObj = new Date(year, monthIndex, 0);
-    const prevMonthLastDay = prevDateObj.getDate();
     for (let i = startPadding - 1; i >= 0; i--) {
-      const d = prevMonthLastDay - i;
-      const dayOfWeek = new Date(prevDateObj.getFullYear(), prevDateObj.getMonth(), d).getDay();
-      const dStr = formatDateStr(prevDateObj.getFullYear(), prevDateObj.getMonth() + 1, d);
-      viewCalendar.appendChild(createCell(d, true, false, dayOfWeek, dStr));
+      const d = prevDateObj.getDate() - i;
+      const dObj = new Date(prevDateObj.getFullYear(), prevDateObj.getMonth(), d);
+      cells.push({
+        dayNo: d,
+        isOtherMonth: true,
+        isToday: false,
+        dayOfWeek: dObj.getDay(),
+        dStr: formatDateStr(dObj.getFullYear(), dObj.getMonth() + 1, d)
+      });
     }
 
-    // Current month days
     for (let i = 1; i <= totalDays; i++) {
       const dStr = formatDateStr(year, monthIndex + 1, i);
-      const dayOfWeek = new Date(year, monthIndex, i).getDay();
-      const dayData = getDayData(dStr);
-      const cell = createCell(i, false, dStr === todayStr, dayOfWeek, dStr);
-      cell.innerHTML += createItemsHtml(dayData.items, tagColors, true);
-      viewCalendar.appendChild(cell);
+      cells.push({
+        dayNo: i,
+        isOtherMonth: false,
+        isToday: dStr === todayStr,
+        dayOfWeek: new Date(year, monthIndex, i).getDay(),
+        dStr
+      });
     }
 
-    // Next month padding
     const totalCells = startPadding + totalDays;
     const endPadding = totalCells % 7 === 0 ? 0 : 7 - (totalCells % 7);
     const nextDateObj = new Date(year, monthIndex + 1, 1);
     for (let i = 1; i <= endPadding; i++) {
-      const dayOfWeek = new Date(nextDateObj.getFullYear(), nextDateObj.getMonth(), i).getDay();
-      const dStr = formatDateStr(nextDateObj.getFullYear(), nextDateObj.getMonth() + 1, i);
-      viewCalendar.appendChild(createCell(i, true, false, dayOfWeek, dStr));
+      const dObj = new Date(nextDateObj.getFullYear(), nextDateObj.getMonth(), i);
+      cells.push({
+        dayNo: i,
+        isOtherMonth: true,
+        isToday: false,
+        dayOfWeek: dObj.getDay(),
+        dStr: formatDateStr(dObj.getFullYear(), dObj.getMonth() + 1, i)
+      });
+    }
+
+    // Render week by week: optional bands row + 7 day cells
+    const numWeeks = cells.length / 7;
+    for (let w = 0; w < numWeeks; w++) {
+      const weekCells = cells.slice(w * 7, (w + 1) * 7);
+      const weekStartStr = weekCells[0].dStr;
+      const weekEndStr = weekCells[6].dStr;
+
+      const bandsEl = createWeekBandsElement(weekStartStr, weekEndStr);
+      if (bandsEl) viewCalendar.appendChild(bandsEl);
+
+      weekCells.forEach(cell => {
+        const dayData = getDayData(cell.dStr);
+        const regularItems = dayData.items.filter(item => !item.endDate);
+        const el = createCell(cell.dayNo, cell.isOtherMonth, cell.isToday, cell.dayOfWeek, cell.dStr);
+        el.innerHTML += createItemsHtml(regularItems, tagColors, true);
+        viewCalendar.appendChild(el);
+      });
     }
   }
 
@@ -465,13 +583,22 @@
     const todayStr = getTodayStr();
     const tagColors = currentTaskMarkData.tagColors;
 
+    const weekStartStr = formatDateStr(d.getFullYear(), d.getMonth() + 1, d.getDate());
+    const weekEndDate = new Date(d);
+    weekEndDate.setDate(weekEndDate.getDate() + 6);
+    const weekEndStr = formatDateStr(weekEndDate.getFullYear(), weekEndDate.getMonth() + 1, weekEndDate.getDate());
+
+    const bandsEl = createWeekBandsElement(weekStartStr, weekEndStr);
+    if (bandsEl) viewCalendar.appendChild(bandsEl);
+
     for (let i = 0; i < 7; i++) {
       const dStr = formatDateStr(d.getFullYear(), d.getMonth() + 1, d.getDate());
       const dayOfWeek = d.getDay();
       const dayData = getDayData(dStr);
+      const regularItems = dayData.items.filter(item => !item.endDate);
       const cell = createCell(d.getDate(), false, dStr === todayStr, dayOfWeek, dStr);
       cell.style.flex = '1';
-      cell.innerHTML += createItemsHtml(dayData.items, tagColors);
+      cell.innerHTML += createItemsHtml(regularItems, tagColors);
       viewCalendar.appendChild(cell);
       d.setDate(d.getDate() + 1);
     }

--- a/media/main.js
+++ b/media/main.js
@@ -17,6 +17,7 @@
   let currentTaskMarkData = null;
   let currentGanttData = null;
   let ganttZoom = 1; // 1 = 100px per day
+  let collapsedGroups = new Set();
   let isPanning = false;
   let startPanX = 0;
   let startPanY = 0;
@@ -714,6 +715,23 @@
     rowBg.className = 'tm-gantt-row-bg';
     rowBg.style.top = yOffset + 'px';
     rowBg.style.width = totalWidth + 'px';
+
+    if (entity.isGroup) {
+      const toggle = document.createElement('span');
+      toggle.className = 'tm-gantt-group-toggle';
+      toggle.textContent = collapsedGroups.has(entity.name) ? '▶' : '▼';
+      toggle.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (collapsedGroups.has(entity.name)) {
+          collapsedGroups.delete(entity.name);
+        } else {
+          collapsedGroups.add(entity.name);
+        }
+        renderTimeline();
+      });
+      rowBg.appendChild(toggle);
+    }
+
     container.appendChild(rowBg);
 
     const bgColor = getItemBorderColor(entity.tags, currentTaskMarkData.tagColors);
@@ -868,7 +886,8 @@
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
     const totalRowCount = entityArray.reduce((sum, e) => {
-      return sum + 1 + (e.isGroup ? e.children.length : 0);
+      const childCount = e.isGroup && !collapsedGroups.has(e.name) ? e.children.length : 0;
+      return sum + 1 + childCount;
     }, 0);
     ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
 
@@ -881,7 +900,7 @@
       const entityYOffset = yOffset;
       renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
       yOffset += GANTT_ROW_HEIGHT + 4;
-      if (entity.isGroup) {
+      if (entity.isGroup && !collapsedGroups.has(entity.name)) {
         renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
         yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
       }

--- a/media/main.js
+++ b/media/main.js
@@ -465,37 +465,50 @@
   }
 
   /**
-   * Create a bands container element for one week row.
-   * Returns null if there are no range events for the given week.
+   * Build a per-column map from week band data.
+   * Returns { map: { colIndex -> [{bandRow, isStart, isEnd, item}] }, maxRow: number }
    */
-  function createWeekBandsElement(weekStartStr, weekEndStr) {
-    const bands = collectWeekBands(weekStartStr, weekEndStr);
-    if (bands.length === 0) return null;
-
-    const container = document.createElement('div');
-    container.className = 'tm-week-bands';
-    container.style.gridColumn = '1 / -1';
-
-    bands.forEach(band => {
-      const el = document.createElement('div');
-      const classes = ['tm-multi-day-band'];
-      if (band.isStart) classes.push('band-start');
-      if (band.isEnd) classes.push('band-end');
-      el.className = classes.join(' ');
-      el.style.gridColumn = `${band.colStart} / ${band.colEnd}`;
-      el.style.gridRow = `${band.bandRow + 1}`;
-
-      const color = getItemBorderColor(band.item.tags, currentTaskMarkData.tagColors);
-      el.style.backgroundColor = color;
-
-      if (band.isStart) {
-        el.textContent = band.item.text;
+  function buildCellBandMap(weekBands) {
+    const map = {};
+    let maxRow = -1;
+    weekBands.forEach(band => {
+      if (band.bandRow > maxRow) maxRow = band.bandRow;
+      for (let col = band.colStart; col < band.colEnd; col++) {
+        if (!map[col]) map[col] = [];
+        map[col].push({
+          bandRow: band.bandRow,
+          isStart: band.isStart && col === band.colStart,
+          isEnd: band.isEnd && col === band.colEnd - 1,
+          item: band.item
+        });
       }
-
-      container.appendChild(el);
     });
+    return { map, maxRow };
+  }
 
-    return container;
+  /** Create HTML for band segments inside a single cell */
+  function createCellBandsHtml(cellBands, maxRow, tagColorsMap) {
+    if (maxRow < 0) return '';
+
+    const rowMap = {};
+    if (cellBands) cellBands.forEach(b => { rowMap[b.bandRow] = b; });
+
+    let html = '<div class="tm-cell-bands">';
+    for (let r = 0; r <= maxRow; r++) {
+      const band = rowMap[r];
+      if (band) {
+        const classes = ['tm-cell-band'];
+        if (band.isStart) classes.push('band-start');
+        if (band.isEnd) classes.push('band-end');
+        const color = getItemBorderColor(band.item.tags, tagColorsMap);
+        const text = band.isStart ? escapeHtml(band.item.text) : '';
+        html += `<div class="${classes.join(' ')}" style="background-color: ${color}">${text}</div>`;
+      } else {
+        html += '<div class="tm-cell-band-spacer"></div>';
+      }
+    }
+    html += '</div>';
+    return html;
   }
 
   // ─── Calendar Views ──────────────────────────────────────────
@@ -553,20 +566,22 @@
       });
     }
 
-    // Render week by week: optional bands row + 7 day cells
+    // Render week by week: band segments inside each cell
     const numWeeks = cells.length / 7;
     for (let w = 0; w < numWeeks; w++) {
       const weekCells = cells.slice(w * 7, (w + 1) * 7);
       const weekStartStr = weekCells[0].dStr;
       const weekEndStr = weekCells[6].dStr;
 
-      const bandsEl = createWeekBandsElement(weekStartStr, weekEndStr);
-      if (bandsEl) viewCalendar.appendChild(bandsEl);
+      const weekBands = collectWeekBands(weekStartStr, weekEndStr);
+      const { map: bandMap, maxRow } = buildCellBandMap(weekBands);
 
-      weekCells.forEach(cell => {
+      weekCells.forEach((cell, i) => {
+        const colIndex = i + 1;
         const dayData = getDayData(cell.dStr);
         const regularItems = dayData.items.filter(item => !item.endDate);
         const el = createCell(cell.dayNo, cell.isOtherMonth, cell.isToday, cell.dayOfWeek, cell.dStr);
+        el.innerHTML += createCellBandsHtml(bandMap[colIndex], maxRow, tagColors);
         el.innerHTML += createItemsHtml(regularItems, tagColors, true);
         viewCalendar.appendChild(el);
       });
@@ -588,16 +603,18 @@
     weekEndDate.setDate(weekEndDate.getDate() + 6);
     const weekEndStr = formatDateStr(weekEndDate.getFullYear(), weekEndDate.getMonth() + 1, weekEndDate.getDate());
 
-    const bandsEl = createWeekBandsElement(weekStartStr, weekEndStr);
-    if (bandsEl) viewCalendar.appendChild(bandsEl);
+    const weekBands = collectWeekBands(weekStartStr, weekEndStr);
+    const { map: bandMap, maxRow } = buildCellBandMap(weekBands);
 
     for (let i = 0; i < 7; i++) {
       const dStr = formatDateStr(d.getFullYear(), d.getMonth() + 1, d.getDate());
       const dayOfWeek = d.getDay();
+      const colIndex = i + 1;
       const dayData = getDayData(dStr);
       const regularItems = dayData.items.filter(item => !item.endDate);
       const cell = createCell(d.getDate(), false, dStr === todayStr, dayOfWeek, dStr);
       cell.style.flex = '1';
+      cell.innerHTML += createCellBandsHtml(bandMap[colIndex], maxRow, tagColors);
       cell.innerHTML += createItemsHtml(regularItems, tagColors);
       viewCalendar.appendChild(cell);
       d.setDate(d.getDate() + 1);

--- a/media/main.js
+++ b/media/main.js
@@ -748,6 +748,11 @@
     pBar.style.backgroundColor = bgColor;
     bar.appendChild(pBar);
 
+    const indicator = document.createElement('span');
+    indicator.className = 'tm-gantt-group-indicator';
+    indicator.textContent = expandedGroups.has(entity.name) ? '▼' : '▶';
+    bar.appendChild(indicator);
+
     bar.addEventListener('click', (e) => {
       e.stopPropagation();
       if (expandedGroups.has(entity.name)) {

--- a/media/main.js
+++ b/media/main.js
@@ -715,11 +715,13 @@
     rowBg.className = 'tm-gantt-row-bg';
     rowBg.style.top = yOffset + 'px';
     rowBg.style.width = totalWidth + 'px';
+    container.appendChild(rowBg);
 
     if (entity.isGroup) {
       const toggle = document.createElement('span');
       toggle.className = 'tm-gantt-group-toggle';
       toggle.textContent = collapsedGroups.has(entity.name) ? '▶' : '▼';
+      toggle.style.top = (yOffset + 4) + 'px';
       toggle.addEventListener('click', (e) => {
         e.stopPropagation();
         if (collapsedGroups.has(entity.name)) {
@@ -729,10 +731,8 @@
         }
         renderTimeline();
       });
-      rowBg.appendChild(toggle);
+      container.appendChild(toggle);
     }
-
-    container.appendChild(rowBg);
 
     const bgColor = getItemBorderColor(entity.tags, currentTaskMarkData.tagColors);
 

--- a/media/main.js
+++ b/media/main.js
@@ -17,7 +17,7 @@
   let currentTaskMarkData = null;
   let currentGanttData = null;
   let ganttZoom = 1; // 1 = 100px per day
-  let collapsedGroups = new Set();
+  let expandedGroups = new Set();
   let isPanning = false;
   let startPanX = 0;
   let startPanY = 0;
@@ -211,14 +211,6 @@
     if (e.button === 0) stopPanning();
   });
   window.addEventListener('blur', stopPanning);
-
-  // Keep group toggles visible at the left edge while scrolling horizontally
-  viewTimeline?.addEventListener('scroll', () => {
-    const sl = viewTimeline.scrollLeft;
-    viewTimeline.querySelectorAll('.tm-gantt-group-toggle').forEach(el => {
-      el.style.left = (sl + 4) + 'px';
-    });
-  });
 
   // Gantt zoom
   viewTimeline?.addEventListener('wheel', (e) => {
@@ -725,23 +717,6 @@
     rowBg.style.width = totalWidth + 'px';
     container.appendChild(rowBg);
 
-    if (entity.isGroup) {
-      const toggle = document.createElement('span');
-      toggle.className = 'tm-gantt-group-toggle';
-      toggle.textContent = collapsedGroups.has(entity.name) ? '▶' : '▼';
-      toggle.style.top = (yOffset + 4) + 'px';
-      toggle.addEventListener('click', (e) => {
-        e.stopPropagation();
-        if (collapsedGroups.has(entity.name)) {
-          collapsedGroups.delete(entity.name);
-        } else {
-          collapsedGroups.add(entity.name);
-        }
-        renderTimeline();
-      });
-      container.appendChild(toggle);
-    }
-
     const bgColor = getItemBorderColor(entity.tags, currentTaskMarkData.tagColors);
 
     if (entity.isGroup) {
@@ -756,6 +731,7 @@
     const width = Math.max((entity.maxTime - entity.minTime) * pxPerMs, GANTT_MIN_BAR_WIDTH);
 
     const bar = createGanttBar(left, yOffset, width, bgColor);
+    bar.classList.add('tm-gantt-group-bar');
 
     // Progress fill
     const pBar = document.createElement('div');
@@ -771,6 +747,17 @@
     }
     pBar.style.backgroundColor = bgColor;
     bar.appendChild(pBar);
+
+    bar.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (expandedGroups.has(entity.name)) {
+        expandedGroups.delete(entity.name);
+      } else {
+        expandedGroups.add(entity.name);
+      }
+      renderTimeline();
+    });
+
     container.appendChild(bar);
 
     // Label (outside bar, to the right)
@@ -894,7 +881,7 @@
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
     const totalRowCount = entityArray.reduce((sum, e) => {
-      const childCount = e.isGroup && !collapsedGroups.has(e.name) ? e.children.length : 0;
+      const childCount = e.isGroup && expandedGroups.has(e.name) ? e.children.length : 0;
       return sum + 1 + childCount;
     }, 0);
     ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
@@ -908,19 +895,13 @@
       const entityYOffset = yOffset;
       renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
       yOffset += GANTT_ROW_HEIGHT + 4;
-      if (entity.isGroup && !collapsedGroups.has(entity.name)) {
+      if (entity.isGroup && expandedGroups.has(entity.name)) {
         renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
         yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
       }
     });
 
     viewTimeline.appendChild(ganttContainer);
-
-    // Align toggle buttons to current scroll position
-    const sl = viewTimeline.scrollLeft;
-    ganttContainer.querySelectorAll('.tm-gantt-group-toggle').forEach(el => {
-      el.style.left = (sl + 4) + 'px';
-    });
   }
 
 })();

--- a/media/style.css
+++ b/media/style.css
@@ -580,18 +580,19 @@ body {
 
 /* Group row toggle button */
 .tm-gantt-group-toggle {
-  position: sticky;
+  position: absolute;
   left: 4px;
   display: inline-flex;
   align-items: center;
-  height: 100%;
+  justify-content: center;
+  width: 20px;
+  height: 32px;
   font-size: 10px;
   color: var(--tm-fg);
   cursor: pointer;
   user-select: none;
-  opacity: 0.5;
-  z-index: 3;
-  padding-right: 4px;
+  opacity: 0.6;
+  z-index: 8;
 }
 
 .tm-gantt-group-toggle:hover {

--- a/media/style.css
+++ b/media/style.css
@@ -578,6 +578,26 @@ body {
   pointer-events: none;
 }
 
+/* Group row toggle button */
+.tm-gantt-group-toggle {
+  position: sticky;
+  left: 4px;
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  font-size: 10px;
+  color: var(--tm-fg);
+  cursor: pointer;
+  user-select: none;
+  opacity: 0.5;
+  z-index: 3;
+  padding-right: 4px;
+}
+
+.tm-gantt-group-toggle:hover {
+  opacity: 1;
+}
+
 /* Child rows (group task members) */
 .tm-gantt-child-row-bg {
   border-left: 2px solid var(--tm-card-border);

--- a/media/style.css
+++ b/media/style.css
@@ -61,12 +61,15 @@ body {
 
 /* ─── Parse Error Banner ────────────────────────────────────── */
 .tm-error-banner {
+  position: relative;
   background: var(--vscode-inputValidation-errorBackground, rgba(180, 30, 30, 0.9));
   color: var(--vscode-inputValidation-errorForeground, #fff);
   border-bottom: 1px solid var(--vscode-inputValidation-errorBorder, #be1100);
   padding: 8px 24px;
   font-size: 13px;
   font-family: var(--tm-font);
+  white-space: pre-wrap;
+  word-break: break-word;
   z-index: 20;
 }
 

--- a/media/style.css
+++ b/media/style.css
@@ -149,16 +149,50 @@ body {
   height: 100%;
 }
 
+/* Monthly & Weekly: compact grid with 1px lines via background trick */
+.tm-calendar-grid.monthly,
+.tm-calendar-grid.weekly {
+  gap: 1px;
+  background-color: var(--tm-card-border);
+  border-radius: var(--tm-radius);
+  overflow: hidden;
+}
+
 .tm-calendar-grid.weekly {
   grid-template-rows: max-content auto 1fr;
+}
+
+.tm-calendar-grid.monthly .tm-day-header,
+.tm-calendar-grid.weekly .tm-day-header {
+  background-color: var(--tm-bg);
+  padding: 10px 0 8px;
+}
+
+.tm-calendar-grid.monthly .tm-cal-cell,
+.tm-calendar-grid.weekly .tm-cal-cell {
+  border: none;
+  border-radius: 0;
+}
+
+.tm-calendar-grid.monthly .tm-cal-cell:hover,
+.tm-calendar-grid.weekly .tm-cal-cell:hover {
+  box-shadow: inset 0 0 0 2px var(--tm-accent);
+}
+
+.tm-calendar-grid.monthly .tm-cal-cell.today,
+.tm-calendar-grid.weekly .tm-cal-cell.today {
+  border: none;
+  box-shadow: inset 0 0 0 2px var(--tm-accent);
 }
 
 /* ─── Multi-Day Bands ────────────────────────────────────────── */
 .tm-week-bands {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
-  gap: 12px;
-  row-gap: 3px;
+  column-gap: 1px;
+  row-gap: 2px;
+  padding: 3px 0;
+  background-color: var(--tm-bg);
 }
 
 .tm-multi-day-band {
@@ -172,21 +206,21 @@ body {
   white-space: nowrap;
   color: #fff;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
-  border-radius: 0;
+  border-radius: 4px;
   opacity: 0.9;
 }
 
 .tm-multi-day-band.band-start {
-  border-radius: 11px 0 0 11px;
-  padding-left: 10px;
+  border-radius: 4px 0 0 4px;
+  padding-left: 8px;
 }
 
 .tm-multi-day-band.band-end {
-  border-radius: 0 11px 11px 0;
+  border-radius: 0 4px 4px 0;
 }
 
 .tm-multi-day-band.band-start.band-end {
-  border-radius: 11px;
+  border-radius: 4px;
 }
 
 .tm-calendar-grid.daily {

--- a/media/style.css
+++ b/media/style.css
@@ -73,6 +73,20 @@ body {
   z-index: 20;
 }
 
+/* ─── Parse Warning Banner ─────────────────────────────────── */
+.tm-warning-banner {
+  position: relative;
+  background: var(--vscode-inputValidation-warningBackground, rgba(180, 140, 20, 0.9));
+  color: var(--vscode-inputValidation-warningForeground, #fff);
+  border-bottom: 1px solid var(--vscode-inputValidation-warningBorder, #be8c00);
+  padding: 8px 24px;
+  font-size: 13px;
+  font-family: var(--tm-font);
+  white-space: pre-wrap;
+  word-break: break-word;
+  z-index: 20;
+}
+
 /* ─── Header & Controls ─────────────────────────────────────── */
 .tm-header {
   padding: 16px 24px;

--- a/media/style.css
+++ b/media/style.css
@@ -552,6 +552,10 @@ body {
   transition: transform 0.1s, filter 0.1s;
 }
 
+.tm-gantt-group-bar {
+  cursor: pointer;
+}
+
 .tm-gantt-absolute-bar:hover {
   transform: translateY(-2px);
   filter: brightness(1.1);
@@ -576,27 +580,6 @@ body {
   font-weight: bold;
   white-space: nowrap;
   pointer-events: none;
-}
-
-/* Group row toggle button */
-.tm-gantt-group-toggle {
-  position: absolute;
-  left: 4px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 32px;
-  font-size: 10px;
-  color: var(--tm-fg);
-  cursor: pointer;
-  user-select: none;
-  opacity: 0.6;
-  z-index: 8;
-}
-
-.tm-gantt-group-toggle:hover {
-  opacity: 1;
 }
 
 /* Child rows (group task members) */

--- a/media/style.css
+++ b/media/style.css
@@ -159,7 +159,7 @@ body {
 }
 
 .tm-calendar-grid.weekly {
-  grid-template-rows: max-content auto 1fr;
+  grid-template-rows: max-content 1fr;
 }
 
 .tm-calendar-grid.monthly .tm-day-header,
@@ -185,42 +185,46 @@ body {
   box-shadow: inset 0 0 0 2px var(--tm-accent);
 }
 
-/* ─── Multi-Day Bands ────────────────────────────────────────── */
-.tm-week-bands {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  column-gap: 1px;
-  row-gap: 2px;
-  padding: 3px 0;
-  background-color: var(--tm-bg);
+/* ─── Multi-Day Bands (inside cells) ─────────────────────────── */
+.tm-cell-bands {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex-shrink: 0;
 }
 
-.tm-multi-day-band {
-  height: 22px;
-  line-height: 22px;
-  font-size: 12px;
+.tm-cell-band {
+  height: 20px;
+  line-height: 20px;
+  font-size: 11px;
   font-weight: 600;
-  padding: 0 6px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: #fff;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
-  border-radius: 4px;
+  border-radius: 0;
   opacity: 0.9;
 }
 
-.tm-multi-day-band.band-start {
+.tm-cell-band.band-start {
   border-radius: 4px 0 0 4px;
-  padding-left: 8px;
+  margin-left: 3px;
+  padding-left: 6px;
 }
 
-.tm-multi-day-band.band-end {
+.tm-cell-band.band-end {
   border-radius: 0 4px 4px 0;
+  margin-right: 3px;
 }
 
-.tm-multi-day-band.band-start.band-end {
+.tm-cell-band.band-start.band-end {
   border-radius: 4px;
+  margin: 0 3px;
+}
+
+.tm-cell-band-spacer {
+  height: 20px;
 }
 
 .tm-calendar-grid.daily {

--- a/media/style.css
+++ b/media/style.css
@@ -150,7 +150,43 @@ body {
 }
 
 .tm-calendar-grid.weekly {
-  grid-template-rows: max-content 1fr;
+  grid-template-rows: max-content auto 1fr;
+}
+
+/* ─── Multi-Day Bands ────────────────────────────────────────── */
+.tm-week-bands {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 12px;
+  row-gap: 3px;
+}
+
+.tm-multi-day-band {
+  height: 22px;
+  line-height: 22px;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 0 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  border-radius: 0;
+  opacity: 0.9;
+}
+
+.tm-multi-day-band.band-start {
+  border-radius: 11px 0 0 11px;
+  padding-left: 10px;
+}
+
+.tm-multi-day-band.band-end {
+  border-radius: 0 11px 11px 0;
+}
+
+.tm-multi-day-band.band-start.band-end {
+  border-radius: 11px;
 }
 
 .tm-calendar-grid.daily {

--- a/media/style.css
+++ b/media/style.css
@@ -556,6 +556,15 @@ body {
   cursor: pointer;
 }
 
+.tm-gantt-group-indicator {
+  position: relative;
+  z-index: 2;
+  padding: 0 6px;
+  font-size: 9px;
+  color: var(--tm-fg);
+  pointer-events: none;
+}
+
 .tm-gantt-absolute-bar:hover {
   transform: translateY(-2px);
   filter: brightness(1.1);

--- a/media/style.css
+++ b/media/style.css
@@ -176,13 +176,18 @@ body {
 
 .tm-calendar-grid.monthly .tm-cal-cell:hover,
 .tm-calendar-grid.weekly .tm-cal-cell:hover {
-  box-shadow: inset 0 0 0 2px var(--tm-accent);
+  box-shadow: inset 0 0 0 2px var(--tm-accent-hover);
 }
 
 .tm-calendar-grid.monthly .tm-cal-cell.today,
 .tm-calendar-grid.weekly .tm-cal-cell.today {
   border: none;
   box-shadow: inset 0 0 0 2px var(--tm-accent);
+}
+
+.tm-calendar-grid.monthly .tm-cal-cell.today:hover,
+.tm-calendar-grid.weekly .tm-cal-cell.today:hover {
+  box-shadow: inset 0 0 0 3px var(--tm-accent-hover);
 }
 
 /* ─── Multi-Day Bands (inside cells) ─────────────────────────── */

--- a/media/style.css
+++ b/media/style.css
@@ -59,6 +59,17 @@ body {
   display: none !important;
 }
 
+/* ─── Parse Error Banner ────────────────────────────────────── */
+.tm-error-banner {
+  background: var(--vscode-inputValidation-errorBackground, rgba(180, 30, 30, 0.9));
+  color: var(--vscode-inputValidation-errorForeground, #fff);
+  border-bottom: 1px solid var(--vscode-inputValidation-errorBorder, #be1100);
+  padding: 8px 24px;
+  font-size: 13px;
+  font-family: var(--tm-font);
+  z-index: 20;
+}
+
 /* ─── Header & Controls ─────────────────────────────────────── */
 .tm-header {
   padding: 16px 24px;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "taskmark",
   "displayName": "TaskMark",
   "description": "Schedule and Task Management with Markdown and Calendar/Timeline Views",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "icon": "media/icon.png",
   "publisher": "Yadecode",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
-    "test:unit": "npm run compile && mocha --ui tdd out/test/suite/parser.test.js out/test/suite/gantt.test.js out/test/suite/debounce.test.js"
+    "test:unit": "npm run compile && mocha --ui tdd \"out/test/suite/*.test.js\" --ignore \"out/test/suite/extension.test.js\""
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
-    "test:unit": "npm run compile && mocha --ui tdd out/test/suite/parser.test.js out/test/suite/gantt.test.js"
+    "test:unit": "npm run compile && mocha --ui tdd out/test/suite/parser.test.js out/test/suite/gantt.test.js out/test/suite/debounce.test.js"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { parseTmd, TaskMarkData } from './parser';
 import { buildGanttEntities, GanttData } from './gantt';
 import { getWebviewHtml } from './template';
-import { debounce } from './utils/debounce';
+import { debounce, DebouncedFn } from './utils/debounce';
 
 export interface TaskMarkUpdateMessage {
   type: 'update';
@@ -17,7 +17,7 @@ export class TaskmarkPanel {
   private readonly _panel: vscode.WebviewPanel;
   private readonly _extensionUri: vscode.Uri;
   private _disposables: vscode.Disposable[] = [];
-  private readonly _debouncedUpdateFromDocument: (document: vscode.TextDocument) => void;
+  private readonly _debouncedUpdateFromDocument: DebouncedFn<(document: vscode.TextDocument) => void>;
 
   public static createOrShow(extensionUri: vscode.Uri) {
     const column = vscode.window.activeTextEditor
@@ -125,6 +125,7 @@ export class TaskmarkPanel {
 
   public dispose() {
     TaskmarkPanel.currentPanel = undefined;
+    this._debouncedUpdateFromDocument.cancel();
     this._panel.dispose();
     vscode.Disposable.from(...this._disposables).dispose();
     this._disposables = [];

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -1,11 +1,12 @@
 import * as vscode from 'vscode';
-import { parseTmd, TaskMarkData } from './parser';
+import { parseTmd, TaskMarkData, VALID_CSS_COLOR_REGEX } from './parser';
 import { buildGanttEntities, GanttData } from './gantt';
 import { getWebviewHtml } from './template';
 import { debounce, DebouncedFn } from './utils/debounce';
 
 export interface TaskMarkUpdateMessage {
   type: 'update';
+  uri: string;
   data: TaskMarkData;
   ganttData: GanttData;
   warnings: string[];
@@ -113,12 +114,21 @@ export class TaskmarkPanel {
       const text = document.getText();
       const { data: parsedData, warnings } = parseTmd(text);
       const configColors = vscode.workspace.getConfiguration('taskmark').get<Record<string, string>>('tagColors', {});
-      parsedData.tagColors = { ...configColors, ...parsedData.tagColors };
+      for (const [tag, color] of Object.entries(configColors)) {
+        if (VALID_CSS_COLOR_REGEX.test(color)) {
+          if (!parsedData.tagColors[tag]) {
+            parsedData.tagColors[tag] = color;
+          }
+        } else {
+          warnings.push(`Setting tagColors: invalid color '${color}' for tag '${tag}', skipped`);
+        }
+      }
       const message: TaskMarkUpdateMessage = {
         type: 'update',
+        uri: document.uri.toString(),
         data: parsedData,
         ganttData: buildGanttEntities(parsedData),
-        warnings
+        warnings: [...new Set(warnings)]
       };
       this._panel.webview.postMessage(message);
     } catch (e) {
@@ -141,6 +151,6 @@ export class TaskmarkPanel {
     const webview = this._panel.webview;
     const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'main.js'));
     const stylesUri = webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'media', 'style.css'));
-    webview.html = getWebviewHtml(scriptUri, stylesUri);
+    webview.html = getWebviewHtml(scriptUri, stylesUri, webview.cspSource);
   }
 }

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -75,8 +75,8 @@ export class TaskmarkPanel {
 
     vscode.window.onDidChangeActiveTextEditor(
       editor => {
+        this._debouncedUpdateFromDocument.cancel();
         if (editor && editor.document.languageId === 'tmd') {
-          this._debouncedUpdateFromDocument.cancel();
           this.updateFromDocument(editor.document);
         }
       },

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -10,6 +10,11 @@ export interface TaskMarkUpdateMessage {
   ganttData: GanttData;
 }
 
+export interface TaskMarkErrorMessage {
+  type: 'parseError';
+  message: string;
+}
+
 export class TaskmarkPanel {
   public static currentPanel: TaskmarkPanel | undefined;
   public static readonly viewType = 'taskmark';
@@ -115,12 +120,11 @@ export class TaskmarkPanel {
       };
       this._panel.webview.postMessage(message);
     } catch (e) {
+      const errorText = e instanceof Error ? e.message : String(e);
       console.error("TaskMark parse error", e);
-      if (e instanceof Error) {
-        vscode.window.showErrorMessage(`TaskMark parse error: ${e.message}`);
-      } else {
-        vscode.window.showErrorMessage(`TaskMark parse error: ${String(e)}`);
-      }
+      vscode.window.showErrorMessage(`TaskMark parse error: ${errorText}`);
+      const errorMessage: TaskMarkErrorMessage = { type: 'parseError', message: errorText };
+      this._panel.webview.postMessage(errorMessage);
     }
   }
 

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -122,7 +122,6 @@ export class TaskmarkPanel {
     } catch (e) {
       const errorText = e instanceof Error ? e.message : String(e);
       console.error("TaskMark parse error", e);
-      vscode.window.showErrorMessage(`TaskMark parse error: ${errorText}`);
       const errorMessage: TaskMarkErrorMessage = { type: 'parseError', message: errorText };
       this._panel.webview.postMessage(errorMessage);
     }

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -76,7 +76,8 @@ export class TaskmarkPanel {
     vscode.window.onDidChangeActiveTextEditor(
       editor => {
         if (editor && editor.document.languageId === 'tmd') {
-          this._debouncedUpdateFromDocument(editor.document);
+          this._debouncedUpdateFromDocument.cancel();
+          this.updateFromDocument(editor.document);
         }
       },
       null,

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { parseTmd, TaskMarkData, ParseResult } from './parser';
+import { parseTmd, TaskMarkData } from './parser';
 import { buildGanttEntities, GanttData } from './gantt';
 import { getWebviewHtml } from './template';
 import { debounce, DebouncedFn } from './utils/debounce';

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { parseTmd, TaskMarkData } from './parser';
+import { parseTmd, TaskMarkData, ParseResult } from './parser';
 import { buildGanttEntities, GanttData } from './gantt';
 import { getWebviewHtml } from './template';
 import { debounce, DebouncedFn } from './utils/debounce';
@@ -8,6 +8,7 @@ export interface TaskMarkUpdateMessage {
   type: 'update';
   data: TaskMarkData;
   ganttData: GanttData;
+  warnings: string[];
 }
 
 export interface TaskMarkErrorMessage {
@@ -110,13 +111,14 @@ export class TaskmarkPanel {
   private updateFromDocument(document: vscode.TextDocument) {
     try {
       const text = document.getText();
-      const parsedData = parseTmd(text);
+      const { data: parsedData, warnings } = parseTmd(text);
       const configColors = vscode.workspace.getConfiguration('taskmark').get<Record<string, string>>('tagColors', {});
       parsedData.tagColors = { ...configColors, ...parsedData.tagColors };
       const message: TaskMarkUpdateMessage = {
         type: 'update',
         data: parsedData,
-        ganttData: buildGanttEntities(parsedData)
+        ganttData: buildGanttEntities(parsedData),
+        warnings
       };
       this._panel.webview.postMessage(message);
     } catch (e) {

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { parseTmd, TaskMarkData } from './parser';
 import { buildGanttEntities, GanttData } from './gantt';
 import { getWebviewHtml } from './template';
+import { debounce } from './utils/debounce';
 
 export interface TaskMarkUpdateMessage {
   type: 'update';
@@ -16,6 +17,7 @@ export class TaskmarkPanel {
   private readonly _panel: vscode.WebviewPanel;
   private readonly _extensionUri: vscode.Uri;
   private _disposables: vscode.Disposable[] = [];
+  private readonly _debouncedUpdateFromDocument: (document: vscode.TextDocument) => void;
 
   public static createOrShow(extensionUri: vscode.Uri) {
     const column = vscode.window.activeTextEditor
@@ -49,6 +51,10 @@ export class TaskmarkPanel {
   private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri) {
     this._panel = panel;
     this._extensionUri = extensionUri;
+    this._debouncedUpdateFromDocument = debounce(
+      (document: vscode.TextDocument) => this.updateFromDocument(document),
+      250
+    );
 
     this._update();
     this.updateFromActiveEditor();
@@ -59,7 +65,7 @@ export class TaskmarkPanel {
       e => {
         if (e.document === vscode.window.activeTextEditor?.document) {
           if (e.document.languageId === 'tmd') {
-            this.updateFromDocument(e.document);
+            this._debouncedUpdateFromDocument(e.document);
           }
         }
       },
@@ -70,7 +76,7 @@ export class TaskmarkPanel {
     vscode.window.onDidChangeActiveTextEditor(
       editor => {
         if (editor && editor.document.languageId === 'tmd') {
-          this.updateFromDocument(editor.document);
+          this._debouncedUpdateFromDocument(editor.document);
         }
       },
       null,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -109,7 +109,7 @@ interface RepeatOptions {
 
 const MAX_OCCURRENCES = 3650;
 
-function parseRepeatOptions(repeatStr: string, lineNum?: number, warnings?: string[]): RepeatOptions {
+function parseRepeatOptions(repeatStr: string, lineNum: number, warnings: string[]): RepeatOptions {
   const parts = repeatStr.split(',').map(s => s.trim());
   let mode: 'days' | 'months' = 'days';
   let interval = 7; // default: weekly
@@ -135,14 +135,11 @@ function parseRepeatOptions(repeatStr: string, lineNum?: number, warnings?: stri
       mode = 'months'; interval = 1;
     } else if (part.startsWith('until:')) {
       const dateStr = part.substring(6);
-      if (dateStr.match(/^\d{4}-\d{2}-\d{2}$/)) {
-        try {
-          until = parseLocalDate(dateStr);
-        } catch {
-          if (warnings && lineNum !== undefined) {
-            warnings.push(`Line ${lineNum + 1}: invalid until date '${dateStr}', skipped`);
-          }
-        }
+      const normalized = tryNormalizeDate(dateStr);
+      if (normalized) {
+        until = parseLocalDate(normalized);
+      } else if (dateStr) {
+        warnings.push(`Line ${lineNum + 1}: invalid until date '${dateStr}', skipped`);
       }
     } else if (part.startsWith('count:')) {
       const parsedCount = parseInt(part.substring(6), 10);
@@ -150,7 +147,11 @@ function parseRepeatOptions(repeatStr: string, lineNum?: number, warnings?: stri
     } else if (part.startsWith('except:')) {
       for (const d of part.substring(7).trim().split(/\s+/).filter(Boolean)) {
         const normalized = tryNormalizeDate(d);
-        if (normalized) { exceptDates.add(normalized); }
+        if (normalized) {
+          exceptDates.add(normalized);
+        } else {
+          warnings.push(`Line ${lineNum + 1}: invalid except date '${d}', skipped`);
+        }
       }
     }
   }
@@ -186,7 +187,11 @@ export function parseTmd(text: string): ParseResult {
     if (line === '@end' && inTagsBlock) { inTagsBlock = false; continue; }
     if (inTagsBlock) {
       const match = line.match(TAG_COLOR_REGEX);
-      if (match) data.tagColors[match[1]] = match[2].trim();
+      if (match) {
+        data.tagColors[match[1]] = match[2].trim();
+      } else {
+        warnings.push(`Line ${i + 1}: invalid tag definition '${line}', skipped`);
+      }
       continue;
     }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -3,6 +3,11 @@ export interface TaskMarkData {
   days: Record<string, DayData>; // Key is YYYY-MM-DD
 }
 
+export interface ParseResult {
+  data: TaskMarkData;
+  warnings: string[];
+}
+
 export interface DayData {
   date: string;
   items: MarkItem[];
@@ -104,7 +109,7 @@ interface RepeatOptions {
 
 const MAX_OCCURRENCES = 3650;
 
-function parseRepeatOptions(repeatStr: string): RepeatOptions {
+function parseRepeatOptions(repeatStr: string, lineNum?: number, warnings?: string[]): RepeatOptions {
   const parts = repeatStr.split(',').map(s => s.trim());
   let mode: 'days' | 'months' = 'days';
   let interval = 7; // default: weekly
@@ -131,7 +136,13 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
     } else if (part.startsWith('until:')) {
       const dateStr = part.substring(6);
       if (dateStr.match(/^\d{4}-\d{2}-\d{2}$/)) {
-        until = parseLocalDate(dateStr);
+        try {
+          until = parseLocalDate(dateStr);
+        } catch {
+          if (warnings && lineNum !== undefined) {
+            warnings.push(`Line ${lineNum + 1}: invalid until date '${dateStr}', skipped`);
+          }
+        }
       }
     } else if (part.startsWith('count:')) {
       const parsedCount = parseInt(part.substring(6), 10);
@@ -151,9 +162,10 @@ function parseRepeatOptions(repeatStr: string): RepeatOptions {
 
 // ─── Main Parser ───────────────────────────────────────────────
 
-export function parseTmd(text: string): TaskMarkData {
+export function parseTmd(text: string): ParseResult {
   const lines = text.split(/\r?\n/);
   const data: TaskMarkData = { tagColors: {}, days: {} };
+  const warnings: string[] = [];
 
   let inTagsBlock = false;
   let currentDate = '';
@@ -182,12 +194,22 @@ export function parseTmd(text: string): TaskMarkData {
     const dateMatch = line.match(DATE_REGEX);
     if (dateMatch) {
       const normalizedStart = tryNormalizeDate(dateMatch[1]);
-      if (!normalizedStart) { currentDate = ''; continue; }
+      if (!normalizedStart) {
+        warnings.push(`Line ${i + 1}: invalid date '${dateMatch[1]}', skipped`);
+        currentDate = '';
+        continue;
+      }
       currentDate = normalizedStart;
       currentEndDate = '';
       if (dateMatch[2]) {
         const normalizedEnd = tryNormalizeDate(dateMatch[2]);
-        if (normalizedEnd && normalizedEnd >= currentDate) { currentEndDate = normalizedEnd; }
+        if (!normalizedEnd) {
+          warnings.push(`Line ${i + 1}: invalid end date '${dateMatch[2]}', skipped`);
+        } else if (normalizedEnd < currentDate) {
+          warnings.push(`Line ${i + 1}: end date '${dateMatch[2]}' is before start date, skipped`);
+        } else {
+          currentEndDate = normalizedEnd;
+        }
       }
       ensureDay(data.days, currentDate);
       currentGroup = '';
@@ -212,7 +234,7 @@ export function parseTmd(text: string): TaskMarkData {
     }
   }
 
-  return expandRepeats(data);
+  return { data: expandRepeats(data, warnings), warnings };
 }
 
 function createMarkItem(
@@ -268,7 +290,7 @@ function createMarkItem(
 
 // ─── Repeat Expansion ──────────────────────────────────────────
 
-function expandRepeats(data: TaskMarkData): TaskMarkData {
+function expandRepeats(data: TaskMarkData, warnings: string[]): TaskMarkData {
   const expandedDays: Record<string, DayData> = {};
   for (const [date, day] of Object.entries(data.days)) {
     expandedDays[date] = { date, items: day.items.map(item => ({ ...item, tags: [...item.tags] })) };
@@ -278,16 +300,16 @@ function expandRepeats(data: TaskMarkData): TaskMarkData {
     day.items.forEach(item => {
       if (!item.repeat || item.type === 'task' || item.endDate) return;
 
-      generateRepeatedItems(item, day.date, expandedDays);
+      generateRepeatedItems(item, day.date, expandedDays, warnings);
     });
   });
 
   return { ...data, days: expandedDays };
 }
 
-function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDays: Record<string, DayData>) {
+function generateRepeatedItems(item: MarkItem, originDateStr: string, expandedDays: Record<string, DayData>, warnings: string[]) {
   const origin = parseLocalDate(originDateStr);
-  const opts = parseRepeatOptions(item.repeat!);
+  const opts = parseRepeatOptions(item.repeat!, item.rawLine, warnings);
   for (let i = 1; i < opts.count; i++) {
     const nextDate = new Date(origin);
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -31,6 +31,8 @@ export interface MarkItem {
 
 // ─── Regex Patterns ────────────────────────────────────────────
 const TAG_COLOR_REGEX = /^#([^\s:]+)\s*:\s*(.+)$/;
+// Keep in sync with VALID_CSS_COLOR_RE in media/main.js
+const VALID_CSS_COLOR_REGEX = /^(?:#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|(?:rgb|hsl)a?\(\s*\d[\d.]*%?(?:\s*[,/\s]\s*\d[\d.]*%?){2,3}\s*\)|[a-zA-Z]{1,30})$/;
 const DATE_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})(?:\s*:\s*(\d{4}-\d{1,2}-\d{1,2}))?/;
 const GROUP_REGEX = /^>\s*([^-\s].+)$/;
 const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{1,2})(?:-(\d{1,2}:\d{1,2}))?)?\s*(.*)$/;
@@ -188,7 +190,12 @@ export function parseTmd(text: string): ParseResult {
     if (inTagsBlock) {
       const match = line.match(TAG_COLOR_REGEX);
       if (match) {
-        data.tagColors[match[1]] = match[2].trim();
+        const colorValue = match[2].trim();
+        if (VALID_CSS_COLOR_REGEX.test(colorValue)) {
+          data.tagColors[match[1]] = colorValue;
+        } else {
+          warnings.push(`Line ${i + 1}: invalid color value '${colorValue}', skipped`);
+        }
       } else {
         warnings.push(`Line ${i + 1}: invalid tag definition '${line}', skipped`);
       }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -32,7 +32,7 @@ export interface MarkItem {
 // ─── Regex Patterns ────────────────────────────────────────────
 const TAG_COLOR_REGEX = /^#([^\s:]+)\s*:\s*(.+)$/;
 // Keep in sync with VALID_CSS_COLOR_RE in media/main.js
-const VALID_CSS_COLOR_REGEX = /^(?:#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|(?:rgb|hsl)a?\(\s*\d[\d.]*%?(?:\s*[,/\s]\s*\d[\d.]*%?){2,3}\s*\)|[a-zA-Z]{1,30})$/;
+export const VALID_CSS_COLOR_REGEX = /^(?:#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|(?:rgb|hsl)a?\(\s*\d[\d.]*%?(?:\s*[,/\s]\s*\d[\d.]*%?){2,3}\s*\)|[a-zA-Z]{1,30})$/;
 const DATE_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})(?:\s*:\s*(\d{4}-\d{1,2}-\d{1,2}))?/;
 const GROUP_REGEX = /^>\s*([^-\s].+)$/;
 const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{1,2})(?:-(\d{1,2}:\d{1,2}))?)?\s*(.*)$/;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -239,7 +239,7 @@ export function parseTmd(text: string): ParseResult {
     }
   }
 
-  return { data: expandRepeats(data, warnings), warnings };
+  return { data: expandRepeats(data, warnings), warnings: [...new Set(warnings)] };
 }
 
 function createMarkItem(

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,10 +1,11 @@
 import * as vscode from 'vscode';
 
-export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri): string {
+export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, cspSource: string): string {
   return `<!DOCTYPE html>
       <html lang="en">
       <head>
         <meta charset="UTF-8">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource}; script-src ${cspSource};">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>TaskMark</title>
         <link href="${stylesUri}" rel="stylesheet">

--- a/src/template.ts
+++ b/src/template.ts
@@ -10,6 +10,7 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri): st
         <link href="${stylesUri}" rel="stylesheet">
       </head>
       <body>
+        <div id="tm-parse-error-banner" class="tm-error-banner hidden"></div>
         <div class="tm-header">
           <div class="tm-toggle-container">
             <button class="tm-view-toggle active" id="btn-calendar">Calendar</button>

--- a/src/template.ts
+++ b/src/template.ts
@@ -11,6 +11,7 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri): st
       </head>
       <body>
         <div id="tm-parse-error-banner" class="tm-error-banner hidden"></div>
+        <div id="tm-warning-banner" class="tm-warning-banner hidden"></div>
         <div class="tm-header">
           <div class="tm-toggle-container">
             <button class="tm-view-toggle active" id="btn-calendar">Calendar</button>

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -5,6 +5,7 @@ suite('TaskmarkPanel message types', () => {
   test('TaskMarkUpdateMessage has type "update"', () => {
     const msg: TaskMarkUpdateMessage = {
       type: 'update',
+      uri: 'file:///test.tmd',
       data: { tagColors: {}, days: {} },
       ganttData: { entities: [], lastDateStr: '' },
       warnings: []
@@ -15,6 +16,7 @@ suite('TaskmarkPanel message types', () => {
   test('TaskMarkUpdateMessage includes warnings array', () => {
     const msg: TaskMarkUpdateMessage = {
       type: 'update',
+      uri: 'file:///test.tmd',
       data: { tagColors: {}, days: {} },
       ganttData: { entities: [], lastDateStr: '' },
       warnings: ["Line 5: invalid date '2026-99-99', skipped"]

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -6,9 +6,21 @@ suite('TaskmarkPanel message types', () => {
     const msg: TaskMarkUpdateMessage = {
       type: 'update',
       data: { tagColors: {}, days: {} },
-      ganttData: { entities: [], lastDateStr: '' }
+      ganttData: { entities: [], lastDateStr: '' },
+      warnings: []
     };
     assert.strictEqual(msg.type, 'update');
+  });
+
+  test('TaskMarkUpdateMessage includes warnings array', () => {
+    const msg: TaskMarkUpdateMessage = {
+      type: 'update',
+      data: { tagColors: {}, days: {} },
+      ganttData: { entities: [], lastDateStr: '' },
+      warnings: ["Line 5: invalid date '2026-99-99', skipped"]
+    };
+    assert.strictEqual(msg.warnings.length, 1);
+    assert.ok(msg.warnings[0].includes('2026-99-99'));
   });
 
   test('TaskMarkErrorMessage has type "parseError" and a message field', () => {

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -1,0 +1,22 @@
+import * as assert from 'assert';
+import { TaskMarkUpdateMessage, TaskMarkErrorMessage } from '../../TaskmarkPanel';
+
+suite('TaskmarkPanel message types', () => {
+  test('TaskMarkUpdateMessage has type "update"', () => {
+    const msg: TaskMarkUpdateMessage = {
+      type: 'update',
+      data: { tagColors: {}, days: {} },
+      ganttData: { entities: [], lastDateStr: '' }
+    };
+    assert.strictEqual(msg.type, 'update');
+  });
+
+  test('TaskMarkErrorMessage has type "parseError" and a message field', () => {
+    const msg: TaskMarkErrorMessage = {
+      type: 'parseError',
+      message: 'unexpected token at line 3'
+    };
+    assert.strictEqual(msg.type, 'parseError');
+    assert.strictEqual(msg.message, 'unexpected token at line 3');
+  });
+});

--- a/src/test/suite/debounce.test.ts
+++ b/src/test/suite/debounce.test.ts
@@ -1,0 +1,63 @@
+import * as assert from 'assert';
+import { debounce } from '../../utils/debounce';
+
+suite('debounce', () => {
+  test('calls the function after the specified delay', done => {
+    let callCount = 0;
+    const fn = debounce(() => { callCount++; }, 50);
+
+    fn();
+    assert.strictEqual(callCount, 0, 'should not be called immediately');
+
+    setTimeout(() => {
+      assert.strictEqual(callCount, 1, 'should be called once after delay');
+      done();
+    }, 100);
+  });
+
+  test('calls the function only once when invoked multiple times within the delay', done => {
+    let callCount = 0;
+    const fn = debounce(() => { callCount++; }, 50);
+
+    fn();
+    fn();
+    fn();
+
+    setTimeout(() => {
+      assert.strictEqual(callCount, 1, 'should be called only once');
+      done();
+    }, 100);
+  });
+
+  test('resets the timer on each call', done => {
+    let callCount = 0;
+    const fn = debounce(() => { callCount++; }, 50);
+
+    fn();
+    setTimeout(() => fn(), 30);
+    setTimeout(() => fn(), 60);
+
+    setTimeout(() => {
+      assert.strictEqual(callCount, 0, 'should not have fired yet');
+    }, 90);
+
+    setTimeout(() => {
+      assert.strictEqual(callCount, 1, 'should be called once after final call settles');
+      done();
+    }, 150);
+  });
+
+  test('calls the function with the latest arguments', done => {
+    let lastArg: number | undefined;
+    const fn = debounce((n: number) => { lastArg = n; }, 50);
+
+    fn(1);
+    fn(2);
+    fn(3);
+
+    setTimeout(() => {
+      assert.strictEqual(lastArg, 3, 'should be called with the last argument');
+      done();
+    }, 100);
+  });
+});

--- a/src/test/suite/debounce.test.ts
+++ b/src/test/suite/debounce.test.ts
@@ -60,4 +60,31 @@ suite('debounce', () => {
       done();
     }, 100);
   });
+
+  test('cancel prevents the pending call from firing', done => {
+    let callCount = 0;
+    const fn = debounce(() => { callCount++; }, 50);
+
+    fn();
+    fn.cancel();
+
+    setTimeout(() => {
+      assert.strictEqual(callCount, 0, 'should not be called after cancel');
+      done();
+    }, 100);
+  });
+
+  test('can be called normally after cancel', done => {
+    let callCount = 0;
+    const fn = debounce(() => { callCount++; }, 50);
+
+    fn();
+    fn.cancel();
+    fn();
+
+    setTimeout(() => {
+      assert.strictEqual(callCount, 1, 'should be called once after re-invoking post-cancel');
+      done();
+    }, 100);
+  });
 });

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -4,7 +4,7 @@ import { parseTmd } from '../../parser';
 
 suite('Gantt Test Suite', () => {
   test('group entity has children with text and tags', () => {
-    const data = parseTmd(`# 2026-03-01
+    const { data } = parseTmd(`# 2026-03-01
 > Sprint 1
 > - [ ] Task A #work
 > - [x] Task B
@@ -28,7 +28,7 @@ suite('Gantt Test Suite', () => {
   });
 
   test('standalone task entity has a children array with one entry', () => {
-    const data = parseTmd(`
+    const { data } = parseTmd(`
 # 2026-03-01
 - [ ] Standalone Task
 `);
@@ -44,7 +44,7 @@ suite('Gantt Test Suite', () => {
   });
 
   test('group entity tracks task completion counters', () => {
-    const data = parseTmd(`
+    const { data } = parseTmd(`
 # 2026-03-01
 > Group
 > - [ ] Open Task
@@ -63,7 +63,7 @@ suite('Gantt Test Suite', () => {
   });
 
   test('lastDateStr accounts for endDate ranges', () => {
-    const data = parseTmd(`
+    const { data } = parseTmd(`
 # 2026-03-01 : 2026-03-15
 - Conference
 `);
@@ -72,7 +72,7 @@ suite('Gantt Test Suite', () => {
   });
 
   test('multiple groups produce one entity per group', () => {
-    const data = parseTmd(`
+    const { data } = parseTmd(`
 # 2026-03-01
 > Group A
 > - [ ] Task 1
@@ -95,7 +95,7 @@ suite('Gantt Test Suite', () => {
   });
 
   test('schedule item inside group is included in children but not counted as task', () => {
-    const data = parseTmd(`
+    const { data } = parseTmd(`
 # 2026-03-01
 > Sprint
 > - [ ] Task Item
@@ -110,7 +110,7 @@ suite('Gantt Test Suite', () => {
   });
 
   test('lastDateStr is the last date when no endDate ranges are present', () => {
-    const data = parseTmd(`
+    const { data } = parseTmd(`
 # 2026-03-01
 - [ ] First Task
 
@@ -122,7 +122,7 @@ suite('Gantt Test Suite', () => {
   });
 
   test('group name and standalone task with the same name do not collide', () => {
-    const data = parseTmd(`
+    const { data } = parseTmd(`
 # 2026-03-01
 > Sprint
 > - [ ] Task A
@@ -141,7 +141,7 @@ suite('Gantt Test Suite', () => {
   });
 
   test('group minTime and maxTime span all child items', () => {
-    const data = parseTmd(`
+    const { data } = parseTmd(`
 # 2026-03-01
 > Sprint
 > - [ ] 9:00-10:00 Morning Task
@@ -160,7 +160,7 @@ suite('Gantt Test Suite', () => {
   });
 
   test('range item child spans correct time in gantt entity', () => {
-    const data = parseTmd(`
+    const { data } = parseTmd(`
 # 2026-03-01 : 2026-03-05
 - Conference
 `);
@@ -182,7 +182,7 @@ suite('Gantt Test Suite', () => {
   });
 
   test('range items from different weeks each produce a separate child in gantt', () => {
-    const data = parseTmd(`
+    const { data } = parseTmd(`
 # 2026-03-01 : 2026-03-03
 - Workshop A
 

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -158,4 +158,44 @@ suite('Gantt Test Suite', () => {
     assert.ok(sprint.minTime < sprint.maxTime, 'minTime should be before maxTime');
     assert.ok(sprint.children[0].startMs < sprint.children[1].startMs, 'children should be in chronological order');
   });
+
+  test('range item child spans correct time in gantt entity', () => {
+    const data = parseTmd(`
+# 2026-03-01 : 2026-03-05
+- Conference
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 1);
+
+    const entity = entities[0];
+    assert.strictEqual(entity.name, 'Conference');
+    assert.strictEqual(entity.children.length, 1);
+
+    const child = entity.children[0];
+    const expectedStart = new Date(2026, 2, 1).getTime();
+    const expectedEnd = new Date(2026, 2, 6).getTime() - 1;
+
+    assert.strictEqual(child.startMs, expectedStart);
+    assert.strictEqual(child.endMs, expectedEnd);
+    assert.strictEqual(entity.minTime, expectedStart);
+    assert.strictEqual(entity.maxTime, expectedEnd);
+  });
+
+  test('range items from different weeks each produce a separate child in gantt', () => {
+    const data = parseTmd(`
+# 2026-03-01 : 2026-03-03
+- Workshop A
+
+# 2026-03-10 : 2026-03-12
+- Workshop B
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 2);
+
+    const workshopA = entities.find(e => e.name === 'Workshop A');
+    const workshopB = entities.find(e => e.name === 'Workshop B');
+    assert.ok(workshopA, 'Workshop A entity should exist');
+    assert.ok(workshopB, 'Workshop B entity should exist');
+    assert.ok(workshopA!.minTime < workshopB!.minTime, 'Workshop A should start before Workshop B');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -1,23 +1,34 @@
 import * as assert from 'assert';
-import { parseTmd } from '../../parser';
+import { parseTmd, ParseResult } from '../../parser';
 
 suite('Parser Test Suite', () => {
+  test('parseTmd returns ParseResult with data and warnings', () => {
+    const text = `
+# 2026-03-26
+- Meeting
+`;
+    const result = parseTmd(text);
+    assert.ok('data' in result, 'Result should have data field');
+    assert.ok('warnings' in result, 'Result should have warnings field');
+    assert.ok(Array.isArray(result.warnings), 'warnings should be an array');
+  });
+
   test('parseTmd basically works for tasks and schedules', () => {
     const text = `
 # 2026-03-26
 - [ ] 09:00-10:00 Meeting
 - Schedule item
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.ok(data.days['2026-03-26'], 'Day entry should be created');
-    
+
     const items = data.days['2026-03-26'].items;
     assert.strictEqual(items.length, 2, 'Should parse 2 items');
-    
+
     assert.strictEqual(items[0].type, 'task');
     assert.strictEqual(items[0].status, 'todo');
     assert.strictEqual(items[0].text, 'Meeting');
-    
+
     assert.strictEqual(items[1].type, 'schedule');
     assert.strictEqual(items[1].text, 'Schedule item');
   });
@@ -32,7 +43,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-26
 - Meeting
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.strictEqual(data.tagColors['meeting'], '#ff0000');
     assert.strictEqual(data.tagColors['work'], '#0088ff');
   });
@@ -46,7 +57,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-26
 - Task item
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.ok(data.days['2026-03-26'], 'Day should exist');
     assert.strictEqual(data.days['2026-03-26'].items.length, 1);
     assert.strictEqual(data.days['2026-03-26'].items[0].text, 'Task item');
@@ -60,7 +71,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-26
 - Task
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.deepStrictEqual(data.tagColors, {});
   });
 
@@ -69,7 +80,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-26
 - Daily habit @repeat(daily, count:3)
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.ok(data.days['2026-03-26']);
     assert.ok(data.days['2026-03-27']);
     assert.ok(data.days['2026-03-28']);
@@ -81,7 +92,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-16
 - 10:00-11:00 Weekly Sync @repeat(weekly, count:3, except:2026-03-23)
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
     assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
     assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
@@ -92,7 +103,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-16
 - 10:00-11:00 Weekly Sync @repeat(weekly, count:3, except:2026-02-30)
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.ok(data.days['2026-03-23'], '2026-03-23 should exist because except date was invalid');
     assert.ok(data.days['2026-03-30'], '2026-03-30 should exist');
   });
@@ -102,7 +113,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-16
 - 10:00-11:00 Weekly Sync @repeat(weekly, count:4, except:2026-03-23 2026-03-30)
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
     assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
     assert.ok(!data.days['2026-03-30'], '2026-03-30 should be skipped');
@@ -114,7 +125,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-01 : 2026-03-10
 - Conference #Work
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.ok(data.days['2026-03-01'], 'Start day should exist');
     assert.ok(!data.days['2026-03-10'], 'End day should NOT be a separate entry');
 
@@ -128,7 +139,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-01
 - Regular item
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     const items = data.days['2026-03-01'].items;
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0].endDate, undefined);
@@ -139,7 +150,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-01 : 2026-03-05
 - [ ] Multi-day task
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     const items = data.days['2026-03-01'].items;
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0].type, 'task');
@@ -151,7 +162,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-01 : 2026-02-30
 - Conference
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     const items = data.days['2026-03-01'].items;
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0].endDate, undefined);
@@ -162,7 +173,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-10 : 2026-03-01
 - Conference
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     const items = data.days['2026-03-10'].items;
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0].endDate, undefined);
@@ -173,7 +184,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-01 : 2026-03-10
 - Daily standup @repeat(daily, count:5)
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.strictEqual(Object.keys(data.days).length, 1, 'Only start day should exist');
     assert.ok(data.days['2026-03-01'], 'Start day should exist');
     assert.ok(!data.days['2026-03-02'], 'Repeat should not expand when endDate is set');
@@ -184,7 +195,7 @@ suite('Parser Test Suite', () => {
 # 2026-3-1
 - Meeting
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.ok(data.days['2026-03-01'], 'Day should be stored with zero-padded key');
     assert.strictEqual(data.days['2026-03-01'].items.length, 1);
     assert.strictEqual(data.days['2026-03-01'].items[0].text, 'Meeting');
@@ -195,7 +206,7 @@ suite('Parser Test Suite', () => {
 # 2026-3-1 : 2026-3-10
 - Conference
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.ok(data.days['2026-03-01'], 'Start day should be zero-padded');
     assert.strictEqual(data.days['2026-03-01'].items[0].endDate, '2026-03-10');
   });
@@ -205,7 +216,7 @@ suite('Parser Test Suite', () => {
 # 2026-13-1
 - Meeting
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.strictEqual(Object.keys(data.days).length, 0, 'Invalid date header should be ignored');
   });
 
@@ -214,7 +225,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-01
 - 9:0-17:0 Conference
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     const items = data.days['2026-03-01'].items;
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0].time, '9:00-17:00');
@@ -225,7 +236,7 @@ suite('Parser Test Suite', () => {
 # 2026-03-01
 - 9:0 Meeting
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     const items = data.days['2026-03-01'].items;
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0].time, '9:00');
@@ -236,9 +247,93 @@ suite('Parser Test Suite', () => {
 # 2026-03-16
 - Weekly Sync @repeat(weekly, count:3, except:2026-3-23)
 `;
-    const data = parseTmd(text);
+    const { data } = parseTmd(text);
     assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
     assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
     assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
+  });
+
+  // ─── Warning Collection Tests ────────────────────────────────
+
+  test('parseTmd returns no warnings for valid input', () => {
+    const text = `
+# 2026-03-26
+- Meeting
+- [ ] Task
+`;
+    const { warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 0, 'Should have no warnings for valid input');
+  });
+
+  test('parseTmd warns on invalid date header', () => {
+    const text = `
+# 2026-99-99
+- Meeting
+`;
+    const { warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1, 'Should have one warning');
+    assert.ok(warnings[0].includes('Line 2'), 'Warning should reference line number');
+    assert.ok(warnings[0].includes('2026-99-99'), 'Warning should include the invalid date');
+  });
+
+  test('parseTmd warns on invalid end date in range header', () => {
+    const text = `
+# 2026-03-01 : 2026-02-30
+- Conference
+`;
+    const { warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1, 'Should have one warning');
+    assert.ok(warnings[0].includes('2026-02-30'), 'Warning should include the invalid end date');
+  });
+
+  test('parseTmd warns when end date is before start date', () => {
+    const text = `
+# 2026-03-10 : 2026-03-01
+- Conference
+`;
+    const { warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1, 'Should have one warning');
+    assert.ok(warnings[0].includes('2026-03-01'), 'Warning should include the end date');
+  });
+
+  test('parseTmd warns on invalid until date in @repeat and does not throw', () => {
+    const text = `
+# 2026-03-16
+- 10:00-11:00 Weekly Sync @repeat(weekly, until:2026-02-30)
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1, 'Should have one warning');
+    assert.ok(warnings[0].includes('2026-02-30'), 'Warning should include the invalid until date');
+    assert.ok(data.days['2026-03-16'], 'Origin item should still exist');
+  });
+
+  test('parseTmd collects multiple warnings', () => {
+    const text = `
+# 2026-99-99
+- Item under invalid date
+# 2026-03-01
+- Valid item
+# 2026-13-01
+- Another item under invalid date
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 2, 'Should have two warnings');
+    assert.ok(data.days['2026-03-01'], 'Valid date should still parse');
+  });
+
+  test('parseTmd valid input has empty warnings array', () => {
+    const text = `
+@tags
+#work : #0088ff
+@end
+
+# 2026-03-01
+- 9:00-10:00 Meeting #work
+- Standup @repeat(daily, count:2)
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 0);
+    assert.ok(data.days['2026-03-01']);
+    assert.ok(data.days['2026-03-02']);
   });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -352,6 +352,86 @@ not a valid tag line
     assert.strictEqual(data.tagColors['work'], '#0088ff', 'Valid tags should still parse');
   });
 
+  test('parseTmd rejects CSS injection in tag color values', () => {
+    const text = `
+@tags
+#valid : #ff0000
+#inject1 : red; background-image: url(evil)
+#inject2 : #fff} .x{color:red
+#inject3 : expression(alert(1))
+#named : steelblue
+#rgb : rgb(255, 0, 128)
+#hsl : hsl(120, 50%, 50%)
+#rgba : rgba(0, 0, 0, 0.5)
+#hsla : hsla(120, 50%, 50%, 0.8)
+@end
+
+# 2026-03-01
+- Task
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(data.tagColors['valid'], '#ff0000', 'Valid hex color accepted');
+    assert.strictEqual(data.tagColors['named'], 'steelblue', 'Valid named color accepted');
+    assert.strictEqual(data.tagColors['rgb'], 'rgb(255, 0, 128)', 'Valid rgb() accepted');
+    assert.strictEqual(data.tagColors['hsl'], 'hsl(120, 50%, 50%)', 'Valid hsl() accepted');
+    assert.strictEqual(data.tagColors['rgba'], 'rgba(0, 0, 0, 0.5)', 'Valid rgba() accepted');
+    assert.strictEqual(data.tagColors['hsla'], 'hsla(120, 50%, 50%, 0.8)', 'Valid hsla() accepted');
+    assert.strictEqual(data.tagColors['inject1'], undefined, 'Semicolon injection rejected');
+    assert.strictEqual(data.tagColors['inject2'], undefined, 'Brace injection rejected');
+    assert.strictEqual(data.tagColors['inject3'], undefined, 'expression() injection rejected');
+    assert.strictEqual(warnings.length, 3, 'Should warn for each rejected color');
+  });
+
+  test('parseTmd validates hex color digit counts', () => {
+    const text = `
+@tags
+#h3 : #fff
+#h4 : #ffff
+#h6 : #ffffff
+#h8 : #ffffffff
+#h1 : #f
+#h2 : #ff
+#h5 : #fffff
+#h7 : #fffffff
+@end
+
+# 2026-03-01
+- Task
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(data.tagColors['h3'], '#fff', '3-digit hex accepted');
+    assert.strictEqual(data.tagColors['h4'], '#ffff', '4-digit hex accepted');
+    assert.strictEqual(data.tagColors['h6'], '#ffffff', '6-digit hex accepted');
+    assert.strictEqual(data.tagColors['h8'], '#ffffffff', '8-digit hex accepted');
+    assert.strictEqual(data.tagColors['h1'], undefined, '1-digit hex rejected');
+    assert.strictEqual(data.tagColors['h2'], undefined, '2-digit hex rejected');
+    assert.strictEqual(data.tagColors['h5'], undefined, '5-digit hex rejected');
+    assert.strictEqual(data.tagColors['h7'], undefined, '7-digit hex rejected');
+    assert.strictEqual(warnings.length, 4, 'Should warn for each invalid hex length');
+  });
+
+  test('parseTmd rejects malformed rgb/hsl values', () => {
+    const text = `
+@tags
+#ok1 : rgb(255, 0, 128)
+#ok2 : rgb(255 0 128 / 0.5)
+#bad1 : rgb()
+#bad2 : rgb(,,,)
+#bad3 : rgb(a, b, c)
+@end
+
+# 2026-03-01
+- Task
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(data.tagColors['ok1'], 'rgb(255, 0, 128)', 'Valid rgb() accepted');
+    assert.strictEqual(data.tagColors['ok2'], 'rgb(255 0 128 / 0.5)', 'Modern rgb() with alpha accepted');
+    assert.strictEqual(data.tagColors['bad1'], undefined, 'Empty rgb() rejected');
+    assert.strictEqual(data.tagColors['bad2'], undefined, 'Comma-only rgb() rejected');
+    assert.strictEqual(data.tagColors['bad3'], undefined, 'Non-numeric rgb() rejected');
+    assert.strictEqual(warnings.length, 3, 'Should warn for each invalid rgb');
+  });
+
   test('parseTmd collects multiple warnings', () => {
     const text = `
 # 2026-99-99

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -381,4 +381,17 @@ not a valid tag line
     assert.ok(data.days['2026-03-01']);
     assert.ok(data.days['2026-03-02']);
   });
+
+  test('parseTmd returns deduplicated warnings', () => {
+    const text = `
+# 2026-99-99
+- Item A
+# 2026-88-88
+- Item B
+`;
+    const { warnings } = parseTmd(text);
+    assert.ok(warnings.length > 0, 'Should have warnings');
+    const uniqueWarnings = [...new Set(warnings)];
+    assert.deepStrictEqual(warnings, uniqueWarnings, 'warnings should be deduplicated');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { parseTmd, ParseResult } from '../../parser';
+import { parseTmd } from '../../parser';
 
 suite('Parser Test Suite', () => {
   test('parseTmd returns ParseResult with data and warnings', () => {
@@ -299,12 +299,57 @@ suite('Parser Test Suite', () => {
   test('parseTmd warns on invalid until date in @repeat and does not throw', () => {
     const text = `
 # 2026-03-16
-- 10:00-11:00 Weekly Sync @repeat(weekly, until:2026-02-30)
+- 10:00-11:00 Weekly Sync @repeat(weekly, count:3, until:2026-02-30)
 `;
     const { data, warnings } = parseTmd(text);
     assert.strictEqual(warnings.length, 1, 'Should have one warning');
     assert.ok(warnings[0].includes('2026-02-30'), 'Warning should include the invalid until date');
     assert.ok(data.days['2026-03-16'], 'Origin item should still exist');
+    // Invalid until is ignored, so count:3 controls expansion
+    assert.strictEqual(Object.keys(data.days).length, 3, 'Should expand based on count when until is invalid');
+  });
+
+  test('parseTmd repeat until with unpadded date works correctly', () => {
+    const text = `
+# 2026-03-16
+- Weekly Sync @repeat(weekly, until:2026-4-6)
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 0, 'Unpadded until date should not produce warnings');
+    assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
+    assert.ok(data.days['2026-03-23'], '2026-03-23 should exist');
+    assert.ok(data.days['2026-03-30'], '2026-03-30 should exist');
+    assert.ok(!data.days['2026-04-13'], '2026-04-13 should not exist (past until)');
+  });
+
+  test('parseTmd warns on invalid except date in @repeat', () => {
+    const text = `
+# 2026-03-16
+- Weekly Sync @repeat(weekly, count:3, except:2026-02-30)
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1, 'Should have one warning for invalid except date');
+    assert.ok(warnings[0].includes('2026-02-30'), 'Warning should include the invalid except date');
+    // Invalid except date is ignored, so all 3 days still exist
+    assert.strictEqual(Object.keys(data.days).length, 3);
+  });
+
+  test('parseTmd warns on invalid line inside @tags block', () => {
+    const text = `
+@tags
+#meeting : #ff0000
+not a valid tag line
+#work : #0088ff
+@end
+
+# 2026-03-01
+- Meeting
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1, 'Should have one warning');
+    assert.ok(warnings[0].includes('Line 4'), 'Warning should reference the correct line');
+    assert.strictEqual(data.tagColors['meeting'], '#ff0000', 'Valid tags should still parse');
+    assert.strictEqual(data.tagColors['work'], '#0088ff', 'Valid tags should still parse');
   });
 
   test('parseTmd collects multiple warnings', () => {

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,10 +1,26 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function debounce<T extends (...args: any[]) => void>(fn: T, delayMs: number): (...args: Parameters<T>) => void {
+export type DebouncedFn<T extends (...args: any[]) => void> = {
+  (...args: Parameters<T>): void;
+  cancel(): void;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function debounce<T extends (...args: any[]) => void>(fn: T, delayMs: number): DebouncedFn<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
-  return (...args: Parameters<T>) => {
+
+  const debounced = (...args: Parameters<T>) => {
     if (timer !== undefined) {
       clearTimeout(timer);
     }
     timer = setTimeout(() => fn(...args), delayMs);
   };
+
+  debounced.cancel = () => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+
+  return debounced;
 }

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -8,22 +8,23 @@ export type DebouncedFn<T extends (...args: any[]) => void> = {
 export function debounce<T extends (...args: any[]) => void>(fn: T, delayMs: number): DebouncedFn<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
 
-  const debounced = (...args: Parameters<T>) => {
-    if (timer !== undefined) {
-      clearTimeout(timer);
+  return Object.assign(
+    (...args: Parameters<T>) => {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => {
+        timer = undefined;
+        fn(...args);
+      }, delayMs);
+    },
+    {
+      cancel() {
+        if (timer !== undefined) {
+          clearTimeout(timer);
+          timer = undefined;
+        }
+      }
     }
-    timer = setTimeout(() => {
-      timer = undefined;
-      fn(...args);
-    }, delayMs);
-  };
-
-  debounced.cancel = () => {
-    if (timer !== undefined) {
-      clearTimeout(timer);
-      timer = undefined;
-    }
-  };
-
-  return debounced;
+  );
 }

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -12,7 +12,10 @@ export function debounce<T extends (...args: any[]) => void>(fn: T, delayMs: num
     if (timer !== undefined) {
       clearTimeout(timer);
     }
-    timer = setTimeout(() => fn(...args), delayMs);
+    timer = setTimeout(() => {
+      timer = undefined;
+      fn(...args);
+    }, delayMs);
   };
 
   debounced.cancel = () => {

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function debounce<T extends (...args: any[]) => void>(fn: T, delayMs: number): (...args: Parameters<T>) => void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return (...args: Parameters<T>) => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => fn(...args), delayMs);
+  };
+}

--- a/syntaxes/tmd.tmLanguage.json
+++ b/syntaxes/tmd.tmLanguage.json
@@ -18,7 +18,7 @@
       "name": "meta.tag-definitions.tmd",
       "patterns": [
         {
-          "match": "\\#([a-zA-Z0-9_\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF]+)\\s*:\\s*(#[0-9a-fA-F]{3,6}|[a-zA-Z]+)",
+          "match": "\\#([a-zA-Z0-9_\\u3040-\\u309F\\u30A0-\\u30FF\\u4E00-\\u9FAF]+)\\s*:\\s*(#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|(?:rgb|hsl)a?\\([^)]+\\)|[a-zA-Z]+)",
           "captures": {
             "1": { "name": "entity.name.tag.tmd" },
             "2": { "name": "constant.color.tmd" }


### PR DESCRIPTION
## 関連Issue
v1.3.1 リリース

## 概要
v1.3.0 リリース以降に `develop` ブランチへマージされた変更をまとめて `main` へリリースします。

## 変更内容
- カレンダー（Monthly/Weekly）でdate rangeイベントをマルチデイバンドとして連続表示 (#55)
- Ganttチャートのグループタスク行を折りたたみ/展開可能に (#56)
- `updateFromDocument` にデバウンスを適用し描画パフォーマンスを改善 (#57)
- Webviewにパースエラーバナーを表示 (#59)
- パーサー警告を収集してWebviewに警告バナーとして表示 (#61)
- バージョンを 1.3.1 に更新 (package.json / CHANGELOG.md / README.md)

## 動作確認・テスト
- [ ] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [ ] 既存の機能に影響（デグレ）がないことを確認した
- [ ] 必要に応じてドキュメントを更新した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| — | — |

## 備考・次やること
特になし