### PR TITLE
feat: グループ名へのタグ付けによる表示色設定

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Options can be combined using commas. If a limit is not explicitly defined, recu
 - Multi-day event spanning date range #Tag
 - [ ] Multi-day task spanning date range
 
-> Group Name
+> Group Name #Tag
 > - 13:00-15:00 Schedule inside group #Tag
 > - [x] Completed task inside group
 > - [ ] Uncompleted task inside group
@@ -154,8 +154,25 @@ Options can be combined using commas. If a limit is not explicitly defined, recu
 | `HH:mm` | Start time only | Schedules |
 | `#Tag` | Tags (Multiple allowed) | Both |
 | `@repeat(...)` | Recurring items | Schedules only |
-| `> Group Name` | Group header | — |
+| `> Group Name` | Group header (tags optional) | — |
 | `> - Item` | Items inside group | Both |
+
+### 🗂️ Group Colors
+
+Attach a tag directly to a group header to control its display color in both the Calendar and Timeline views.
+
+```tmd
+# 2026-03-01
+> Sprint #Dev
+> - [ ] Implement feature A
+> - [ ] Write tests
+```
+
+If no tag is specified on the group header, the color falls back to the first tag found among the child items, or the default accent color if none exist.
+
+> **Note:** When a schedule inside a group uses `@repeat`, the repeated copies appear on different dates. Because the group header tag is only recorded for the original date, the group bars on those expanded dates will fall back to the child item's tag color (or the default accent color). This is expected behavior.
+
+---
 
 ### 📅 Date Range Header
 

--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ Attach a tag directly to a group header to control its display color in both the
 > - [ ] Write tests
 ```
 
-If no tag is specified on the group header, the color falls back to the first tag found among the child items, or the default accent color if none exist.
+If no tag is specified on the group header, the group box and its bar use the default accent color. Each child item continues to use its own tag color independently.
 
-> **Note:** When a schedule inside a group uses `@repeat`, the repeated copies appear on different dates. Because the group header tag is only recorded for the original date, the group bars on those expanded dates will fall back to the child item's tag color (or the default accent color). This is expected behavior.
+> **Note:** When a schedule inside a group uses `@repeat`, the group header tag is correctly applied to all expanded instances by referencing the original date where the group was defined.
 
 ---
 

--- a/media/main.js
+++ b/media/main.js
@@ -351,7 +351,7 @@
 
   // ─── Calendar Items HTML ─────────────────────────────────────
 
-  function createItemsHtml(items, tagColorsMap, isMonthly = false) {
+  function createItemsHtml(items, tagColorsMap, isMonthly = false, dateStr = '') {
     if (!items || items.length === 0) return '';
 
     const sortedItems = [...items].sort((a, b) => {
@@ -398,7 +398,18 @@
       </div>`;
     };
 
