### PR TITLE
fix: ガントチャートで同名グループを別エンティティとして扱う (#68)

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -838,19 +838,18 @@
     pBar.style.backgroundColor = bgColor;
     bar.appendChild(pBar);
 
-    const entityKey = entity.id !== undefined ? entity.id : entity.name;
     const indicator = document.createElement('span');
     indicator.className = 'tm-gantt-group-indicator';
-    indicator.textContent = expandedGroups.has(entityKey) ? '▼' : '▶';
+    indicator.textContent = expandedGroups.has(entity.id) ? '▼' : '▶';
     bar.appendChild(indicator);
 
     bar.addEventListener('click', (e) => {
       e.stopPropagation();
       if (hasDragged) return;
-      if (expandedGroups.has(entityKey)) {
-        expandedGroups.delete(entityKey);
+      if (expandedGroups.has(entity.id)) {
+        expandedGroups.delete(entity.id);
       } else {
-        expandedGroups.add(entityKey);
+        expandedGroups.add(entity.id);
       }
       renderTimeline();
     });
@@ -983,26 +982,25 @@
     const laneGroups = [];
     const seenLanes = new Map();
     entityArray.forEach(entity => {
-      const lane = entity.lane !== undefined ? entity.lane : entity.name;
-      if (!seenLanes.has(lane)) {
-        seenLanes.set(lane, laneGroups.length);
+      if (!seenLanes.has(entity.lane)) {
+        seenLanes.set(entity.lane, laneGroups.length);
         laneGroups.push([entity]);
       } else {
-        laneGroups[seenLanes.get(lane)].push(entity);
+        laneGroups[seenLanes.get(entity.lane)].push(entity);
       }
     });
+
+    // Precompute max expanded child count per lane (reused for height and rendering)
+    const laneMaxChildCounts = laneGroups.map(laneEntities =>
+      laneEntities.reduce((max, e) =>
+        e.isGroup && expandedGroups.has(e.id) ? Math.max(max, e.children.length) : max, 0)
+    );
 
     // Build container
     const ganttContainer = document.createElement('div');
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
-    const totalRowCount = laneGroups.reduce((sum, laneEntities) => {
-      const maxChildren = laneEntities.reduce((max, e) => {
-        const key = e.id !== undefined ? e.id : e.name;
-        return e.isGroup && expandedGroups.has(key) ? Math.max(max, e.children.length) : max;
-      }, 0);
-      return sum + 1 + maxChildren;
-    }, 0);
+    const totalRowCount = laneGroups.reduce((sum, _, i) => sum + 1 + laneMaxChildCounts[i], 0);
     ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
 
     // Render axis and column backgrounds
@@ -1010,26 +1008,22 @@
 
     // Render entity bars grouped by lane (same lane = same row)
     let yOffset = GANTT_HEADER_HEIGHT;
-    laneGroups.forEach(laneEntities => {
+    laneGroups.forEach((laneEntities, laneIdx) => {
       const laneYOffset = yOffset;
       yOffset += GANTT_ROW_HEIGHT + 4;
 
       // Render all bars for this lane first
-      laneEntities.forEach((entity, laneIdx) => {
-        renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth, laneIdx > 0);
+      laneEntities.forEach((entity, i) => {
+        renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth, i > 0);
       });
 
       // Render children of each expanded entity relative to laneYOffset.
       // Row backgrounds are rendered once for the full child area depth.
-      const maxChildCount = laneEntities.reduce((max, e) => {
-        const key = e.id !== undefined ? e.id : e.name;
-        return e.isGroup && expandedGroups.has(key) ? Math.max(max, e.children.length) : max;
-      }, 0);
+      const maxChildCount = laneMaxChildCounts[laneIdx];
       if (maxChildCount > 0) {
         renderGroupChildRowBgs(ganttContainer, maxChildCount, laneYOffset, totalWidth);
         laneEntities.forEach(entity => {
-          const entityKey = entity.id !== undefined ? entity.id : entity.name;
-          if (entity.isGroup && expandedGroups.has(entityKey)) {
+          if (entity.isGroup && expandedGroups.has(entity.id)) {
             renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
           }
         });

--- a/media/main.js
+++ b/media/main.js
@@ -885,11 +885,10 @@
     });
   }
 
-  /** Render child task rows below the group bar.
-   *  childStartYOffset is the absolute top of the first child row. */
-  function renderGroupChildren(container, entity, startDate, pxPerMs, childStartYOffset, totalWidth) {
+  /** Render child task rows below the group bar. */
+  function renderGroupChildren(container, entity, startDate, pxPerMs, groupYOffset, totalWidth) {
     entity.children.forEach((child, i) => {
-      const childYOffset = childStartYOffset + (GANTT_ROW_HEIGHT + 4) * i;
+      const childYOffset = groupYOffset + (GANTT_ROW_HEIGHT + 4) * (i + 1);
 
       // Child row background
       const rowBg = document.createElement('div');
@@ -994,11 +993,11 @@
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
     const totalRowCount = laneGroups.reduce((sum, laneEntities) => {
-      const expandedChildCount = laneEntities.reduce((childSum, e) => {
+      const maxChildren = laneEntities.reduce((max, e) => {
         const key = e.id !== undefined ? e.id : e.name;
-        return childSum + (e.isGroup && expandedGroups.has(key) ? e.children.length : 0);
+        return e.isGroup && expandedGroups.has(key) ? Math.max(max, e.children.length) : max;
       }, 0);
-      return sum + 1 + expandedChildCount;
+      return sum + 1 + maxChildren;
     }, 0);
     ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
 
@@ -1016,14 +1015,17 @@
         renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth, laneIdx > 0);
       });
 
-      // Then render children of each expanded entity sequentially below the lane
+      // Render children of each expanded entity relative to laneYOffset,
+      // then advance yOffset by the largest child count in this lane
+      let maxChildCount = 0;
       laneEntities.forEach(entity => {
         const entityKey = entity.id !== undefined ? entity.id : entity.name;
         if (entity.isGroup && expandedGroups.has(entityKey)) {
-          renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, yOffset, totalWidth);
-          yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
+          renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
+          maxChildCount = Math.max(maxChildCount, entity.children.length);
         }
       });
+      yOffset += (GANTT_ROW_HEIGHT + 4) * maxChildCount;
     });
 
     viewTimeline.appendChild(ganttContainer);

--- a/media/main.js
+++ b/media/main.js
@@ -885,17 +885,21 @@
     });
   }
 
-  /** Render child task rows below the group bar. */
+  /** Render row backgrounds for the child area below a lane (called once per lane). */
+  function renderGroupChildRowBgs(container, childCount, groupYOffset, totalWidth) {
+    for (let i = 0; i < childCount; i++) {
+      const rowBg = document.createElement('div');
+      rowBg.className = 'tm-gantt-row-bg tm-gantt-child-row-bg';
+      rowBg.style.top = (groupYOffset + (GANTT_ROW_HEIGHT + 4) * (i + 1)) + 'px';
+      rowBg.style.width = totalWidth + 'px';
+      container.appendChild(rowBg);
+    }
+  }
+
+  /** Render child task bars below the group bar (row backgrounds are rendered separately). */
   function renderGroupChildren(container, entity, startDate, pxPerMs, groupYOffset, totalWidth) {
     entity.children.forEach((child, i) => {
       const childYOffset = groupYOffset + (GANTT_ROW_HEIGHT + 4) * (i + 1);
-
-      // Child row background
-      const rowBg = document.createElement('div');
-      rowBg.className = 'tm-gantt-row-bg tm-gantt-child-row-bg';
-      rowBg.style.top = childYOffset + 'px';
-      rowBg.style.width = totalWidth + 'px';
-      container.appendChild(rowBg);
 
       const childColor = getItemBorderColor(child.tags, currentTaskMarkData.tagColors);
       const left = (child.startMs - startDate.getTime()) * pxPerMs;
@@ -1015,17 +1019,22 @@
         renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth, laneIdx > 0);
       });
 
-      // Render children of each expanded entity relative to laneYOffset,
-      // then advance yOffset by the largest child count in this lane
-      let maxChildCount = 0;
-      laneEntities.forEach(entity => {
-        const entityKey = entity.id !== undefined ? entity.id : entity.name;
-        if (entity.isGroup && expandedGroups.has(entityKey)) {
-          renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
-          maxChildCount = Math.max(maxChildCount, entity.children.length);
-        }
-      });
-      yOffset += (GANTT_ROW_HEIGHT + 4) * maxChildCount;
+      // Render children of each expanded entity relative to laneYOffset.
+      // Row backgrounds are rendered once for the full child area depth.
+      const maxChildCount = laneEntities.reduce((max, e) => {
+        const key = e.id !== undefined ? e.id : e.name;
+        return e.isGroup && expandedGroups.has(key) ? Math.max(max, e.children.length) : max;
+      }, 0);
+      if (maxChildCount > 0) {
+        renderGroupChildRowBgs(ganttContainer, maxChildCount, laneYOffset, totalWidth);
+        laneEntities.forEach(entity => {
+          const entityKey = entity.id !== undefined ? entity.id : entity.name;
+          if (entity.isGroup && expandedGroups.has(entityKey)) {
+            renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
+          }
+        });
+        yOffset += (GANTT_ROW_HEIGHT + 4) * maxChildCount;
+      }
     });
 
     viewTimeline.appendChild(ganttContainer);

--- a/media/main.js
+++ b/media/main.js
@@ -798,13 +798,14 @@
   }
 
   /** Render a single Gantt bar (group or standalone) */
