### PR TITLE
feat: add taskmark.fontSize setting for calendar views

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,14 @@ You can also define global tag colors in your VS Code `settings.json` to reuse t
 
 *Note: Tags defined within a `.tmd` file via the `@tags` block will take precedence over global settings.*
 
+- `taskmark.fontSize`: Font size (in px) applied to the calendar views (Monthly/Weekly/Daily). Default: `14`. Values outside the range `10`–`24` are clamped.
+
+```json
+{
+  "taskmark.fontSize": 16
+}
+```
+
 ---
 
 ## Feedback & Support

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ You can also define global tag colors in your VS Code `settings.json` to reuse t
 
 *Note: Tags defined within a `.tmd` file via the `@tags` block will take precedence over global settings.*
 
-- `taskmark.fontSize`: Font size (in px) applied to the calendar views (Monthly/Weekly/Daily). Default: `14`. Values outside the range `10`–`24` are clamped.
+- `taskmark.fontSize`: Font size (in px) applied to the calendar views (Monthly/Weekly/Daily) and Gantt timeline labels. Default: `14`. Values outside the range `10`–`24` are clamped.
 
 ```json
 {

--- a/media/main.js
+++ b/media/main.js
@@ -11,7 +11,7 @@
   const GANTT_LABEL_OFFSET_Y = 4;
   const GANTT_ZOOM_IN_FACTOR = 1.25;
   const GANTT_ZOOM_OUT_FACTOR = 0.8;
-  const GANTT_DEFAULT_ZOOM = Math.pow(GANTT_ZOOM_IN_FACTOR, 3); // ≈1.95, three zoom-in steps
+  const GANTT_DEFAULT_ZOOM = Math.pow(GANTT_ZOOM_IN_FACTOR, 5); // ≈3.05, five zoom-in steps
 
   // ─── State ───────────────────────────────────────────────────
   let baseView = 'calendar'; // 'calendar' | 'timeline'

--- a/media/main.js
+++ b/media/main.js
@@ -186,6 +186,9 @@
       currentTaskMarkData = message.data;
       currentGanttData = message.ganttData;
       rangeItemIndex = buildRangeItemIndex(currentTaskMarkData);
+      if (typeof message.fontSize === 'number') {
+        document.documentElement.style.setProperty('--tm-font-size', `${message.fontSize}px`);
+      }
       if (errorBanner) {
         errorBanner.textContent = '';
         errorBanner.classList.add('hidden');

--- a/media/main.js
+++ b/media/main.js
@@ -11,6 +11,7 @@
   const GANTT_LABEL_OFFSET_Y = 4;
   const GANTT_ZOOM_IN_FACTOR = 1.25;
   const GANTT_ZOOM_OUT_FACTOR = 0.8;
+  const GANTT_DEFAULT_ZOOM = Math.pow(GANTT_ZOOM_IN_FACTOR, 3); // ≈1.95, three zoom-in steps
 
   // ─── State ───────────────────────────────────────────────────
   let baseView = 'calendar'; // 'calendar' | 'timeline'
@@ -20,7 +21,7 @@
   let currentTaskMarkData = null;
   let currentGanttData = null;
   let rangeItemIndex = null; // Pre-built index: date string -> range items spanning that date
-  let ganttZoom = 1; // 1 = 100px per day
+  let ganttZoom = GANTT_DEFAULT_ZOOM; // 1 = 100px per day
   let expandedGroups = new Set();
   let isPanning = false;
   let hasDragged = false;
@@ -177,7 +178,7 @@
       if (message.uri && message.uri !== currentUri) {
         currentUri = message.uri;
         expandedGroups = new Set();
-        ganttZoom = 1;
+        ganttZoom = GANTT_DEFAULT_ZOOM;
         if (viewTimeline) {
           viewTimeline.scrollLeft = 0;
           viewTimeline.scrollTop = 0;

--- a/media/style.css
+++ b/media/style.css
@@ -608,6 +608,7 @@ body {
   box-sizing: border-box;
   padding: 4px;
   color: var(--tm-fg);
+  font-size: var(--tm-font-size);
 }
 
 .tm-gantt-axis-day.sat-text strong {
@@ -624,7 +625,7 @@ body {
   left: 0;
   width: 100%;
   height: 20px;
-  font-size: 10px;
+  font-size: calc(var(--tm-font-size) - 4px);
   opacity: 0.5;
   border-top: 1px dashed var(--tm-axis-line);
 }
@@ -689,7 +690,7 @@ body {
   position: relative;
   z-index: 2;
   padding: 0 6px;
-  font-size: 9px;
+  font-size: calc(var(--tm-font-size) - 5px);
   color: var(--tm-fg);
   pointer-events: none;
 }
@@ -712,7 +713,7 @@ body {
   position: absolute;
   z-index: 7;
   padding: 0 8px;
-  font-size: 13px;
+  font-size: calc(var(--tm-font-size) - 1px);
   line-height: 32px;
   color: var(--tm-fg);
   font-weight: bold;

--- a/media/style.css
+++ b/media/style.css
@@ -260,8 +260,8 @@ body {
 }
 
 .tm-cell-band {
-  height: 20px;
-  line-height: 20px;
+  height: calc(var(--tm-font-size) + 6px);
+  line-height: calc(var(--tm-font-size) + 6px);
   font-size: calc(var(--tm-font-size) - 3px);
   font-weight: 600;
   overflow: hidden;
@@ -290,7 +290,7 @@ body {
 }
 
 .tm-cell-band-spacer {
-  height: 20px;
+  height: calc(var(--tm-font-size) + 6px);
 }
 
 .tm-calendar-grid.daily {
@@ -381,9 +381,9 @@ body {
   font-size: calc(var(--tm-font-size) + 2px);
   font-weight: 600;
   display: inline-block;
-  width: 24px;
-  height: 24px;
-  line-height: 24px;
+  width: 1.5em;
+  height: 1.5em;
+  line-height: 1.5em;
   text-align: center;
   border-radius: 50%;
   transition: var(--tm-transition);
@@ -541,7 +541,7 @@ body {
 .tm-item.compact .tm-tag {
   flex-shrink: 0;
   padding: 1px 5px;
-  font-size: calc(var(--tm-font-size) - 4px);
+  font-size: max(9px, calc(var(--tm-font-size) - 4px));
   margin-left: 0;
 }
 
@@ -625,7 +625,7 @@ body {
   left: 0;
   width: 100%;
   height: 20px;
-  font-size: calc(var(--tm-font-size) - 4px);
+  font-size: max(9px, calc(var(--tm-font-size) - 4px));
   opacity: 0.5;
   border-top: 1px dashed var(--tm-axis-line);
 }

--- a/media/style.css
+++ b/media/style.css
@@ -690,7 +690,7 @@ body {
   position: relative;
   z-index: 2;
   padding: 0 6px;
-  font-size: calc(var(--tm-font-size) - 5px);
+  font-size: 9px;
   color: var(--tm-fg);
   pointer-events: none;
 }

--- a/media/style.css
+++ b/media/style.css
@@ -214,6 +214,11 @@ body {
   overflow: hidden;
 }
 
+.tm-calendar-grid.monthly {
+  grid-template-rows: max-content;
+  grid-auto-rows: 1fr;
+}
+
 .tm-calendar-grid.weekly {
   grid-template-rows: max-content 1fr;
 }

--- a/media/style.css
+++ b/media/style.css
@@ -19,6 +19,7 @@
   --tm-radius: 8px;
   --tm-transition: all 0.2s ease-in-out;
   --tm-font: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif);
+  --tm-font-size: 14px;
   --tm-sat-color: #3498db;
   --tm-sun-color: #e74c3c;
   --tm-sat-bg: rgba(52, 152, 219, 0.08);
@@ -220,7 +221,7 @@ body {
 .tm-calendar-grid.monthly .tm-day-header,
 .tm-calendar-grid.weekly .tm-day-header {
   background-color: var(--tm-bg);
-  padding: 10px 0 8px;
+  padding: 4px 0 3px;
 }
 
 .tm-calendar-grid.monthly .tm-cal-cell,
@@ -256,7 +257,7 @@ body {
 .tm-cell-band {
   height: 20px;
   line-height: 20px;
-  font-size: 11px;
+  font-size: calc(var(--tm-font-size) - 3px);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -295,12 +296,12 @@ body {
 /* ─── Day Headers ───────────────────────────────────────────── */
 .tm-day-header {
   text-align: center;
-  font-size: 14px;
+  font-size: var(--tm-font-size);
   font-weight: 600;
   text-transform: uppercase;
   color: var(--tm-fg);
   opacity: 0.7;
-  padding-bottom: 8px;
+  padding-bottom: 3px;
 }
 
 .tm-day-header.sat {
@@ -365,19 +366,19 @@ body {
   background: var(--tm-bg);
   width: 100%;
   box-sizing: border-box;
-  padding: 8px;
-  margin-bottom: 4px;
+  padding: 3px 6px;
+  margin-bottom: 2px;
   border-bottom: 1px solid var(--tm-separator);
   flex-shrink: 0;
 }
 
 .tm-cal-date {
-  font-size: 16px;
+  font-size: calc(var(--tm-font-size) + 2px);
   font-weight: 600;
   display: inline-block;
-  width: 28px;
-  height: 28px;
-  line-height: 28px;
+  width: 24px;
+  height: 24px;
+  line-height: 24px;
   text-align: center;
   border-radius: 50%;
   transition: var(--tm-transition);
@@ -437,7 +438,7 @@ body {
 }
 
 .tm-group-title {
-  font-size: 13px;
+  font-size: calc(var(--tm-font-size) - 1px);
   font-weight: bold;
   opacity: 0.7;
   margin-bottom: 6px;
@@ -445,7 +446,7 @@ body {
 }
 
 .tm-item {
-  font-size: 14px;
+  font-size: var(--tm-font-size);
   padding: 8px 10px;
   border-radius: 4px;
   background: var(--tm-item-bg);
@@ -495,7 +496,7 @@ body {
   display: inline-block;
   padding: 2px 6px;
   border-radius: 10px;
-  font-size: 11px;
+  font-size: calc(var(--tm-font-size) - 3px);
   font-weight: 600;
   margin-left: 4px;
   color: #fff;
@@ -504,7 +505,7 @@ body {
 
 /* ─── Compact Items (Monthly View) ──────────────────────────── */
 .tm-item.compact {
-  font-size: 12px;
+  font-size: calc(var(--tm-font-size) - 2px);
   padding: 2px 6px;
   gap: 4px;
   align-items: center;
@@ -528,14 +529,14 @@ body {
 }
 
 .tm-item.compact .tm-time {
-  font-size: 11px;
+  font-size: calc(var(--tm-font-size) - 3px);
   flex-shrink: 0;
 }
 
 .tm-item.compact .tm-tag {
   flex-shrink: 0;
   padding: 1px 5px;
-  font-size: 10px;
+  font-size: calc(var(--tm-font-size) - 4px);
   margin-left: 0;
 }
 
@@ -561,7 +562,7 @@ body {
 }
 
 .tm-calendar-grid.monthly .tm-group-title {
-  font-size: 11px;
+  font-size: calc(var(--tm-font-size) - 3px);
   margin-bottom: 2px;
 }
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,13 @@
           "type": "object",
           "default": {},
           "description": "Custom color mapping for tags (e.g. {\"meeting\": \"#ff0000\"})"
+        },
+        "taskmark.fontSize": {
+          "type": "number",
+          "default": 14,
+          "minimum": 10,
+          "maximum": 24,
+          "description": "Font size (in px) applied to the calendar views (Monthly/Weekly/Daily). Values outside 10–24 are clamped."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
           "default": 14,
           "minimum": 10,
           "maximum": 24,
-          "description": "Font size (in px) applied to the calendar views (Monthly/Weekly/Daily). Values outside 10–24 are clamped."
+          "description": "Font size (in px) applied to the calendar views (Monthly/Weekly/Daily) and Gantt timeline labels. Values outside 10–24 are clamped."
         }
       }
     }

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -8,7 +8,8 @@ import {
   TaskMarkErrorMessage,
   ToggleTaskMessage,
   toggleCheckboxInLine,
-  resolveToggleTargetLineIndex
+  resolveToggleTargetLineIndex,
+  resolveFontSize
 } from './messages';
 
 export class TaskmarkPanel {
@@ -87,7 +88,10 @@ export class TaskmarkPanel {
 
     vscode.workspace.onDidChangeConfiguration(
       e => {
-        if (e.affectsConfiguration('taskmark.tagColors')) {
+        if (
+          e.affectsConfiguration('taskmark.tagColors') ||
+          e.affectsConfiguration('taskmark.fontSize')
+        ) {
           this.updateFromActiveEditor();
         }
       },
@@ -174,7 +178,8 @@ export class TaskmarkPanel {
     try {
       const text = document.getText();
       const { data: parsedData, warnings } = parseTmd(text);
-      const configColors = vscode.workspace.getConfiguration('taskmark').get<Record<string, string>>('tagColors', {});
+      const config = vscode.workspace.getConfiguration('taskmark');
+      const configColors = config.get<Record<string, string>>('tagColors', {});
       for (const [tag, color] of Object.entries(configColors)) {
         if (VALID_CSS_COLOR_REGEX.test(color)) {
           if (!parsedData.tagColors[tag]) {
@@ -184,12 +189,14 @@ export class TaskmarkPanel {
           warnings.push(`Setting tagColors: invalid color '${color}' for tag '${tag}', skipped`);
         }
       }
+      const fontSize = resolveFontSize(config.get<number>('fontSize'));
       const message: TaskMarkUpdateMessage = {
         type: 'update',
         uri: document.uri.toString(),
         data: parsedData,
         ganttData: buildGanttEntities(parsedData),
-        warnings: [...new Set(warnings)]
+        warnings: [...new Set(warnings)],
+        fontSize
       };
       this._panel.webview.postMessage(message);
     } catch (e) {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -18,20 +18,8 @@ export function resolveFontSize(value: unknown, fallback: number = FONT_SIZE_DEF
   if (typeof value !== 'number' || Number.isNaN(value)) {
     return fallback;
   }
-  if (value === Infinity) {
-    return FONT_SIZE_MAX;
-  }
-  if (value === -Infinity) {
-    return FONT_SIZE_MIN;
-  }
   const floored = Math.floor(value);
-  if (floored < FONT_SIZE_MIN) {
-    return FONT_SIZE_MIN;
-  }
-  if (floored > FONT_SIZE_MAX) {
-    return FONT_SIZE_MAX;
-  }
-  return floored;
+  return Math.max(FONT_SIZE_MIN, Math.min(FONT_SIZE_MAX, floored));
 }
 
 export interface TaskMarkErrorMessage {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -7,6 +7,31 @@ export interface TaskMarkUpdateMessage {
   data: TaskMarkData;
   ganttData: GanttData;
   warnings: string[];
+  fontSize: number;
+}
+
+export const FONT_SIZE_MIN = 10;
+export const FONT_SIZE_MAX = 24;
+export const FONT_SIZE_DEFAULT = 14;
+
+export function resolveFontSize(value: unknown, fallback: number = FONT_SIZE_DEFAULT): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return fallback;
+  }
+  if (value === Infinity) {
+    return FONT_SIZE_MAX;
+  }
+  if (value === -Infinity) {
+    return FONT_SIZE_MIN;
+  }
+  const floored = Math.floor(value);
+  if (floored < FONT_SIZE_MIN) {
+    return FONT_SIZE_MIN;
+  }
+  if (floored > FONT_SIZE_MAX) {
+    return FONT_SIZE_MAX;
+  }
+  return floored;
 }
 
 export interface TaskMarkErrorMessage {

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -4,7 +4,8 @@ import {
   TaskMarkErrorMessage,
   ToggleTaskMessage,
   toggleCheckboxInLine,
-  resolveToggleTargetLineIndex
+  resolveToggleTargetLineIndex,
+  resolveFontSize
 } from '../../messages';
 
 suite('TaskmarkPanel message types', () => {
@@ -14,7 +15,8 @@ suite('TaskmarkPanel message types', () => {
       uri: 'file:///test.tmd',
       data: { tagColors: {}, groupTags: {}, days: {} },
       ganttData: { entities: [], lastDateStr: '' },
-      warnings: []
+      warnings: [],
+      fontSize: 14
     };
     assert.strictEqual(msg.type, 'update');
   });
@@ -25,10 +27,24 @@ suite('TaskmarkPanel message types', () => {
       uri: 'file:///test.tmd',
       data: { tagColors: {}, groupTags: {}, days: {} },
       ganttData: { entities: [], lastDateStr: '' },
-      warnings: ["Line 5: invalid date '2026-99-99', skipped"]
+      warnings: ["Line 5: invalid date '2026-99-99', skipped"],
+      fontSize: 14
     };
     assert.strictEqual(msg.warnings.length, 1);
     assert.ok(msg.warnings[0].includes('2026-99-99'));
+  });
+
+  test('TaskMarkUpdateMessage carries a numeric fontSize', () => {
+    const msg: TaskMarkUpdateMessage = {
+      type: 'update',
+      uri: 'file:///test.tmd',
+      data: { tagColors: {}, groupTags: {}, days: {} },
+      ganttData: { entities: [], lastDateStr: '' },
+      warnings: [],
+      fontSize: 18
+    };
+    assert.strictEqual(typeof msg.fontSize, 'number');
+    assert.strictEqual(msg.fontSize, 18);
   });
 
   test('TaskMarkErrorMessage has type "parseError" and a message field', () => {
@@ -150,5 +166,56 @@ suite('toggleCheckboxInLine', () => {
 
   test('returns null when non-bullet text precedes the checkbox', () => {
     assert.strictEqual(toggleCheckboxInLine('foo - [ ] bar'), null);
+  });
+});
+
+suite('resolveFontSize', () => {
+  test('returns default (14) when value is undefined', () => {
+    assert.strictEqual(resolveFontSize(undefined), 14);
+  });
+
+  test('returns default (14) when value is null', () => {
+    assert.strictEqual(resolveFontSize(null), 14);
+  });
+
+  test('returns the value unchanged when within allowed range', () => {
+    assert.strictEqual(resolveFontSize(16), 16);
+    assert.strictEqual(resolveFontSize(10), 10);
+    assert.strictEqual(resolveFontSize(24), 24);
+  });
+
+  test('clamps below-minimum values up to 10', () => {
+    assert.strictEqual(resolveFontSize(4), 10);
+    assert.strictEqual(resolveFontSize(0), 10);
+    assert.strictEqual(resolveFontSize(-5), 10);
+  });
+
+  test('clamps above-maximum values down to 24', () => {
+    assert.strictEqual(resolveFontSize(99), 24);
+    assert.strictEqual(resolveFontSize(25), 24);
+  });
+
+  test('returns fallback when value is a non-number string', () => {
+    assert.strictEqual(resolveFontSize('big'), 14);
+    assert.strictEqual(resolveFontSize('16'), 14);
+  });
+
+  test('returns fallback for NaN', () => {
+    assert.strictEqual(resolveFontSize(NaN), 14);
+  });
+
+  test('clamps Infinity to the max bound', () => {
+    assert.strictEqual(resolveFontSize(Infinity), 24);
+    assert.strictEqual(resolveFontSize(-Infinity), 10);
+  });
+
+  test('respects a custom fallback', () => {
+    assert.strictEqual(resolveFontSize(undefined, 18), 18);
+    assert.strictEqual(resolveFontSize('nope', 20), 20);
+  });
+
+  test('floors fractional values before clamping', () => {
+    assert.strictEqual(resolveFontSize(14.7), 14);
+    assert.strictEqual(resolveFontSize(10.9), 10);
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #79

## 概要
月表示カレンダービューをはじめとするカレンダー表示のフォントサイズをユーザーが設定で変更できるようにしました。また、曜日ヘッダと日付バッジの周囲の余白を詰め、1 セルあたりに表示できる予定行数を増やしています。Weekly / Daily ビューでも曜日・日付表示および予定行のフォントサイズ・余白を Monthly と揃えました。

## 変更内容
- `taskmark.fontSize` 設定項目を追加（`number`、デフォルト `14`、`10`〜`24` に制限）。不正値はクランプ／フォールバックする `resolveFontSize` ヘルパーを追加しユニットテストでカバー。
- `TaskMarkUpdateMessage` に `fontSize` を追加し、`TaskmarkPanel` が設定変更を監視して webview に通知するように変更。
- `media/style.css` で `--tm-font-size` CSS 変数を導入し、Monthly / Weekly / Daily ビューの `.tm-day-header` / `.tm-cal-date` / `.tm-item` / `.tm-tag` / `.tm-group-title` / `.tm-cell-band` を変数ベースに統一。曜日ヘッダと日付バッジのパディング／マージンを削減。
- `media/main.js` で受信した `fontSize` を CSS 変数として適用。
- README に `taskmark.fontSize` 設定の説明を追記。

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した
- [x] `npm run lint` / `npm run test:unit` がパスすることを確認した（108 tests passing）

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| （必要に応じて画像を貼る） | （必要に応じて画像を貼る） |

## 備考・次やること
- Gantt / Timeline ビューは既存のズーム機構があるため対象外としています。必要になったら別 Issue で検討。