-    const renderTaskSummary = (itemList, titleFallback) => {
+    const getGroupBorderColor = (gName, itemList) => {
+      if (dateStr && currentTaskMarkData.groupTags) {
+        const gTags = currentTaskMarkData.groupTags[`${dateStr}::${gName}`];
+        if (gTags && gTags.length > 0) {
+          return getTagColor(gTags[0], tagColorsMap);
+        }
+      }
+      const firstTagItem = itemList.find(i => i.tags && i.tags.length > 0);
+      return firstTagItem ? getTagColor(firstTagItem.tags[0], tagColorsMap) : 'var(--tm-accent)';
+    };
+
+    const renderTaskSummary = (itemList, titleFallback, gName = '') => {
       const tasks = itemList.filter(i => i.type === 'task');
       const schedules = itemList.filter(i => i.type === 'schedule');
       let outHtml = schedules.map(renderItem).join('');
@@ -407,10 +418,7 @@
         const doneCount = tasks.filter(t => t.status === 'done').length;
         const totalCount = tasks.length;
         const isAllDone = doneCount === totalCount;
-        const firstTagTask = tasks.find(t => t.tags && t.tags.length > 0);
-        const borderColor = firstTagTask
-          ? getTagColor(firstTagTask.tags[0], tagColorsMap)
-          : 'var(--tm-accent)';
+        const borderColor = getGroupBorderColor(gName, tasks);
         const classNames = `tm-item task ${isAllDone ? 'done' : ''}`;
 
         outHtml += `<div class="${classNames}" style="border-left-color: ${borderColor}">
@@ -424,10 +432,11 @@
     let html = '<div class="tm-items-list">';
 
     Object.keys(grouped).forEach(gName => {
+      const groupBorderColor = getGroupBorderColor(gName, grouped[gName]);
       const groupContent = isMonthly
-        ? renderTaskSummary(grouped[gName], 'Tasks')
+        ? renderTaskSummary(grouped[gName], 'Tasks', gName)
         : grouped[gName].map(renderItem).join('');
-      html += `<div class="tm-group-box">
+      html += `<div class="tm-group-box" style="border-left-color: ${groupBorderColor}">
         <div class="tm-group-title">${escapeHtml(gName)}</div>
         ${groupContent}
       </div>`;
@@ -688,7 +697,7 @@
         const regularItems = dayItems.filter(item => !item.endDate);
         const el = createCell(cell.dayNo, cell.isOtherMonth, cell.isToday, cell.dayOfWeek, cell.dStr);
         el.innerHTML += createCellBandsHtml(bandMap[colIndex], maxRow, tagColors);
-        el.innerHTML += createItemsHtml(regularItems, tagColors, true);
+        el.innerHTML += createItemsHtml(regularItems, tagColors, true, cell.dStr);
         viewCalendar.appendChild(el);
       });
     }
@@ -722,7 +731,7 @@
       const cell = createCell(d.getDate(), false, dStr === todayStr, dayOfWeek, dStr);
       cell.style.flex = '1';
       cell.innerHTML += createCellBandsHtml(bandMap[colIndex], maxRow, tagColors);
-      cell.innerHTML += createItemsHtml(regularItems, tagColors);
+      cell.innerHTML += createItemsHtml(regularItems, tagColors, false, dStr);
       viewCalendar.appendChild(cell);
       d.setDate(d.getDate() + 1);
     }
@@ -745,7 +754,7 @@
     const dayData = getDayData(dStr);
     const cell = createCell('', false, dStr === todayStr, dayOfWeek);
     cell.style.flex = '1';
-    cell.innerHTML += createItemsHtml(dayData.items, currentTaskMarkData.tagColors);
+    cell.innerHTML += createItemsHtml(dayData.items, currentTaskMarkData.tagColors, false, dStr);
     viewCalendar.appendChild(cell);
   }
 

