### PR TITLE
feat: ガントチャートにズームイン・アウトボタンを追加する

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -216,12 +216,12 @@
       viewTimeline.classList.remove('hidden');
       viewCalendar.classList.add('hidden');
       monthNav?.classList.add('hidden');
-      zoomControls?.classList.remove('hidden');
+      zoomControls.classList.remove('hidden');
     } else {
       viewTimeline.classList.add('hidden');
       viewCalendar.classList.remove('hidden');
       monthNav?.classList.remove('hidden');
-      zoomControls?.classList.add('hidden');
+      zoomControls.classList.add('hidden');
     }
   }
 
@@ -293,23 +293,20 @@
   window.addEventListener('blur', stopPanning);
 
   // Gantt zoom
-  viewTimeline?.addEventListener('wheel', (e) => {
+  function applyZoom(factor) {
+    ganttZoom *= factor;
+    renderTimeline();
+  }
+
+  viewTimeline.addEventListener('wheel', (e) => {
     if (e.ctrlKey) {
       e.preventDefault();
-      ganttZoom *= (e.deltaY < 0 ? GANTT_ZOOM_IN_FACTOR : GANTT_ZOOM_OUT_FACTOR);
-      renderTimeline();
+      applyZoom(e.deltaY < 0 ? GANTT_ZOOM_IN_FACTOR : GANTT_ZOOM_OUT_FACTOR);
     }
   });
 
-  btnZoomIn?.addEventListener('click', () => {
-    ganttZoom *= GANTT_ZOOM_IN_FACTOR;
-    renderTimeline();
-  });
-
-  btnZoomOut?.addEventListener('click', () => {
-    ganttZoom *= GANTT_ZOOM_OUT_FACTOR;
-    renderTimeline();
-  });
+  btnZoomIn.addEventListener('click', () => applyZoom(GANTT_ZOOM_IN_FACTOR));
+  btnZoomOut.addEventListener('click', () => applyZoom(GANTT_ZOOM_OUT_FACTOR));
 
   // Date navigation
   function navigateDate(direction) {

--- a/media/main.js
+++ b/media/main.js
@@ -42,6 +42,9 @@
   const viewTimeline = document.getElementById('tm-timeline');
   const monthNav = document.querySelector('.tm-month-nav');
   const monthDisplay = document.getElementById('current-month-display');
+  const zoomControls = document.getElementById('tm-zoom-controls');
+  const btnZoomIn = document.getElementById('btn-zoom-in');
+  const btnZoomOut = document.getElementById('btn-zoom-out');
 
   // ─── Utility Functions ───────────────────────────────────────
 
@@ -211,10 +214,12 @@
       viewTimeline.classList.remove('hidden');
       viewCalendar.classList.add('hidden');
       monthNav?.classList.add('hidden');
+      zoomControls?.classList.remove('hidden');
     } else {
       viewTimeline.classList.add('hidden');
       viewCalendar.classList.remove('hidden');
       monthNav?.classList.remove('hidden');
+      zoomControls?.classList.add('hidden');
     }
   }
 
@@ -292,6 +297,16 @@
       ganttZoom *= (e.deltaY < 0 ? 1.2 : 0.8);
       renderTimeline();
     }
+  });
+
+  btnZoomIn?.addEventListener('click', () => {
+    ganttZoom *= 1.2;
+    renderTimeline();
+  });
+
+  btnZoomOut?.addEventListener('click', () => {
+    ganttZoom *= 0.8;
+    renderTimeline();
   });
 
   // Date navigation

--- a/media/main.js
+++ b/media/main.js
@@ -9,6 +9,8 @@
   const GANTT_MIN_BAR_WIDTH = 12;
   const GANTT_LABEL_OFFSET_X = 6;
   const GANTT_LABEL_OFFSET_Y = 4;
+  const GANTT_ZOOM_IN_FACTOR = 1.25;
+  const GANTT_ZOOM_OUT_FACTOR = 0.8;
 
   // ─── State ───────────────────────────────────────────────────
   let baseView = 'calendar'; // 'calendar' | 'timeline'
