### PR TITLE
feat: ビューからタスク完了をトグル可能にする

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -267,7 +267,8 @@
     render();
   });
 
-  viewCalendar?.addEventListener('dblclick', (e) => {
+  viewCalendar?.addEventListener('click', (e) => {
+    if (e.target.closest('.tm-checkbox[data-raw-line]')) return;
     const wrap = e.target.closest('.clickable-date');
     if (wrap && wrap.dataset.date) {
       currentDate = parseLocalDate(wrap.dataset.date);
@@ -509,10 +510,7 @@
       dStr ? 'clickable-date' : ''
     ].filter(Boolean).join(' ');
 
-    if (dStr) {
-      el.dataset.date = dStr;
-      el.title = 'Double-click to view daily';
-    }
+    if (dStr) el.dataset.date = dStr;
     if (dayNo !== '') {
       el.innerHTML = `<div class="tm-cal-date-wrap"><span class="tm-cal-date">${dayNo}</span></div>`;
     }

--- a/media/main.js
+++ b/media/main.js
@@ -267,7 +267,7 @@
     render();
   });
 
-  viewCalendar?.addEventListener('click', (e) => {
+  viewCalendar?.addEventListener('dblclick', (e) => {
     const wrap = e.target.closest('.clickable-date');
     if (wrap && wrap.dataset.date) {
       currentDate = parseLocalDate(wrap.dataset.date);
@@ -509,7 +509,10 @@
       dStr ? 'clickable-date' : ''
     ].filter(Boolean).join(' ');
 
-    if (dStr) el.dataset.date = dStr;
+    if (dStr) {
+      el.dataset.date = dStr;
+      el.title = 'Double-click to view daily';
+    }
     if (dayNo !== '') {
       el.innerHTML = `<div class="tm-cal-date-wrap"><span class="tm-cal-date">${dayNo}</span></div>`;
     }

--- a/media/main.js
+++ b/media/main.js
@@ -29,6 +29,9 @@
   let initialScrollL = 0;
   let initialScrollT = 0;
 
+  // ─── VS Code API ─────────────────────────────────────────────
+  const vscode = acquireVsCodeApi();
+
   // ─── DOM References ──────────────────────────────────────────
   const errorBanner = document.getElementById('tm-parse-error-banner');
   const warningBanner = document.getElementById('tm-warning-banner');
@@ -207,6 +210,16 @@
         warningBanner.classList.add('hidden');
       }
     }
+  });
+
+  // ─── Checkbox Toggle ─────────────────────────────────────────
+
+  document.addEventListener('click', event => {
+    const cb = event.target.closest('.tm-checkbox[data-raw-line]');
+    if (!cb || !currentUri) return;
+    const rawLine = Number(cb.dataset.rawLine);
+    if (!Number.isInteger(rawLine) || rawLine < 0) return;
+    vscode.postMessage({ type: 'toggleTask', uri: currentUri, rawLine });
   });
 
   // ─── UI State Management ─────────────────────────────────────
@@ -405,7 +418,9 @@
     const renderItem = (item) => {
       const tagsHtml = createTagPillsHtml(item.tags, tagColorsMap);
 
-      const cbHtml = item.type === 'task' ? '<span class="tm-checkbox"></span>' : '';
+      const cbHtml = item.type === 'task'
+        ? `<span class="tm-checkbox" data-raw-line="${item.rawLine}"></span>`
+        : '';
       const timeHtml = itemHasTime(item) ? `<span class="tm-time">${item.time}</span>` : '';
       const compactClass = isMonthly ? ' compact' : '';
       const classNames = `tm-item ${item.type} ${item.status || ''}${compactClass}`;

--- a/media/main.js
+++ b/media/main.js
@@ -219,7 +219,9 @@
     if (!cb || !currentUri) return;
     const rawLine = Number(cb.dataset.rawLine);
     if (!Number.isInteger(rawLine) || rawLine < 0) return;
-    vscode.postMessage({ type: 'toggleTask', uri: currentUri, rawLine });
+    const sourceLine = cb.dataset.sourceLine;
+    if (typeof sourceLine !== 'string') return;
+    vscode.postMessage({ type: 'toggleTask', uri: currentUri, rawLine, sourceLine });
   });
 
   // ─── UI State Management ─────────────────────────────────────
@@ -420,7 +422,7 @@
       const tagsHtml = createTagPillsHtml(item.tags, tagColorsMap);
 
       const cbHtml = item.type === 'task'
-        ? `<span class="tm-checkbox" data-raw-line="${item.rawLine}"></span>`
+        ? `<span class="tm-checkbox" data-raw-line="${item.rawLine}" data-source-line="${escapeHtml(item.sourceLine)}"></span>`
         : '';
       const timeHtml = itemHasTime(item) ? `<span class="tm-time">${item.time}</span>` : '';
       const compactClass = isMonthly ? ' compact' : '';

--- a/media/style.css
+++ b/media/style.css
@@ -351,6 +351,7 @@ body {
 
 .clickable-date {
   cursor: pointer;
+  user-select: none;
 }
 
 .clickable-date:hover .tm-cal-date {

--- a/media/style.css
+++ b/media/style.css
@@ -351,7 +351,6 @@ body {
 
 .clickable-date {
   cursor: pointer;
-  user-select: none;
 }
 
 .clickable-date:hover .tm-cal-date {

--- a/media/style.css
+++ b/media/style.css
@@ -472,6 +472,10 @@ body {
   position: relative;
 }
 
+.tm-checkbox[data-raw-line] {
+  cursor: pointer;
+}
+
 .tm-item.task.done .tm-checkbox::after {
   content: '✓';
   position: absolute;

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -138,6 +138,7 @@ export class TaskmarkPanel {
       edit.replace(uri, line.range, toggled);
       const applied = await vscode.workspace.applyEdit(edit);
       if (applied) {
+        this._debouncedUpdateFromDocument.cancel();
         this.updateFromDocument(document);
       } else {
         vscode.window.showErrorMessage(

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -139,7 +139,8 @@ export class TaskmarkPanel {
       const applied = await vscode.workspace.applyEdit(edit);
       if (applied) {
         this._debouncedUpdateFromDocument.cancel();
-        this.updateFromDocument(document);
+        const latest = await vscode.workspace.openTextDocument(uri);
+        this.updateFromDocument(latest);
       } else {
         vscode.window.showErrorMessage(
           'TaskMark: Failed to toggle task. The file may be read-only or locked by another process.'

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -7,15 +7,9 @@ import {
   TaskMarkUpdateMessage,
   TaskMarkErrorMessage,
   ToggleTaskMessage,
-  toggleCheckboxInLine
+  toggleCheckboxInLine,
+  resolveToggleTargetLineIndex
 } from './messages';
-
-export {
-  TaskMarkUpdateMessage,
-  TaskMarkErrorMessage,
-  ToggleTaskMessage,
-  toggleCheckboxInLine
-};
 
 export class TaskmarkPanel {
   public static currentPanel: TaskmarkPanel | undefined;
@@ -115,21 +109,38 @@ export class TaskmarkPanel {
     const msg = message as { type?: unknown };
     if (msg.type === 'toggleTask') {
       const toggle = message as ToggleTaskMessage;
-      if (typeof toggle.uri !== 'string' || typeof toggle.rawLine !== 'number') {
+      if (
+        typeof toggle.uri !== 'string' ||
+        typeof toggle.rawLine !== 'number' ||
+        typeof toggle.sourceLine !== 'string'
+      ) {
         return;
       }
-      void this.toggleTaskInDocument(toggle.uri, toggle.rawLine);
+      void this.toggleTaskInDocument(toggle.uri, toggle.rawLine, toggle.sourceLine);
     }
   }
 
-  private async toggleTaskInDocument(uriString: string, rawLine: number): Promise<void> {
+  private async toggleTaskInDocument(
+    uriString: string,
+    rawLine: number,
+    sourceLine: string
+  ): Promise<void> {
     try {
       const uri = vscode.Uri.parse(uriString);
       const document = await vscode.workspace.openTextDocument(uri);
-      if (rawLine < 0 || rawLine >= document.lineCount) {
+      const resolved = resolveToggleTargetLineIndex(
+        document.lineCount,
+        i => document.lineAt(i).text,
+        rawLine,
+        sourceLine
+      );
+      if (resolved === null) {
+        vscode.window.showInformationMessage(
+          'TaskMark: That task no longer matches the file (it may have been edited). Open TaskMark again or toggle from the editor.'
+        );
         return;
       }
-      const line = document.lineAt(rawLine);
+      const line = document.lineAt(resolved);
       const toggled = toggleCheckboxInLine(line.text);
       if (toggled === null || toggled === line.text) {
         return;

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -139,9 +139,15 @@ export class TaskmarkPanel {
       const applied = await vscode.workspace.applyEdit(edit);
       if (applied) {
         this.updateFromDocument(document);
+      } else {
+        vscode.window.showErrorMessage(
+          'TaskMark: Failed to toggle task. The file may be read-only or locked by another process.'
+        );
       }
     } catch (e) {
       console.error('TaskMark toggleTask error', e);
+      const detail = e instanceof Error ? e.message : String(e);
+      vscode.window.showErrorMessage(`TaskMark: Failed to toggle task. ${detail}`);
     }
   }
 

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -139,8 +139,7 @@ export class TaskmarkPanel {
       const applied = await vscode.workspace.applyEdit(edit);
       if (applied) {
         this._debouncedUpdateFromDocument.cancel();
-        const latest = await vscode.workspace.openTextDocument(uri);
-        this.updateFromDocument(latest);
+        this.updateFromDocument(document);
       } else {
         vscode.window.showErrorMessage(
           'TaskMark: Failed to toggle task. The file may be read-only or locked by another process.'

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -1,21 +1,21 @@
 import * as vscode from 'vscode';
-import { parseTmd, TaskMarkData, VALID_CSS_COLOR_REGEX } from './parser';
-import { buildGanttEntities, GanttData } from './gantt';
+import { parseTmd, VALID_CSS_COLOR_REGEX } from './parser';
+import { buildGanttEntities } from './gantt';
 import { getWebviewHtml } from './template';
 import { debounce, DebouncedFn } from './utils/debounce';
+import {
+  TaskMarkUpdateMessage,
+  TaskMarkErrorMessage,
+  ToggleTaskMessage,
+  toggleCheckboxInLine
+} from './messages';
 
-export interface TaskMarkUpdateMessage {
-  type: 'update';
-  uri: string;
-  data: TaskMarkData;
-  ganttData: GanttData;
-  warnings: string[];
-}
-
-export interface TaskMarkErrorMessage {
-  type: 'parseError';
-  message: string;
-}
+export {
+  TaskMarkUpdateMessage,
+  TaskMarkErrorMessage,
+  ToggleTaskMessage,
+  toggleCheckboxInLine
+};
 
 export class TaskmarkPanel {
   public static currentPanel: TaskmarkPanel | undefined;
@@ -100,6 +100,49 @@ export class TaskmarkPanel {
       null,
       this._disposables
     );
+
+    this._panel.webview.onDidReceiveMessage(
+      msg => this.handleWebviewMessage(msg),
+      null,
+      this._disposables
+    );
+  }
+
+  private handleWebviewMessage(message: unknown): void {
+    if (!message || typeof message !== 'object') {
+      return;
+    }
+    const msg = message as { type?: unknown };
+    if (msg.type === 'toggleTask') {
+      const toggle = message as ToggleTaskMessage;
+      if (typeof toggle.uri !== 'string' || typeof toggle.rawLine !== 'number') {
+        return;
+      }
+      void this.toggleTaskInDocument(toggle.uri, toggle.rawLine);
+    }
+  }
+
+  private async toggleTaskInDocument(uriString: string, rawLine: number): Promise<void> {
+    try {
+      const uri = vscode.Uri.parse(uriString);
+      const document = await vscode.workspace.openTextDocument(uri);
+      if (rawLine < 0 || rawLine >= document.lineCount) {
+        return;
+      }
+      const line = document.lineAt(rawLine);
+      const toggled = toggleCheckboxInLine(line.text);
+      if (toggled === null || toggled === line.text) {
+        return;
+      }
+      const edit = new vscode.WorkspaceEdit();
+      edit.replace(uri, line.range, toggled);
+      const applied = await vscode.workspace.applyEdit(edit);
+      if (applied) {
+        this.updateFromDocument(document);
+      }
+    } catch (e) {
+      console.error('TaskMark toggleTask error', e);
+    }
   }
 
   private updateFromActiveEditor() {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,4 +1,4 @@
-import { TaskMarkData, TASK_LINE_PREFIX_SRC } from './parser';
+import { TaskMarkData, TASK_LINE_PREFIX_NC } from './parser';
 import { GanttData } from './gantt';
 
 export interface TaskMarkUpdateMessage {
@@ -22,28 +22,31 @@ export interface ToggleTaskMessage {
   sourceLine: string;
 }
 
-// Anchored to the start of the line and built from the same
-// TASK_LINE_PREFIX_SRC as parser.ts ITEM_REGEX, so that only the leading
-// status checkbox of a line that parser would recognise as a task is
-// ever matched. Leading indentation is intentionally rejected because
-// parser.ts ITEM_REGEX does not accept indented task lines either.
-// Capture layout:
-//   1: full prefix up to and including '[' and optional inner space
-//   2: group marker '>\s*' (nested within group 1)
-//   3: bullet '-'         (nested within group 1)
-//   4: the checkbox character (' ' | 'x' | 'X')
-//   5: optional inner space + ']'
-const CHECKBOX_REGEX = new RegExp(
-  `^(${TASK_LINE_PREFIX_SRC}\\s*\\[\\s*)([ xX])(\\s*\\])`
+// Leading line prefix matches parser ITEM_REGEX (TASK_LINE_PREFIX_NC + \s*).
+// Bracket interior mirrors ITEM: \[\s*([xX\s])\s*\] — one mark character
+// with flexible inner whitespace. Only that mark is swapped ('x' todo→done,
+// ASCII space done→todo) so surrounding spaces inside the brackets are kept.
+const CHECKBOX_LINE_REGEX = new RegExp(
+  `^(${TASK_LINE_PREFIX_NC}\\s*)(\\[)(\\s*)([xX\\s])(\\s*)(\\])`
 );
 
 export function toggleCheckboxInLine(line: string): string | null {
-  const match = CHECKBOX_REGEX.exec(line);
+  const match = CHECKBOX_LINE_REGEX.exec(line);
   if (!match) {
     return null;
   }
-  const toggled = match[4] === ' ' ? 'x' : ' ';
-  return line.replace(CHECKBOX_REGEX, `$1${toggled}$5`);
+  const mark = match[4];
+  const isDone = mark.trim().toLowerCase() === 'x';
+  const newMark = isDone ? ' ' : 'x';
+  return (
+    match[1] +
+    match[2] +
+    match[3] +
+    newMark +
+    match[5] +
+    match[6] +
+    line.slice(match[0].length)
+  );
 }
 
 /**

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -22,9 +22,9 @@ export interface ToggleTaskMessage {
 
 // Anchored to the start of the line and built from the same
 // TASK_LINE_PREFIX_SRC as parser.ts ITEM_REGEX, so that only the leading
-// status checkbox is ever matched — never a bracketed token that happens
-// to appear inside the task text — and the prefix definition stays in
-// sync with the parser.
+// status checkbox of a line that parser would recognise as a task is
+// ever matched. Leading indentation is intentionally rejected because
+// parser.ts ITEM_REGEX does not accept indented task lines either.
 // Capture layout:
 //   1: full prefix up to and including '[' and optional inner space
 //   2: group marker '>\s*' (nested within group 1)
@@ -32,7 +32,7 @@ export interface ToggleTaskMessage {
 //   4: the checkbox character (' ' | 'x' | 'X')
 //   5: optional inner space + ']'
 const CHECKBOX_REGEX = new RegExp(
-  `^(\\s*${TASK_LINE_PREFIX_SRC}\\s*\\[\\s*)([ xX])(\\s*\\])`
+  `^(${TASK_LINE_PREFIX_SRC}\\s*\\[\\s*)([ xX])(\\s*\\])`
 );
 
 export function toggleCheckboxInLine(line: string): string | null {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,4 +1,4 @@
-import { TaskMarkData } from './parser';
+import { TaskMarkData, TASK_LINE_PREFIX_SRC } from './parser';
 import { GanttData } from './gantt';
 
 export interface TaskMarkUpdateMessage {
@@ -20,17 +20,26 @@ export interface ToggleTaskMessage {
   rawLine: number;
 }
 
-// Anchored to the start of the line, matching the same prefix shape as
-// parser.ts ITEM_REGEX (optional indent, optional group marker, optional
-// bullet) so only the status checkbox is touched — never a bracketed token
-// that appears inside the task text.
-const CHECKBOX_REGEX = /^(\s*(?:>\s*)?(?:-\s*)?\[\s*)([ xX])(\s*\])/;
+// Anchored to the start of the line and built from the same
+// TASK_LINE_PREFIX_SRC as parser.ts ITEM_REGEX, so that only the leading
+// status checkbox is ever matched — never a bracketed token that happens
+// to appear inside the task text — and the prefix definition stays in
+// sync with the parser.
+// Capture layout:
+//   1: full prefix up to and including '[' and optional inner space
+//   2: group marker '>\s*' (nested within group 1)
+//   3: bullet '-'         (nested within group 1)
+//   4: the checkbox character (' ' | 'x' | 'X')
+//   5: optional inner space + ']'
+const CHECKBOX_REGEX = new RegExp(
+  `^(\\s*${TASK_LINE_PREFIX_SRC}\\s*\\[\\s*)([ xX])(\\s*\\])`
+);
 
 export function toggleCheckboxInLine(line: string): string | null {
   const match = CHECKBOX_REGEX.exec(line);
   if (!match) {
     return null;
   }
-  const toggled = match[2] === ' ' ? 'x' : ' ';
-  return line.replace(CHECKBOX_REGEX, `$1${toggled}$3`);
+  const toggled = match[4] === ' ' ? 'x' : ' ';
+  return line.replace(CHECKBOX_REGEX, `$1${toggled}$5`);
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -20,13 +20,17 @@ export interface ToggleTaskMessage {
   rawLine: number;
 }
 
-const CHECKBOX_REGEX = /\[([ xX])\]/;
+// Anchored to the start of the line, matching the same prefix shape as
+// parser.ts ITEM_REGEX (optional indent, optional group marker, optional
+// bullet) so only the status checkbox is touched — never a bracketed token
+// that appears inside the task text.
+const CHECKBOX_REGEX = /^(\s*(?:>\s*)?(?:-\s*)?\[\s*)([ xX])(\s*\])/;
 
 export function toggleCheckboxInLine(line: string): string | null {
   const match = CHECKBOX_REGEX.exec(line);
   if (!match) {
     return null;
   }
-  const toggled = match[1] === ' ' ? 'x' : ' ';
-  return line.replace(CHECKBOX_REGEX, `[${toggled}]`);
+  const toggled = match[2] === ' ' ? 'x' : ' ';
+  return line.replace(CHECKBOX_REGEX, `$1${toggled}$3`);
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -18,6 +18,8 @@ export interface ToggleTaskMessage {
   type: 'toggleTask';
   uri: string;
   rawLine: number;
+  /** Full document line as captured when the panel last parsed the file. */
+  sourceLine: string;
 }
 
 // Anchored to the start of the line and built from the same
@@ -42,4 +44,47 @@ export function toggleCheckboxInLine(line: string): string | null {
   }
   const toggled = match[4] === ' ' ? 'x' : ' ';
   return line.replace(CHECKBOX_REGEX, `$1${toggled}$5`);
+}
+
+/**
+ * Resolves which zero-based line index to toggle when `rawLine` may be stale
+ * (e.g. the document changed since the webview rendered). Uses exact line text
+ * equality with the value captured at parse time. When multiple lines match,
+ * picks the index closest to `rawLine`, breaking ties toward a lower line number.
+ */
+export function resolveToggleTargetLineIndex(
+  lineCount: number,
+  getLineText: (index: number) => string,
+  rawLine: number,
+  sourceLine: string
+): number | null {
+  if (lineCount <= 0 || rawLine < 0) {
+    return null;
+  }
+  if (rawLine < lineCount && getLineText(rawLine) === sourceLine) {
+    return rawLine;
+  }
+  const matches: number[] = [];
+  for (let j = 0; j < lineCount; j++) {
+    if (getLineText(j) === sourceLine) {
+      matches.push(j);
+    }
+  }
+  if (matches.length === 0) {
+    return null;
+  }
+  if (matches.length === 1) {
+    return matches[0];
+  }
+  let best = matches[0];
+  let bestDist = Math.abs(best - rawLine);
+  for (let k = 1; k < matches.length; k++) {
+    const m = matches[k];
+    const d = Math.abs(m - rawLine);
+    if (d < bestDist || (d === bestDist && m < best)) {
+      best = m;
+      bestDist = d;
+    }
+  }
+  return best;
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,32 @@
+import { TaskMarkData } from './parser';
+import { GanttData } from './gantt';
+
+export interface TaskMarkUpdateMessage {
+  type: 'update';
+  uri: string;
+  data: TaskMarkData;
+  ganttData: GanttData;
+  warnings: string[];
+}
+
+export interface TaskMarkErrorMessage {
+  type: 'parseError';
+  message: string;
+}
+
+export interface ToggleTaskMessage {
+  type: 'toggleTask';
+  uri: string;
+  rawLine: number;
+}
+
+const CHECKBOX_REGEX = /\[([ xX])\]/;
+
+export function toggleCheckboxInLine(line: string): string | null {
+  const match = CHECKBOX_REGEX.exec(line);
+  if (!match) {
+    return null;
+  }
+  const toggled = match[1] === ' ' ? 'x' : ' ';
+  return line.replace(CHECKBOX_REGEX, `[${toggled}]`);
+}

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -41,6 +41,8 @@ const DATE_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})(?:\s*:\s*(\d{4}-\d{1,2}-\d{1,2}
 const GROUP_REGEX = /^>\s*([^-\s].+)$/;
 // Shared with messages.ts toggleCheckboxInLine — modify both together.
 export const TASK_LINE_PREFIX_SRC = '(>\\s*)?(-)?';
+/** Non-capturing form of TASK_LINE_PREFIX_SRC for toggle / search helpers. */
+export const TASK_LINE_PREFIX_NC = '(?:>\\s*)?(?:-)?';
 const ITEM_REGEX = new RegExp(
   `^${TASK_LINE_PREFIX_SRC}\\s*(\\[\\s*([xX\\s])\\s*\\])?\\s*((\\d{1,2}:\\d{1,2})(?:-(\\d{1,2}:\\d{1,2}))?)?\\s*(.*)$`
 );

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -21,6 +21,8 @@ export interface MarkItem {
   id: string;
   type: ItemType;
   text: string;
+  /** Exact document line text at parse time; used to verify toggles after edits. */
+  sourceLine: string;
   time?: string;
   tags: string[];
   status?: TaskStatus;
@@ -252,7 +254,7 @@ export function parseTmd(text: string): ParseResult {
     // 4. Item (schedule or task)
     const itemMatch = rawLine.match(ITEM_REGEX);
     if (itemMatch && itemMatch[2]) {
-      const result = createMarkItem(itemMatch, i, currentDate, currentGroup, currentEndDate);
+      const result = createMarkItem(itemMatch, i, rawLine, currentDate, currentGroup, currentEndDate);
       if (result) {
         data.days[currentDate].items.push(result.item);
         currentGroup = result.newGroup;
@@ -266,6 +268,7 @@ export function parseTmd(text: string): ParseResult {
 function createMarkItem(
   itemMatch: RegExpMatchArray,
   lineIndex: number,
+  sourceLine: string,
   currentDate: string,
   currentGroup: string,
   endDate = '',
@@ -302,6 +305,7 @@ function createMarkItem(
     id: `item-${lineIndex}-${currentDate}`,
     type,
     text: cleaned,
+    sourceLine,
     time: timeString,
     tags,
     status,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -37,7 +37,11 @@ const TAG_COLOR_REGEX = /^#([^\s:]+)\s*:\s*(.+)$/;
 export const VALID_CSS_COLOR_REGEX = /^(?:#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|(?:rgb|hsl)a?\(\s*\d[\d.]*%?(?:\s*[,/\s]\s*\d[\d.]*%?){2,3}\s*\)|[a-zA-Z]{1,30})$/;
 const DATE_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})(?:\s*:\s*(\d{4}-\d{1,2}-\d{1,2}))?/;
 const GROUP_REGEX = /^>\s*([^-\s].+)$/;
-const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{1,2})(?:-(\d{1,2}:\d{1,2}))?)?\s*(.*)$/;
+// Shared with messages.ts toggleCheckboxInLine — modify both together.
+export const TASK_LINE_PREFIX_SRC = '(>\\s*)?(-)?';
+const ITEM_REGEX = new RegExp(
+  `^${TASK_LINE_PREFIX_SRC}\\s*(\\[\\s*([xX\\s])\\s*\\])?\\s*((\\d{1,2}:\\d{1,2})(?:-(\\d{1,2}:\\d{1,2}))?)?\\s*(.*)$`
+);
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
 const TAG_SPLIT_REGEX = /#([^\s#]+)/g;
 const EVERY_REGEX = /^(\d+)(days?|weeks?|months?)$/;

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -1,5 +1,10 @@
 import * as assert from 'assert';
-import { TaskMarkUpdateMessage, TaskMarkErrorMessage } from '../../TaskmarkPanel';
+import {
+  TaskMarkUpdateMessage,
+  TaskMarkErrorMessage,
+  ToggleTaskMessage,
+  toggleCheckboxInLine
+} from '../../messages';
 
 suite('TaskmarkPanel message types', () => {
   test('TaskMarkUpdateMessage has type "update"', () => {
@@ -32,5 +37,56 @@ suite('TaskmarkPanel message types', () => {
     };
     assert.strictEqual(msg.type, 'parseError');
     assert.strictEqual(msg.message, 'unexpected token at line 3');
+  });
+
+  test('ToggleTaskMessage has type "toggleTask" with uri and rawLine', () => {
+    const msg: ToggleTaskMessage = {
+      type: 'toggleTask',
+      uri: 'file:///test.tmd',
+      rawLine: 4
+    };
+    assert.strictEqual(msg.type, 'toggleTask');
+    assert.strictEqual(msg.uri, 'file:///test.tmd');
+    assert.strictEqual(msg.rawLine, 4);
+  });
+});
+
+suite('toggleCheckboxInLine', () => {
+  test('flips unchecked task to checked', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [ ] foo'), '- [x] foo');
+  });
+
+  test('flips checked task to unchecked', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [x] foo'), '- [ ] foo');
+  });
+
+  test('flips uppercase checked task to unchecked', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [X] foo'), '- [ ] foo');
+  });
+
+  test('preserves leading indent and group marker', () => {
+    assert.strictEqual(
+      toggleCheckboxInLine('  > - [ ] nested'),
+      '  > - [x] nested'
+    );
+  });
+
+  test('preserves content after checkbox including time and tags', () => {
+    assert.strictEqual(
+      toggleCheckboxInLine('- [ ] 10:00-11:00 Meeting #work'),
+      '- [x] 10:00-11:00 Meeting #work'
+    );
+  });
+
+  test('returns null for a line with no checkbox', () => {
+    assert.strictEqual(toggleCheckboxInLine('- plain schedule'), null);
+  });
+
+  test('returns null for a date header', () => {
+    assert.strictEqual(toggleCheckboxInLine('# 2026-04-18'), null);
+  });
+
+  test('returns null for an empty line', () => {
+    assert.strictEqual(toggleCheckboxInLine(''), null);
   });
 });

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -3,7 +3,8 @@ import {
   TaskMarkUpdateMessage,
   TaskMarkErrorMessage,
   ToggleTaskMessage,
-  toggleCheckboxInLine
+  toggleCheckboxInLine,
+  resolveToggleTargetLineIndex
 } from '../../messages';
 
 suite('TaskmarkPanel message types', () => {
@@ -39,15 +40,44 @@ suite('TaskmarkPanel message types', () => {
     assert.strictEqual(msg.message, 'unexpected token at line 3');
   });
 
-  test('ToggleTaskMessage has type "toggleTask" with uri and rawLine', () => {
+  test('ToggleTaskMessage has type "toggleTask" with uri, rawLine, and sourceLine', () => {
     const msg: ToggleTaskMessage = {
       type: 'toggleTask',
       uri: 'file:///test.tmd',
-      rawLine: 4
+      rawLine: 4,
+      sourceLine: '- [ ] task'
     };
     assert.strictEqual(msg.type, 'toggleTask');
     assert.strictEqual(msg.uri, 'file:///test.tmd');
     assert.strictEqual(msg.rawLine, 4);
+    assert.strictEqual(msg.sourceLine, '- [ ] task');
+  });
+});
+
+suite('resolveToggleTargetLineIndex', () => {
+  const lines = ['# 2026-01-01', '- [ ] a', '- [ ] b', '- [ ] c'];
+  const get = (i: number) => lines[i];
+
+  test('returns rawLine when the line still matches', () => {
+    assert.strictEqual(resolveToggleTargetLineIndex(lines.length, get, 2, '- [ ] b'), 2);
+  });
+
+  test('relocates when content moved but source line text is unchanged', () => {
+    const shifted = ['intro', '# 2026-01-01', '- [ ] a', '- [ ] b', '- [ ] c'];
+    const g = (i: number) => shifted[i];
+    assert.strictEqual(resolveToggleTargetLineIndex(shifted.length, g, 2, '- [ ] b'), 3);
+  });
+
+  test('returns null when no line matches sourceLine', () => {
+    assert.strictEqual(resolveToggleTargetLineIndex(lines.length, get, 2, '- [ ] gone'), null);
+  });
+
+  test('picks closest index among duplicate matching lines', () => {
+    const dup = ['- [ ] same', 'x', '- [ ] same'];
+    const g = (i: number) => dup[i];
+    assert.strictEqual(resolveToggleTargetLineIndex(dup.length, g, 0, '- [ ] same'), 0);
+    assert.strictEqual(resolveToggleTargetLineIndex(dup.length, g, 1, '- [ ] same'), 0);
+    assert.strictEqual(resolveToggleTargetLineIndex(dup.length, g, 2, '- [ ] same'), 2);
   });
 });
 

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -89,4 +89,26 @@ suite('toggleCheckboxInLine', () => {
   test('returns null for an empty line', () => {
     assert.strictEqual(toggleCheckboxInLine(''), null);
   });
+
+  test('only toggles the leading status checkbox when text contains bracketed content', () => {
+    assert.strictEqual(
+      toggleCheckboxInLine('- [ ] Check the [ ] box'),
+      '- [x] Check the [ ] box'
+    );
+  });
+
+  test('does not toggle a checked checkbox that appears inside text', () => {
+    assert.strictEqual(
+      toggleCheckboxInLine('- [ ] see [x] below'),
+      '- [x] see [x] below'
+    );
+  });
+
+  test('returns null when bracket pair is not at the start of the line', () => {
+    assert.strictEqual(toggleCheckboxInLine('random [ ] text'), null);
+  });
+
+  test('returns null when non-bullet text precedes the checkbox', () => {
+    assert.strictEqual(toggleCheckboxInLine('foo - [ ] bar'), null);
+  });
 });

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -101,6 +101,11 @@ suite('toggleCheckboxInLine', () => {
     );
   });
 
+  test('preserves extra spaces inside brackets (matches ITEM_REGEX split)', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [  ] foo'), '- [ x] foo');
+    assert.strictEqual(toggleCheckboxInLine('- [  x  ] foo'), '- [     ] foo');
+  });
+
   test('returns null for indented task lines (parser does not accept them)', () => {
     assert.strictEqual(toggleCheckboxInLine('  - [ ] indented'), null);
     assert.strictEqual(toggleCheckboxInLine('  > - [ ] indented group'), null);

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -64,11 +64,16 @@ suite('toggleCheckboxInLine', () => {
     assert.strictEqual(toggleCheckboxInLine('- [X] foo'), '- [ ] foo');
   });
 
-  test('preserves leading indent and group marker', () => {
+  test('preserves group marker without indentation', () => {
     assert.strictEqual(
-      toggleCheckboxInLine('  > - [ ] nested'),
-      '  > - [x] nested'
+      toggleCheckboxInLine('> - [ ] grouped'),
+      '> - [x] grouped'
     );
+  });
+
+  test('returns null for indented task lines (parser does not accept them)', () => {
+    assert.strictEqual(toggleCheckboxInLine('  - [ ] indented'), null);
+    assert.strictEqual(toggleCheckboxInLine('  > - [ ] indented group'), null);
   });
 
   test('preserves content after checkbox including time and tags', () => {

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -28,9 +28,11 @@ suite('Parser Test Suite', () => {
     assert.strictEqual(items[0].type, 'task');
     assert.strictEqual(items[0].status, 'todo');
     assert.strictEqual(items[0].text, 'Meeting');
+    assert.strictEqual(items[0].sourceLine, '- [ ] 09:00-10:00 Meeting');
 
     assert.strictEqual(items[1].type, 'schedule');
     assert.strictEqual(items[1].text, 'Schedule item');
+    assert.strictEqual(items[1].sourceLine, '- Schedule item');
   });
 
   test('parseTmd parses @tags block', () => {


### PR DESCRIPTION
## 関連Issue
Closes #32

## 概要
カレンダー/デイリービューに表示されているタスクのチェックボックスをクリックすると、対応する `.tmd` ファイルの `[ ]` ↔ `[x]` を直接書き換えられるようにした。ビューとエディタを往復する必要がなくなり、運用上のストレスを軽減する。

## 変更内容
- WebView → Extension 間に新しいメッセージ `toggleTask` を追加し、`TaskmarkPanel` で `onDidReceiveMessage` を購読
- 該当行は `MarkItem.rawLine` で特定し、`vscode.WorkspaceEdit` でチェックボックス文字のみを置換
- `src/messages.ts` を新設し、メッセージ型と純粋関数 `toggleCheckboxInLine` を切り出して vscode モジュール非依存でユニットテスト可能にした
- WebView 側では `.tm-checkbox` に `data-raw-line` 属性を付与し、`document` への委譲クリックリスナーで `vscode.postMessage` を送信
- インタラクティブなチェックボックスには `cursor: pointer` を付与
- 月次ビューのサマリー（集計）チェックボックスは複数タスクを表すため意図的にトグル対象外

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] `npm run lint` がパスすることを確認した（既存の警告のみ）
- [x] `npm run test:unit` がパスすることを確認した（新規テスト9件含む計87件）

## 備考・次やること
- 月次ビューのサマリーチェックボックス、および Timeline (Gantt) バーからのトグルは本 PR のスコープ外