--- a/media/main.js
+++ b/media/main.js
@@ -399,10 +399,13 @@
     };
 
     const getGroupBorderColor = (gName, itemList) => {
-      if (dateStr && currentTaskMarkData.groupTags) {
-        const gTags = currentTaskMarkData.groupTags[`${dateStr}::${gName}`];
-        if (gTags && gTags.length > 0) {
-          return getTagColor(gTags[0], tagColorsMap);
+      if (currentTaskMarkData.groupTags) {
+        const lookupDates = new Set();
+        if (dateStr) lookupDates.add(dateStr);
+        itemList.forEach(i => { if (i.startDate) lookupDates.add(i.startDate); });
+        for (const d of lookupDates) {
+          const gTags = currentTaskMarkData.groupTags[`${d}::${gName}`];
+          if (gTags && gTags.length > 0) return getTagColor(gTags[0], tagColorsMap);
         }
       }
       const firstTagItem = itemList.find(i => i.tags && i.tags.length > 0);

--- a/media/main.js
+++ b/media/main.js
@@ -399,7 +399,7 @@
     };
 
     const getGroupBorderColor = (gName, itemList) => {
-      if (currentTaskMarkData.groupTags) {
+      if (gName && currentTaskMarkData.groupTags) {
         const lookupDates = new Set();
         if (dateStr) lookupDates.add(dateStr);
         itemList.forEach(i => { if (i.startDate) lookupDates.add(i.startDate); });
@@ -407,8 +407,10 @@
           const gTags = currentTaskMarkData.groupTags[`${d}::${gName}`];
           if (gTags && gTags.length > 0) return getTagColor(gTags[0], tagColorsMap);
         }
+        return 'var(--tm-accent)';
       }
-      return 'var(--tm-accent)';
+      const firstTagItem = itemList.find(i => i.tags && i.tags.length > 0);
+      return firstTagItem ? getTagColor(firstTagItem.tags[0], tagColorsMap) : 'var(--tm-accent)';
     };
 
     const renderTaskSummary = (itemList, titleFallback, gName = '') => {

--- a/media/main.js
+++ b/media/main.js
@@ -408,8 +408,7 @@
           if (gTags && gTags.length > 0) return getTagColor(gTags[0], tagColorsMap);
         }
       }
-      const firstTagItem = itemList.find(i => i.tags && i.tags.length > 0);
-      return firstTagItem ? getTagColor(firstTagItem.tags[0], tagColorsMap) : 'var(--tm-accent)';
+      return 'var(--tm-accent)';
     };
 
     const renderTaskSummary = (itemList, titleFallback, gName = '') => {
@@ -421,7 +420,7 @@
         const doneCount = tasks.filter(t => t.status === 'done').length;
         const totalCount = tasks.length;
         const isAllDone = doneCount === totalCount;
-        const borderColor = getGroupBorderColor(gName, tasks);
+        const borderColor = getGroupBorderColor(gName, itemList);
         const classNames = `tm-item task ${isAllDone ? 'done' : ''}`;
 
         outHtml += `<div class="${classNames}" style="border-left-color: ${borderColor}">
@@ -510,7 +509,7 @@
           const key = item.group;
           if (!groupMerged[key]) {
             const groupTags = currentTaskMarkData.groupTags && currentTaskMarkData.groupTags[`${date}::${item.group}`];
-            const tags = groupTags ? groupTags : item.tags;
+            const tags = groupTags || [];
             groupMerged[key] = { date, item: { ...item, text: item.group, tags } };
           } else {
             const existing = groupMerged[key];

--- a/media/main.js
+++ b/media/main.js
@@ -506,7 +506,9 @@
         if (item.group) {
           const key = item.group;
           if (!groupMerged[key]) {
-            groupMerged[key] = { date, item: { ...item, text: item.group } };
+            const groupTags = currentTaskMarkData.groupTags && currentTaskMarkData.groupTags[`${date}::${item.group}`];
+            const tags = groupTags ? groupTags : item.tags;
+            groupMerged[key] = { date, item: { ...item, text: item.group, tags } };
           } else {
             const existing = groupMerged[key];
             if (date < existing.date) { existing.date = date; }

--- a/media/style.css
+++ b/media/style.css
@@ -401,6 +401,7 @@ body {
 
 .tm-group-box {
   border: 1px dashed var(--tm-group-border);
+  border-left: 3px solid var(--tm-accent);
   background: var(--tm-group-bg);
   border-radius: var(--tm-radius);
   padding: 8px;

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -92,7 +92,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
           isGroup: !!item.group,
           minTime: startMs,
           maxTime: endMs,
-          tags: groupHeaderTags ? [...groupHeaderTags] : [...item.tags],
+          tags: groupHeaderTags ? [...groupHeaderTags] : [],
           tasksTotal: 0,
           tasksDone: 0,
           children: []

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -84,6 +84,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
       const typePrefix = item.group ? 'g' : 's';
       const key = `${typePrefix}::${dStr}::${displayName}`;
       if (!bucket[key]) {
+        const groupHeaderTags = item.group ? (data.groupTags[`${dStr}::${displayName}`] ?? null) : null;
         bucket[key] = {
           id: key,
           name: displayName,
@@ -91,7 +92,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
           isGroup: !!item.group,
           minTime: startMs,
           maxTime: endMs,
-          tags: [...item.tags],
+          tags: groupHeaderTags ? [...groupHeaderTags] : [...item.tags],
           tasksTotal: 0,
           tasksDone: 0,
           children: []

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -84,7 +84,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
       const typePrefix = item.group ? 'g' : 's';
       const key = `${typePrefix}::${dStr}::${displayName}`;
       if (!bucket[key]) {
-        const groupHeaderTags = item.group ? (data.groupTags[`${dStr}::${displayName}`] ?? null) : null;
+        const groupHeaderTags = item.group ? (data.groupTags[`${item.startDate}::${displayName}`] ?? null) : null;
         bucket[key] = {
           id: key,
           name: displayName,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -233,6 +233,10 @@ export function parseTmd(text: string): ParseResult {
     const groupMatch = line.match(GROUP_REGEX);
     if (groupMatch) {
       const { tags: gTags, cleaned: gName } = extractTags(groupMatch[1].trim());
+      if (!gName) {
+        warnings.push(`Line ${i + 1}: group header has no name, skipped`);
+        continue;
+      }
       currentGroup = gName;
       if (gTags.length > 0 && currentDate) {
         data.groupTags[`${currentDate}::${currentGroup}`] = gTags;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,6 @@
 export interface TaskMarkData {
   tagColors: Record<string, string>;
+  groupTags: Record<string, string[]>; // Key is "YYYY-MM-DD::groupName"
   days: Record<string, DayData>; // Key is YYYY-MM-DD
 }
 
@@ -167,7 +168,7 @@ function parseRepeatOptions(repeatStr: string, lineNum: number, warnings: string
 
 export function parseTmd(text: string): ParseResult {
   const lines = text.split(/\r?\n/);
-  const data: TaskMarkData = { tagColors: {}, days: {} };
+  const data: TaskMarkData = { tagColors: {}, groupTags: {}, days: {} };
   const warnings: string[] = [];
 
   let inTagsBlock = false;
@@ -231,7 +232,11 @@ export function parseTmd(text: string): ParseResult {
     // 3. Group header
     const groupMatch = line.match(GROUP_REGEX);
     if (groupMatch) {
-      currentGroup = groupMatch[1].trim();
+      const { tags: gTags, cleaned: gName } = extractTags(groupMatch[1].trim());
+      currentGroup = gName;
+      if (gTags.length > 0 && currentDate) {
+        data.groupTags[`${currentDate}::${currentGroup}`] = gTags;
+      }
       continue;
     }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -27,6 +27,7 @@ export interface MarkItem {
   repeat?: string;
   group?: string;
   rawLine: number;
+  startDate: string;
   endDate?: string;
 }
 
@@ -303,6 +304,7 @@ function createMarkItem(
     repeat: repeatStr,
     group: newGroup || undefined,
     rawLine: lineIndex,
+    startDate: currentDate,
     endDate: endDate || undefined,
   };
 

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -6,7 +6,7 @@ suite('TaskmarkPanel message types', () => {
     const msg: TaskMarkUpdateMessage = {
       type: 'update',
       uri: 'file:///test.tmd',
-      data: { tagColors: {}, days: {} },
+      data: { tagColors: {}, groupTags: {}, days: {} },
       ganttData: { entities: [], lastDateStr: '' },
       warnings: []
     };
@@ -17,7 +17,7 @@ suite('TaskmarkPanel message types', () => {
     const msg: TaskMarkUpdateMessage = {
       type: 'update',
       uri: 'file:///test.tmd',
-      data: { tagColors: {}, days: {} },
+      data: { tagColors: {}, groupTags: {}, days: {} },
       ganttData: { entities: [], lastDateStr: '' },
       warnings: ["Line 5: invalid date '2026-99-99', skipped"]
     };

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -57,7 +57,7 @@ suite('Gantt Test Suite', () => {
   });
 
   test('empty data returns empty entities and empty lastDateStr', () => {
-    const { entities, lastDateStr } = buildGanttEntities({ tagColors: {}, days: {} });
+    const { entities, lastDateStr } = buildGanttEntities({ tagColors: {}, groupTags: {}, days: {} });
     assert.strictEqual(entities.length, 0);
     assert.strictEqual(lastDateStr, '');
   });
@@ -266,5 +266,39 @@ suite('Gantt Test Suite', () => {
     assert.ok(entities[0].id, 'entity should have an id');
     assert.strictEqual(entities[0].lane, 'Sprint');
     assert.strictEqual(entities[0].name, 'Sprint');
+  });
+
+  test('group entity uses group-header tags when present', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+> Sprint #backend
+> - [ ] Task A #frontend
+`);
+    const { entities } = buildGanttEntities(data);
+    const group = entities[0];
+    assert.deepStrictEqual(group.tags, ['backend'], 'group entity should use the group header tags, not child item tags');
+  });
+
+  test('group entity falls back to first child tags when no group-header tags', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+> Sprint
+> - [ ] Task A #frontend
+`);
+    const { entities } = buildGanttEntities(data);
+    const group = entities[0];
+    assert.deepStrictEqual(group.tags, ['frontend'], 'group entity should fall back to first child item tags');
+  });
+
+  test('group entity with header tags ignores empty child tags', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+> Sprint #design
+> - [ ] Task A
+> - [ ] Task B
+`);
+    const { entities } = buildGanttEntities(data);
+    const group = entities[0];
+    assert.deepStrictEqual(group.tags, ['design'], 'group entity should use header tags even when children have no tags');
   });
 });

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -279,7 +279,7 @@ suite('Gantt Test Suite', () => {
     assert.deepStrictEqual(group.tags, ['backend'], 'group entity should use the group header tags, not child item tags');
   });
 