@@ -294,18 +296,18 @@
   viewTimeline?.addEventListener('wheel', (e) => {
     if (e.ctrlKey) {
       e.preventDefault();
-      ganttZoom *= (e.deltaY < 0 ? 1.25 : 0.8);
+      ganttZoom *= (e.deltaY < 0 ? GANTT_ZOOM_IN_FACTOR : GANTT_ZOOM_OUT_FACTOR);
       renderTimeline();
     }
   });
 
   btnZoomIn?.addEventListener('click', () => {
-    ganttZoom *= 1.25;
+    ganttZoom *= GANTT_ZOOM_IN_FACTOR;
     renderTimeline();
   });
 
   btnZoomOut?.addEventListener('click', () => {
-    ganttZoom *= 0.8;
+    ganttZoom *= GANTT_ZOOM_OUT_FACTOR;
     renderTimeline();
   });
 

--- a/media/main.js
+++ b/media/main.js
@@ -294,7 +294,7 @@
   viewTimeline?.addEventListener('wheel', (e) => {
     if (e.ctrlKey) {
       e.preventDefault();
-      ganttZoom *= (e.deltaY < 0 ? 1.2 : 0.8);
+      ganttZoom *= (e.deltaY < 0 ? 1.25 : 0.8);
       renderTimeline();
     }
   });

--- a/media/main.js
+++ b/media/main.js
@@ -300,7 +300,7 @@
   });
 
   btnZoomIn?.addEventListener('click', () => {
-    ganttZoom *= 1.2;
+    ganttZoom *= 1.25;
     renderTimeline();
   });
 

--- a/media/style.css
+++ b/media/style.css
@@ -162,6 +162,35 @@ body {
   background: var(--tm-card-border);
 }
 