-  function renderGanttEntityBar(container, entity, startDate, pxPerMs, yOffset, totalWidth) {
-    // Row background
-    const rowBg = document.createElement('div');
-    rowBg.className = 'tm-gantt-row-bg';
-    rowBg.style.top = yOffset + 'px';
-    rowBg.style.width = totalWidth + 'px';
-    container.appendChild(rowBg);
+  function renderGanttEntityBar(container, entity, startDate, pxPerMs, yOffset, totalWidth, skipRowBg) {
+    if (!skipRowBg) {
+      const rowBg = document.createElement('div');
+      rowBg.className = 'tm-gantt-row-bg';
+      rowBg.style.top = yOffset + 'px';
+      rowBg.style.width = totalWidth + 'px';
+      container.appendChild(rowBg);
+    }
 
     const bgColor = getItemBorderColor(entity.tags, currentTaskMarkData.tagColors);
 
@@ -1008,8 +1009,8 @@
     laneGroups.forEach(laneEntities => {
       const laneYOffset = yOffset;
       yOffset += GANTT_ROW_HEIGHT + 4;
-      laneEntities.forEach(entity => {
-        renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
+      laneEntities.forEach((entity, laneIdx) => {
+        renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth, laneIdx > 0);
         const entityKey = entity.id !== undefined ? entity.id : entity.name;
         if (entity.isGroup && expandedGroups.has(entityKey)) {
           renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);

--- a/media/main.js
+++ b/media/main.js
@@ -837,18 +837,19 @@
     pBar.style.backgroundColor = bgColor;
     bar.appendChild(pBar);
 
+    const entityKey = entity.id !== undefined ? entity.id : entity.name;
     const indicator = document.createElement('span');
     indicator.className = 'tm-gantt-group-indicator';
-    indicator.textContent = expandedGroups.has(entity.name) ? '▼' : '▶';
+    indicator.textContent = expandedGroups.has(entityKey) ? '▼' : '▶';
     bar.appendChild(indicator);
 
     bar.addEventListener('click', (e) => {
       e.stopPropagation();
       if (hasDragged) return;
-      if (expandedGroups.has(entity.name)) {
-        expandedGroups.delete(entity.name);
+      if (expandedGroups.has(entityKey)) {
+        expandedGroups.delete(entityKey);
       } else {
-        expandedGroups.add(entity.name);
+        expandedGroups.add(entityKey);
       }
       renderTimeline();
     });
@@ -973,29 +974,48 @@
     const totalWidth = totalMs * pxPerMs;
     const totalRenderDays = Math.ceil(totalMs / MS_PER_DAY);
 
+    // Group entities by lane while preserving order of first occurrence
+    const laneGroups = [];
+    const seenLanes = new Map();
+    entityArray.forEach(entity => {
+      const lane = entity.lane !== undefined ? entity.lane : entity.name;
+      if (!seenLanes.has(lane)) {
+        seenLanes.set(lane, laneGroups.length);
+        laneGroups.push([entity]);
+      } else {
+        laneGroups[seenLanes.get(lane)].push(entity);
+      }
+    });
+
     // Build container
     const ganttContainer = document.createElement('div');
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
-    const totalRowCount = entityArray.reduce((sum, e) => {
-      const childCount = e.isGroup && expandedGroups.has(e.name) ? e.children.length : 0;
-      return sum + 1 + childCount;
+    const totalRowCount = laneGroups.reduce((sum, laneEntities) => {
+      const maxChildren = laneEntities.reduce((max, e) => {
+        return e.isGroup && expandedGroups.has(e.id !== undefined ? e.id : e.name)
+          ? Math.max(max, e.children.length) : max;
+      }, 0);
+      return sum + 1 + maxChildren;
     }, 0);
     ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
 
     // Render axis and column backgrounds
     renderGanttAxis(ganttContainer, startDate, totalRenderDays, pxPerMs);
 
-    // Render entity bars
+    // Render entity bars grouped by lane (same lane = same row)
     let yOffset = GANTT_HEADER_HEIGHT;
-    entityArray.forEach(entity => {
-      const entityYOffset = yOffset;
-      renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
+    laneGroups.forEach(laneEntities => {
+      const laneYOffset = yOffset;
       yOffset += GANTT_ROW_HEIGHT + 4;
-      if (entity.isGroup && expandedGroups.has(entity.name)) {
-        renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
-        yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
-      }
+      laneEntities.forEach(entity => {
+        renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
+        const entityKey = entity.id !== undefined ? entity.id : entity.name;
+        if (entity.isGroup && expandedGroups.has(entityKey)) {
+          renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
+          yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
+        }
+      });
     });
 
     viewTimeline.appendChild(ganttContainer);

--- a/media/main.js
+++ b/media/main.js
@@ -885,10 +885,11 @@
     });
   }
 
-  /** Render child task rows below the group bar */
-  function renderGroupChildren(container, entity, startDate, pxPerMs, groupYOffset, totalWidth) {
+  /** Render child task rows below the group bar.
+   *  childStartYOffset is the absolute top of the first child row. */
+  function renderGroupChildren(container, entity, startDate, pxPerMs, childStartYOffset, totalWidth) {
     entity.children.forEach((child, i) => {
-      const childYOffset = groupYOffset + (GANTT_ROW_HEIGHT + 4) * (i + 1);
+      const childYOffset = childStartYOffset + (GANTT_ROW_HEIGHT + 4) * i;
 
       // Child row background
       const rowBg = document.createElement('div');
@@ -993,11 +994,11 @@
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
     const totalRowCount = laneGroups.reduce((sum, laneEntities) => {
-      const maxChildren = laneEntities.reduce((max, e) => {
-        return e.isGroup && expandedGroups.has(e.id !== undefined ? e.id : e.name)
-          ? Math.max(max, e.children.length) : max;
+      const expandedChildCount = laneEntities.reduce((childSum, e) => {
+        const key = e.id !== undefined ? e.id : e.name;
+        return childSum + (e.isGroup && expandedGroups.has(key) ? e.children.length : 0);
       }, 0);
-      return sum + 1 + maxChildren;
+      return sum + 1 + expandedChildCount;
     }, 0);
     ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
 
@@ -1009,11 +1010,17 @@
     laneGroups.forEach(laneEntities => {
       const laneYOffset = yOffset;
       yOffset += GANTT_ROW_HEIGHT + 4;
+
+      // Render all bars for this lane first
       laneEntities.forEach((entity, laneIdx) => {
         renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth, laneIdx > 0);
+      });
+
+      // Then render children of each expanded entity sequentially below the lane
+      laneEntities.forEach(entity => {
         const entityKey = entity.id !== undefined ? entity.id : entity.name;
         if (entity.isGroup && expandedGroups.has(entityKey)) {
-          renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
+          renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, yOffset, totalWidth);
           yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
         }
       });

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -13,7 +13,9 @@ export interface GanttChildItem {
 }
 
 export interface GanttEntity {
+  id: string;
   name: string;
+  lane: string;
   isGroup: boolean;
   minTime: number;
   maxTime: number;
@@ -78,10 +80,13 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
       }
 
       const bucket = item.group ? groupEntities : standaloneEntities;
-      const key = item.group ?? item.text;
+      const displayName = item.group ?? item.text;
+      const key = `${dStr}::${displayName}`;
       if (!bucket[key]) {
         bucket[key] = {
-          name: key,
+          id: key,
+          name: displayName,
+          lane: displayName,
           isGroup: !!item.group,
           minTime: startMs,
           maxTime: endMs,

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -81,7 +81,8 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
 
       const bucket = item.group ? groupEntities : standaloneEntities;
       const displayName = item.group ?? item.text;
-      const key = `${dStr}::${displayName}`;
+      const typePrefix = item.group ? 'g' : 's';
+      const key = `${typePrefix}::${dStr}::${displayName}`;
       if (!bucket[key]) {
         bucket[key] = {
           id: key,

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -140,7 +140,7 @@ suite('Gantt Test Suite', () => {
     assert.strictEqual(standalone!.name, 'Sprint');
   });
 
-  test('group minTime and maxTime span all child items', () => {
+  test('same-named groups in different date sections produce separate entities each with correct time range', () => {
     const { data } = parseTmd(`
 # 2026-03-01
 > Sprint
@@ -151,12 +151,13 @@ suite('Gantt Test Suite', () => {
 > - [ ] 14:00-15:00 Afternoon Task
 `);
     const { entities } = buildGanttEntities(data);
-    assert.strictEqual(entities.length, 1);
+    assert.strictEqual(entities.length, 2, 'same-named groups in different date sections must be separate entities');
 
-    const sprint = entities[0];
-    assert.strictEqual(sprint.children.length, 2);
-    assert.ok(sprint.minTime < sprint.maxTime, 'minTime should be before maxTime');
-    assert.ok(sprint.children[0].startMs < sprint.children[1].startMs, 'children should be in chronological order');
+    assert.ok(entities.every(e => e.lane === 'Sprint'), 'all entities should share the Sprint lane');
+    assert.strictEqual(entities[0].children.length, 1);
+    assert.strictEqual(entities[1].children.length, 1);
+    assert.ok(entities[0].minTime < entities[1].minTime, 'entities should be ordered by start time');
+    assert.ok(entities[0].minTime < entities[0].maxTime, 'each entity minTime should be before maxTime');
   });
 
   test('range item child spans correct time in gantt entity', () => {
@@ -227,15 +228,43 @@ suite('Gantt Test Suite', () => {
 > - [ ] Task B
 `);
     const { entities } = buildGanttEntities(data);
-    assert.strictEqual(entities.length, 1, 'same group across different date ranges should be one entity');
+    assert.strictEqual(entities.length, 2, 'same group across different date ranges should produce separate entities');
 
-    const sprint = entities[0];
-    assert.strictEqual(sprint.name, 'Sprint');
-    assert.strictEqual(sprint.children.length, 2);
+    assert.ok(entities.every(e => e.name === 'Sprint'), 'all entities should be named Sprint');
+    assert.ok(entities.every(e => e.lane === 'Sprint'), 'all entities should be on the Sprint lane');
+    assert.notStrictEqual(entities[0].id, entities[1].id, 'entities should have different ids');
+    assert.strictEqual(entities[0].children.length, 1);
+    assert.strictEqual(entities[1].children.length, 1);
+  });
 
-    const expectedMinTime = new Date(2026, 2, 1).getTime();
-    const expectedMaxTime = new Date(2026, 2, 8).getTime() - 1;
-    assert.strictEqual(sprint.minTime, expectedMinTime, 'minTime should be earliest start');
-    assert.strictEqual(sprint.maxTime, expectedMaxTime, 'maxTime should be latest end');
+  test('same-named groups in different date sections produce separate entities on the same lane', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+> Sprint
+> - [ ] Task A
+
+# 2026-03-10
+> Sprint
+> - [ ] Task B
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 2, 'same-named groups across date sections should be separate entities');
+
+    assert.ok(entities.every(e => e.lane === 'Sprint'), 'all entities should share the Sprint lane');
+    assert.notStrictEqual(entities[0].id, entities[1].id, 'entities should have unique ids');
+    assert.strictEqual(entities[0].tasksTotal, 1, 'first entity task count should be independent');
+    assert.strictEqual(entities[1].tasksTotal, 1, 'second entity task count should be independent');
+  });
+
+  test('entity has id and lane fields', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+> Sprint
+> - [ ] Task A
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.ok(entities[0].id, 'entity should have an id');
+    assert.strictEqual(entities[0].lane, 'Sprint');
+    assert.strictEqual(entities[0].name, 'Sprint');
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #68

## 概要
ガントチャートで同名グループが日付セクションをまたいで1つのエンティティに統合されてしまうバグを修正した。日付セクションが異なる同名グループは別々のエンティティとして扱い、タスク数・進捗をそれぞれ独立して管理する。同名グループは同じレーン（行）に表示されるため、視覚的なまとまりは維持される。

## 変更内容
- `GanttEntity` インターフェースに `id`（ユニークキー）と `lane`（同一行に表示するグループ名）フィールドを追加
- `buildGanttEntities` のグルーピングキーを `item.group` から `dStr::group名` に変更し、日付セクションが異なる同名グループを別エンティティとして生成
- `media/main.js` の `renderTimeline` でレーンベースの描画に変更し、同じ `lane` を持つエンティティを同一行に配置
- 展開状態のトラッキングを `entity.name` から `entity.id` ベースに変更し、同名グループを個別に展開できるよう対応
- 同一レーン内で複数エンティティを展開した際の行背景の重複描画を修正（半透明の破線が濃くなる問題の解消）
- 同一レーン内の子エリアをレーン単位で共有し、行背景は `renderGroupChildRowBgs` で一度だけ描画するよう分離

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した
- [x] `npm run lint` パス（既存 warning のみ）
- [x] `npm run test:unit` 全 60 テストパス（新規テスト 3 件含む）

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| 同名グループが1行に統合されタスク数も合算される | 日付セクションごとに別バーで表示され、タスク数は独立して計算される |

## 備考・次やること
特になし