-  test('group entity falls back to first child tags when no group-header tags', () => {
+  test('group entity has empty tags when no group-header tags', () => {
     const { data } = parseTmd(`
 # 2026-03-01
 > Sprint
@@ -287,7 +287,7 @@ suite('Gantt Test Suite', () => {
 `);
     const { entities } = buildGanttEntities(data);
     const group = entities[0];
-    assert.deepStrictEqual(group.tags, ['frontend'], 'group entity should fall back to first child item tags');
+    assert.deepStrictEqual(group.tags, [], 'group entity should have no tags when group header has no tags');
   });
 
   test('group entity with header tags ignores empty child tags', () => {

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -301,4 +301,17 @@ suite('Gantt Test Suite', () => {
     const group = entities[0];
     assert.deepStrictEqual(group.tags, ['design'], 'group entity should use header tags even when children have no tags');
   });
+
+  test('repeat-expanded group entity inherits group-header tags from original date', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+> Sprint #backend
+> - 9:00-10:00 Daily Standup @repeat(weekly, count:2)
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 2, 'should produce two entities');
+    entities.forEach(entity => {
+      assert.deepStrictEqual(entity.tags, ['backend'], 'repeat-expanded entity should use group header tags from original date');
+    });
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -537,4 +537,25 @@ not a valid tag line
     assert.strictEqual(warnings.length, 1, 'Should warn for empty group name');
     assert.ok(warnings[0].includes('Line 3'), 'Warning should reference line number');
   });
+
+  test('parseTmd item has startDate matching the date header', () => {
+    const text = `
+# 2026-03-01
+- Meeting
+`;
+    const { data } = parseTmd(text);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.startDate, '2026-03-01');
+  });
+
+  test('parseTmd range item has startDate matching the range start date', () => {
+    const text = `
+# 2026-03-01 : 2026-03-10
+> Sprint #backend
+> - [ ] Task A
+`;
+    const { data } = parseTmd(text);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.startDate, '2026-03-01');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -526,4 +526,15 @@ not a valid tag line
     const { data } = parseTmd(text);
     assert.deepStrictEqual(data.groupTags, {});
   });