+/* ─── Zoom Controls ─────────────────────────────────────────── */
+.tm-zoom-controls {
+  display: flex;
+  gap: 4px;
+  padding: 4px 24px;
+  background: var(--tm-bg);
+  border-bottom: 1px solid var(--tm-card-border);
+}
+
+.tm-zoom-controls button {
+  background: var(--tm-card-bg);
+  border: 1px solid var(--tm-card-border);
+  color: var(--tm-fg);
+  width: 28px;
+  height: 28px;
+  border-radius: var(--tm-radius);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--tm-transition);
+}
+
+.tm-zoom-controls button:hover {
+  background: var(--tm-card-border);
+}
+
 /* ─── Main Content Area ─────────────────────────────────────── */
 .tm-content {
   flex: 1;

--- a/media/style.css
+++ b/media/style.css
@@ -166,9 +166,7 @@ body {
 .tm-zoom-controls {
   display: flex;
   gap: 4px;
-  padding: 4px 24px;
-  background: var(--tm-bg);
-  border-bottom: 1px solid var(--tm-card-border);
+  align-items: center;
 }
 
 .tm-zoom-controls button {

--- a/media/style.css
+++ b/media/style.css
@@ -173,9 +173,9 @@ body {
   background: var(--tm-card-bg);
   border: 1px solid var(--tm-card-border);
   color: var(--tm-fg);
-  width: 28px;
-  height: 28px;
-  border-radius: var(--tm-radius);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
   cursor: pointer;
   font-size: 16px;
   line-height: 1;

--- a/src/template.ts
+++ b/src/template.ts
@@ -29,10 +29,10 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
              <h2 id="current-month-display"></h2>
              <button id="btn-next-month">&gt;</button>
           </div>
-        </div>
-        <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
-          <button id="btn-zoom-in">+</button>
-          <button id="btn-zoom-out">-</button>
+          <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
+            <button id="btn-zoom-out">-</button>
+            <button id="btn-zoom-in">+</button>
+          </div>
         </div>
         <div class="tm-content" id="tm-content-area">
           <div class="tm-calendar-grid" id="tm-calendar"></div>

--- a/src/template.ts
+++ b/src/template.ts
@@ -30,6 +30,10 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
              <button id="btn-next-month">&gt;</button>
           </div>
         </div>
+        <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
+          <button id="btn-zoom-in">+</button>
+          <button id="btn-zoom-out">-</button>
+        </div>
         <div class="tm-content" id="tm-content-area">
           <div class="tm-calendar-grid" id="tm-calendar"></div>
           <div class="tm-timeline-view hidden" id="tm-timeline"></div>

--- a/src/template.ts
+++ b/src/template.ts
@@ -30,8 +30,8 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
              <button id="btn-next-month">&gt;</button>
           </div>
           <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
-            <button id="btn-zoom-out">-</button>
-            <button id="btn-zoom-in">+</button>
+            <button id="btn-zoom-out" title="Zoom Out">-</button>
+            <button id="btn-zoom-in" title="Zoom In">+</button>
           </div>
         </div>
         <div class="tm-content" id="tm-content-area">

--- a/src/test/suite/template.test.ts
+++ b/src/test/suite/template.test.ts
@@ -1,0 +1,45 @@
+import * as assert from 'assert';
+import { getWebviewHtml } from '../../template';
+
+suite('Template Test Suite', () => {
+  function getHtml(): string {
+    const fakeUri = { toString: () => 'vscode-resource://fake/script.js' } as any;
+    const fakeStyles = { toString: () => 'vscode-resource://fake/style.css' } as any;
+    return getWebviewHtml(fakeUri, fakeStyles, 'vscode-resource:');
+  }
+
+  test('template contains zoom-in button', () => {
+    const html = getHtml();
+    assert.ok(html.includes('id="btn-zoom-in"'), 'template should include a zoom-in button with id="btn-zoom-in"');
+  });
+
+  test('template contains zoom-out button', () => {
+    const html = getHtml();
+    assert.ok(html.includes('id="btn-zoom-out"'), 'template should include a zoom-out button with id="btn-zoom-out"');
+  });
+
+  test('zoom controls are inside tm-zoom-controls container', () => {
+    const html = getHtml();
+    assert.ok(html.includes('tm-zoom-controls'), 'template should include tm-zoom-controls container');
+    const zoomStart = html.indexOf('tm-zoom-controls');
+    const zoomSection = html.slice(zoomStart, zoomStart + 200);
+    assert.ok(zoomSection.includes('btn-zoom-in'), 'zoom controls container should include zoom-in button');
+    assert.ok(zoomSection.includes('btn-zoom-out'), 'zoom controls container should include zoom-out button');
+  });
+
+  test('zoom-in button label is +', () => {
+    const html = getHtml();
+    const zoomInIdx = html.indexOf('id="btn-zoom-in"');
+    assert.ok(zoomInIdx !== -1, 'btn-zoom-in should exist');
+    const snippet = html.slice(zoomInIdx, zoomInIdx + 60);
+    assert.ok(snippet.includes('+'), 'zoom-in button should have + label');
+  });
+
+  test('zoom-out button label is -', () => {
+    const html = getHtml();
+    const zoomOutIdx = html.indexOf('id="btn-zoom-out"');
+    assert.ok(zoomOutIdx !== -1, 'btn-zoom-out should exist');
+    const snippet = html.slice(zoomOutIdx, zoomOutIdx + 60);
+    assert.ok(snippet.includes('-'), 'zoom-out button should have - label');
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #51

## 概要
タイムラインビューにズームイン（`+`）・ズームアウト（`-`）ボタンを追加した。既存の `Ctrl + ホイール` によるズーム操作は引き続き有効。

## 変更内容
- `src/template.ts`: ヘッダー下部に `tm-zoom-controls` コンテナと `btn-zoom-in` / `btn-zoom-out` ボタンを追加
- `media/main.js`: ズームボタンのDOM参照・クリックイベントを追加。タイムラインビュー切り替え時に表示/非表示を制御
- `media/style.css`: ズームコントロールのスタイルを追加
- `src/test/suite/template.test.ts`: テンプレートHTMLにズームボタンが含まれることを検証するテストを追加

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した
- [x] `npm run lint` および `npm run test:unit` がすべてパスすることを確認した（77 tests passing）

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| ズームは `Ctrl + ホイール` のみ | タイムラインビューのヘッダー下に `+` / `-` ボタンが表示される |

## 備考・次やること
なし