### PR TITLE
feat: 月表示アイテムをバンド形式にコンパクト化しガントバンドにタグ表示を追加

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -104,6 +104,15 @@
     return 'var(--tm-accent)';
   }
 
+  /** Build HTML for a list of tag pills */
+  function createTagPillsHtml(tags, tagColorsMap) {
+    if (!tags || tags.length === 0) return '';
+    return tags.map(t => {
+      const color = getTagColor(t, tagColorsMap);
+      return `<span class="tm-tag" style="background-color: ${color}">${escapeHtml(t)}</span>`;
+    }).join('');
+  }
+
   /** Escape special HTML characters to prevent XSS when embedding user content */
   function escapeHtml(str) {
     return str
@@ -394,12 +403,7 @@
     });
 
     const renderItem = (item) => {
-      const tagsHtml = (item.tags && item.tags.length > 0)
-        ? item.tags.map(t => {
-          const color = getTagColor(t, tagColorsMap);
-          return `<span class="tm-tag" style="background-color: ${color}">${escapeHtml(t)}</span>`;
-        }).join('')
-        : '';
+      const tagsHtml = createTagPillsHtml(item.tags, tagColorsMap);
 
       const cbHtml = item.type === 'task' ? '<span class="tm-checkbox"></span>' : '';
       const timeHtml = itemHasTime(item) ? `<span class="tm-time">${item.time}</span>` : '';

--- a/media/main.js
+++ b/media/main.js
@@ -888,7 +888,7 @@
 
     // Label (outside bar, to the right)
     const progText = entity.tasksTotal > 0 ? ` [${entity.tasksDone}/${entity.tasksTotal}]` : '';
-    container.appendChild(createGanttLabel(entity.name + progText, left + width, yOffset));
+    container.appendChild(createGanttLabel(entity.name + progText, left + width, yOffset, entity.tags, currentTaskMarkData.tagColors));
   }
 
   function renderStandaloneBars(container, entity, startDate, pxPerMs, yOffset, bgColor) {
@@ -910,7 +910,7 @@
       container.appendChild(bar);
 
       // Label (outside bar, to the right)
-      container.appendChild(createGanttLabel(entity.name, left + width, yOffset));
+      container.appendChild(createGanttLabel(entity.name, left + width, yOffset, entity.tags, currentTaskMarkData.tagColors));
     });
   }
 
@@ -965,13 +965,26 @@
     return bar;
   }
 
-  /** Create a label element positioned outside the bar */
-  function createGanttLabel(text, leftPx, yOffset) {
+  /** Create a label element positioned outside the bar, optionally with tag pills */
+  function createGanttLabel(text, leftPx, yOffset, tags, tagColorsMap) {
     const label = document.createElement('span');
     label.className = 'tm-gantt-bar-label';
     label.style.left = (leftPx + GANTT_LABEL_OFFSET_X) + 'px';
     label.style.top = (yOffset + GANTT_LABEL_OFFSET_Y) + 'px';
-    label.textContent = text;
+
+    const textNode = document.createElement('span');
+    textNode.className = 'tm-gantt-bar-label-text';
+    textNode.textContent = text;
+    label.appendChild(textNode);
+
+    const pillsHtml = createTagPillsHtml(tags, tagColorsMap);
+    if (pillsHtml) {
+      const pills = document.createElement('span');
+      pills.className = 'tm-gantt-bar-label-tags';
+      pills.innerHTML = pillsHtml;
+      label.appendChild(pills);
+    }
+
     return label;
   }
 

--- a/media/main.js
+++ b/media/main.js
@@ -446,7 +446,7 @@
 
         outHtml += `<div class="${classNames}" style="border-left-color: ${borderColor}">
           <span class="tm-checkbox"></span>
-          <div class="tm-item-body"><span class="tm-item-text"><strong>${doneCount}/${totalCount}</strong> ${titleFallback}</span></div>
+          <div class="tm-item-body"><span class="tm-time">${doneCount}/${totalCount}</span> <span class="tm-item-text">${titleFallback}</span></div>
         </div>`;
       }
       return outHtml;

--- a/media/main.js
+++ b/media/main.js
@@ -407,12 +407,13 @@
 
       const cbHtml = item.type === 'task' ? '<span class="tm-checkbox"></span>' : '';
       const timeHtml = itemHasTime(item) ? `<span class="tm-time">${item.time}</span>` : '';
-      const classNames = `tm-item ${item.type} ${item.status || ''}`;
+      const compactClass = isMonthly ? ' compact' : '';
+      const classNames = `tm-item ${item.type} ${item.status || ''}${compactClass}`;
       const borderColor = getItemBorderColor(item.tags, tagColorsMap);
 
       return `<div class="${classNames}" style="border-left-color: ${borderColor}">
         ${cbHtml}
-        <div>${timeHtml} ${escapeHtml(item.text)} ${tagsHtml}</div>
+        <div class="tm-item-body">${timeHtml} <span class="tm-item-text">${escapeHtml(item.text)}</span> ${tagsHtml}</div>
       </div>`;
     };
 