+
+  test('parseTmd warns when group header has only tags and no group name', () => {
+    const text = `
+# 2026-03-01
+> #backend
+> - [ ] Task A
+`;
+    const { warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1, 'Should warn for empty group name');
+    assert.ok(warnings[0].includes('Line 3'), 'Warning should reference line number');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -474,4 +474,56 @@ not a valid tag line
     const uniqueWarnings = [...new Set(warnings)];
     assert.deepStrictEqual(warnings, uniqueWarnings, 'warnings should be deduplicated');
   });
+
+  // ─── Group Tags Tests ────────────────────────────────────────
+
+  test('parseTmd group header with tag stores groupTags entry', () => {
+    const text = `
+# 2026-03-01
+> Sprint #backend
+> - [ ] Task A
+`;
+    const { data } = parseTmd(text);
+    assert.deepStrictEqual(data.groupTags['2026-03-01::Sprint'], ['backend']);
+  });
+
+  test('parseTmd group header without tag produces no groupTags entry', () => {
+    const text = `
+# 2026-03-01
+> Sprint
+> - [ ] Task A
+`;
+    const { data } = parseTmd(text);
+    assert.strictEqual(data.groupTags['2026-03-01::Sprint'], undefined);
+  });
+
+  test('parseTmd group header tag is stripped from group name', () => {
+    const text = `
+# 2026-03-01
+> Sprint #backend
+> - [ ] Task A
+`;
+    const { data } = parseTmd(text);
+    const items = data.days['2026-03-01'].items;
+    assert.strictEqual(items[0].group, 'Sprint', 'group name should not include the tag');
+  });
+
+  test('parseTmd group header with multiple tags stores all tags', () => {
+    const text = `
+# 2026-03-01
+> Sprint #backend #mobile
+> - [ ] Task A
+`;
+    const { data } = parseTmd(text);
+    assert.deepStrictEqual(data.groupTags['2026-03-01::Sprint'], ['backend', 'mobile']);
+  });
+
+  test('parseTmd groupTags is empty object when no group tags exist', () => {
+    const text = `
+# 2026-03-01
+- Task
+`;
+    const { data } = parseTmd(text);
+    assert.deepStrictEqual(data.groupTags, {});
+  });
 });


