### PR TITLE
release: v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "TaskMark" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.3.2] - 2026-04-12
+
+### Fixed
+- Fixed an issue where custom tag colors were not applied in the Webview due to CSP restrictions.
+
 ## [1.3.1] - 2026-04-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "taskmark",
   "displayName": "TaskMark",
   "description": "Schedule and Task Management with Markdown and Calendar/Timeline Views",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "icon": "media/icon.png",
   "publisher": "Yadecode",
   "repository": {

--- a/src/template.ts
+++ b/src/template.ts
@@ -5,7 +5,7 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
       <html lang="en">
       <head>
         <meta charset="UTF-8">
-        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource}; script-src ${cspSource};">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'unsafe-inline'; script-src ${cspSource};">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>TaskMark</title>
         <link href="${stylesUri}" rel="stylesheet">


### PR DESCRIPTION
## 概要
Webview 内でカスタムタグの色が正しく適用されないバグを修正し、バージョン 1.3.2 としてリリースします。

## 変更内容
- **CSP の修正**: Webview の Content-Security-Policy (CSP) において、`style-src` に `'unsafe-inline'` を追加しました。これにより、動的に生成されるタグのインラインスタイルが適用されるようになります。
- **バージョンバンプ**: `package.json` のバージョンを `1.3.2` に更新しました。
- **CHANGELOG 更新**: 1.3.2 の変更内容を追記しました。

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作（タグの色付けが反映されること）になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| タグに色がついていない状態 | 設定した色が正しく表示されている状態 |

## 備考・次やること
なし