@@ -441,11 +442,11 @@
         const totalCount = tasks.length;
         const isAllDone = doneCount === totalCount;
         const borderColor = getGroupBorderColor(gName, itemList);
-        const classNames = `tm-item task ${isAllDone ? 'done' : ''}`;
+        const classNames = `tm-item task compact ${isAllDone ? 'done' : ''}`;
 
         outHtml += `<div class="${classNames}" style="border-left-color: ${borderColor}">
           <span class="tm-checkbox"></span>
-          <div><strong>${doneCount}/${totalCount}</strong> ${titleFallback}</div>
+          <div class="tm-item-body"><span class="tm-item-text"><strong>${doneCount}/${totalCount}</strong> ${titleFallback}</span></div>
         </div>`;
       }
       return outHtml;

--- a/media/style.css
+++ b/media/style.css
@@ -708,6 +708,20 @@ body {
   font-weight: bold;
   white-space: nowrap;
   pointer-events: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tm-gantt-bar-label-tags {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.tm-gantt-bar-label-tags .tm-tag {
+  margin-left: 0;
+  line-height: 1.4;
 }
 
 /* Child rows (group task members) */

--- a/media/style.css
+++ b/media/style.css
@@ -498,6 +498,69 @@ body {
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
+/* ─── Compact Items (Monthly View) ──────────────────────────── */
+.tm-item.compact {
+  font-size: 12px;
+  padding: 2px 6px;
+  gap: 4px;
+  align-items: center;
+  min-width: 0;
+}
+
+.tm-item.compact .tm-item-body {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.tm-item.compact .tm-item-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tm-item.compact .tm-time {
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.tm-item.compact .tm-tag {
+  flex-shrink: 0;
+  padding: 1px 5px;
+  font-size: 10px;
+  margin-left: 0;
+}
+
+.tm-item.compact .tm-checkbox {
+  width: 12px;
+  height: 12px;
+  margin-top: 0;
+}
+
+.tm-item.compact.task.done .tm-checkbox::after {
+  top: -3px;
+  left: 0;
+  font-size: 11px;
+}
+
+.tm-calendar-grid.monthly .tm-items-list {
+  gap: 2px;
+}
+
+.tm-calendar-grid.monthly .tm-group-box {
+  padding: 4px 6px;
+  margin: 2px 0;
+}
+
+.tm-calendar-grid.monthly .tm-group-title {
+  font-size: 11px;
+  margin-bottom: 2px;
+}
+
 /* ─── Gantt / Timeline View ─────────────────────────────────── */
 .tm-gantt-view {
   width: 100%;


### PR DESCRIPTION
## 関連Issue
Closes #75

## 概要
月表示ではアイテム 1 件あたりの高さが大きく、件数が増えるとセルが縦に伸びて月全体の俯瞰が難しくなっていた。月表示の各アイテムをガントチャートのグループバンドと同程度の細いバンド形式に変更し、「月全体を一目で把握する」本来の役割を取り戻す。あわせて、ガントチャートのグループバンド・単体バンド側にもタグピルを表示し、両ビュー間のデザインを統一した。

## 変更内容
- 月表示の `.tm-item` に `compact` クラスを付与し、高さ・余白・フォントをガントバンド相当まで縮小。本文を `.tm-item-text` でラップして長いタイトルを `text-overflow: ellipsis` で省略。タグは `flex-shrink: 0` で末尾に常時表示。
- 月表示のグループボックス・タスク集約行 (`1/3 Tasks`) にも同じコンパクトスタイルを適用。週・日表示の見た目は従来どおり。
- ガントチャートの `renderGroupBar` / `renderStandaloneBars` から `createGanttLabel` に `entity.tags` を渡し、ラベル横にタグピルを表示。
- `createTagPillsHtml` ヘルパーを切り出し、月表示とガントで同じタグピル生成ロジックを共用。

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] `npm run lint` がエラーなく通ることを確認した
- [x] `npm run test:unit` が 78 件すべてパスすることを確認した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| 月表示: 各アイテムが高く、件数が増えるとセルが縦に長くなる | 月表示: バンド形式でコンパクト、タイトル省略、タグは常時表示 |
| ガント: バンドのラベルにタグ表示なし | ガント: ラベル横にタグピル表示、月表示とデザインが統一 |

## 備考・次やること
- `media/` 配下の webview スクリプトは jsdom テスト基盤がないため、レイアウト面はデバッグ実行での手動検証に依存。`entity.tags` の生成ロジックは既存 `gantt.test.ts` で網羅済み。
- グループ展開時の子タスクラベルへのタグ表示は今回は対象外（必要なら別 Issue で検討）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)