### PR DESCRIPTION
## 関連Issue
Closes #66

## 概要
グループヘッダー行（`> グループ名`）にタグを付けることで、グループの表示色を直接指定できるようにした。これまでグループ色は最初の子要素のタグから取得していたが、グループ名自体にタグを付けることで明示的に色を制御できるようになった。

## 変更内容
- `parser.ts`: グループヘッダー行からタグを抽出し、`TaskMarkData.groupTags` に `"YYYY-MM-DD::グループ名"` をキーとして保存。またすべての `MarkItem` に `startDate` フィールドを追加し、期間アイテムが別の日付で表示される場合もグループタグを正しく参照できるようにした
- `gantt.ts`: グループエンティティのタグをグループヘッダーのタグから取得（`item.startDate` を使用することで `@repeat` で展開されたアイテムにも正しく適用）
- `media/main.js`: カレンダービューのグループボックスおよび日付範囲バンドにグループヘッダーのタグ色を適用。グループヘッダーにタグがない場合はアクセント色を使用。グループに属さないスタンドアロンアイテムは従来通り自身のタグ色を使用
- `media/style.css`: グループボックスに左ボーダーカラーのスタイルを追加
- テスト追加: パーサーおよびGanttエンティティのグループタグ関連テスト（計10件）

## 色の優先順位
**グループ（枠・バー）**
1. グループヘッダーのタグ（`> Sprint #backend`）
2. アクセント色（`var(--tm-accent)`）

**各子アイテム・スタンドアロンアイテム**
1. そのアイテム自身のタグ
2. アクセント色（`var(--tm-accent)`）

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した
- [x] `npm run lint` と `npm run test:unit` がすべてパスすることを確認した（72 passing）

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| グループ色は最初の子要素のタグから自動取得 | `> Sprint #backend` のようにグループ名にタグを付けることで色を明示指定可能 |

## 備考・次やること
- グループタグのキーは `"YYYY-MM-DD::グループ名"` 形式。`item.startDate` を参照するため `@repeat` で展開されたアイテムにも正しく適用される
- タグなしのグループはアクセント色（後方互換性維持）