### PR TITLE
Release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to the "TaskMark" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.4.0] - 2026-04-19
+
+### Added
+- Toggle task completion by clicking the checkbox directly in Calendar views; updates the underlying `.tmd` file (#32).
+- Configurable `taskmark.fontSize` setting (10–24 px) that scales Calendar views and Gantt timeline labels (#79).
+- Zoom in / zoom out buttons in the Gantt timeline header, in addition to `Ctrl + Mouse Wheel` (#51).
+- Group header tags now set the group display color in both Calendar and Gantt views (#66).
+- Monthly calendar items are now rendered as compact bands with ellipsis to fit more per cell (#75).
+
+### Fixed
+- Gantt standalone bars and Monthly standalone tasks now use their own tags for color resolution (#66).
+- Same-named groups in different date sections are treated as separate entities in the Gantt chart (#68).
+- Calendar now merges group range items into a single continuous band across the range (#65).
+- Monthly day-header row no longer stretches to fill extra vertical space.
+- Checkbox toggle regex is anchored to the start of a line to avoid matching brackets appearing in item text.
+- Cell band height, date badge, and minimum readable sizes scale correctly with `taskmark.fontSize`.
+
+### Changed
+- Default Gantt zoom level raised to reduce label overlap on first open.
+- Minimum supported VS Code engine version is `1.109.1`.
+
 ## [1.3.2] - 2026-04-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -223,6 +223,14 @@ You can also define global tag colors in your VS Code `settings.json` to reuse t
 
 *Note: Tags defined within a `.tmd` file via the `@tags` block will take precedence over global settings.*
 
+- `taskmark.fontSize`: Font size (in px) applied to the calendar views (Monthly/Weekly/Daily). Default: `14`. Values outside the range `10`–`24` are clamped.
+
+```json
+{
+  "taskmark.fontSize": 16
+}
+```
+
 ---
 
 ## Feedback & Support

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ You can also define global tag colors in your VS Code `settings.json` to reuse t
 
 *Note: Tags defined within a `.tmd` file via the `@tags` block will take precedence over global settings.*
 
-- `taskmark.fontSize`: Font size (in px) applied to the calendar views (Monthly/Weekly/Daily). Default: `14`. Values outside the range `10`–`24` are clamped.
+- `taskmark.fontSize`: Font size (in px) applied to the calendar views (Monthly/Weekly/Daily) and Gantt timeline labels. Default: `14`. Values outside the range `10`–`24` are clamped.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Switch between three granularity levels to check your schedule.
 
 **Interactions:**
 - Click a date cell → Jump directly to the Daily view for that day
+- Click a task checkbox → Toggle completion (`- [ ]` / `- [x]`) directly in the `.tmd` file
 - `<` `>` Buttons → Navigate forward and backward in time
 - `Today` Button → Return to the current date
 - Saturdays are highlighted in blue, Sundays in red
@@ -65,7 +66,7 @@ Visualize schedule durations and project spans as a Gantt chart.
 
 
 - **Pan** — Move smoothly in any direction by clicking and dragging
-- **Zoom** — Use `Ctrl + Mouse Wheel` to zoom in/out (from days to hours)
+- **Zoom** — Zoom in/out (from days to hours) with `Ctrl + Mouse Wheel`, or the zoom buttons in the view header
 - **Progress Bars** — Group task completion rates are displayed visually on the bars
 - **Weekend Colors** — Colored backgrounds corresponding to the calendar view
 - **Sub-rows** — Tasks inside a group are displayed as individual sub-rows beneath the group bar; click the group bar to collapse or expand them

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Options can be combined using commas. If a limit is not explicitly defined, recu
 - Multi-day event spanning date range #Tag
 - [ ] Multi-day task spanning date range
 
-> Group Name
+> Group Name #Tag
 > - 13:00-15:00 Schedule inside group #Tag
 > - [x] Completed task inside group
 > - [ ] Uncompleted task inside group
@@ -154,8 +154,25 @@ Options can be combined using commas. If a limit is not explicitly defined, recu
 | `HH:mm` | Start time only | Schedules |
 | `#Tag` | Tags (Multiple allowed) | Both |
 | `@repeat(...)` | Recurring items | Schedules only |
-| `> Group Name` | Group header | — |
+| `> Group Name` | Group header (tags optional) | — |
 | `> - Item` | Items inside group | Both |
+
+### 🗂️ Group Colors
+
+Attach a tag directly to a group header to control its display color in both the Calendar and Timeline views.
+
+```tmd
+# 2026-03-01
+> Sprint #Dev
+> - [ ] Implement feature A
+> - [ ] Write tests
+```
+
+If no tag is specified on the group header, the color falls back to the first tag found among the child items, or the default accent color if none exist.
+
+> **Note:** When a schedule inside a group uses `@repeat`, the repeated copies appear on different dates. Because the group header tag is only recorded for the original date, the group bars on those expanded dates will fall back to the child item's tag color (or the default accent color). This is expected behavior.
+
+---
 
 ### 📅 Date Range Header
 

--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ Attach a tag directly to a group header to control its display color in both the
 > - [ ] Write tests
 ```
 
-If no tag is specified on the group header, the color falls back to the first tag found among the child items, or the default accent color if none exist.
+If no tag is specified on the group header, the group box and its bar use the default accent color. Each child item continues to use its own tag color independently.
 
-> **Note:** When a schedule inside a group uses `@repeat`, the repeated copies appear on different dates. Because the group header tag is only recorded for the original date, the group bars on those expanded dates will fall back to the child item's tag color (or the default accent color). This is expected behavior.
+> **Note:** When a schedule inside a group uses `@repeat`, the group header tag is correctly applied to all expanded instances by referencing the original date where the group was defined.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ Categorize schedules and tasks visually with tags.
 
 Define tag colors inside the `@tags` block. Undefined tags automatically receive a deterministic, generated color based on the tag name.
 
+Any of the following CSS color formats are accepted:
+
+| Format | Example |
+|------|------|
+| Hex (3 / 4 / 6 / 8 digits) | `#fff`, `#ffff`, `#e74c3c`, `#e74c3cff` |
+| `rgb()` / `rgba()` | `rgb(255, 0, 128)`, `rgba(0, 0, 0, 0.5)` |
+| `hsl()` / `hsla()` | `hsl(120, 50%, 50%)`, `hsla(120, 50%, 50%, 0.8)` |
+| Named color | `steelblue`, `crimson` |
+
+Values that do not match any of these formats are rejected with a warning and the tag falls back to the deterministic generated color.
+
 ### 🔁 Recurring Schedules
 
 Automatically expand recurring schedules. Tasks (`- [ ]` / `- [x]`) manage independent completion states and are ignored by repeat modifiers.
@@ -209,7 +220,7 @@ Use `# YYYY-MM-DD : YYYY-MM-DD` to define events or tasks that span multiple day
 
 You can also define global tag colors in your VS Code `settings.json` to reuse them across multiple `.tmd` files.
 
-- `taskmark.tagColors`: A JSON object mapping tag names (without `#`) to hex color codes.
+- `taskmark.tagColors`: A JSON object mapping tag names (without `#`) to CSS color values. The same formats accepted inside the `@tags` block are supported here (hex, `rgb()`/`rgba()`, `hsl()`/`hsla()`, named colors).
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Use `# YYYY-MM-DD : YYYY-MM-DD` to define events or tasks that span multiple day
 - [ ] Prepare conference materials #Dev
 ```
 
-> **Note:** If the end date is invalid or earlier than the start date, the range is silently ignored and the header is treated as a single date.
+> **Note:** If the end date is invalid or earlier than the start date, the range is ignored (a warning is shown) and the header is treated as a single date.
 >
 > **Note:** Date range items are always treated as all-day — any time specification (`HH:mm`) is ignored in the Timeline view.
 >
@@ -244,21 +244,31 @@ Found a bug or have a feature request? Please feel free to open an issue on our 
 ```
 TaskMark/
 ├── src/
-│   ├── extension.ts       # Extension entry point
-│   ├── TaskmarkPanel.ts   # Webview panel management
-│   ├── parser.ts          # .tmd file parser
+│   ├── extension.ts         # Extension entry point
+│   ├── TaskmarkPanel.ts     # Webview panel management
+│   ├── parser.ts            # .tmd file parser
+│   ├── gantt.ts             # Gantt entity builder for the Timeline view
+│   ├── messages.ts          # Webview message types and shared helpers
+│   ├── template.ts          # Webview HTML template
+│   ├── utils/
+│   │   └── debounce.ts      # Generic debounce utility
 │   └── test/
-│       ├── runTest.ts     # Integration test runner
+│       ├── runTest.ts       # Integration test runner
 │       └── suite/
-│           ├── index.ts             # Test suite entry point
-│           ├── parser.test.ts       # Unit tests for the parser
-│           └── extension.test.ts    # Integration tests for the extension
+│           ├── index.ts               # Test suite entry point
+│           ├── parser.test.ts         # Unit tests for the parser
+│           ├── gantt.test.ts          # Unit tests for Gantt entity building
+│           ├── TaskmarkPanel.test.ts  # Unit tests for panel messages and helpers
+│           ├── template.test.ts       # Unit tests for the HTML template
+│           ├── debounce.test.ts       # Unit tests for the debounce utility
+│           └── extension.test.ts      # Integration tests for the extension
 ├── media/
-│   ├── main.js            # Webview frontend logic
-│   └── style.css          # Webview frontend styling
+│   ├── main.js              # Webview frontend logic
+│   ├── style.css            # Webview frontend styling
+│   └── screenshots/         # Images used in README
 ├── syntaxes/
 │   └── tmd.tmLanguage.json  # Syntax highlighting definitions
-├── sample.tmd             # Sample file
+├── sample.tmd               # Sample file
 └── package.json
 ```
 

--- a/media/main.js
+++ b/media/main.js
@@ -78,8 +78,9 @@
     return '';
   }
 
-  // Keep in sync with VALID_CSS_COLOR_REGEX in src/parser.ts
-  const VALID_CSS_COLOR_RE = /^(?:#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|(?:rgb|hsl)a?\(\s*\d[\d.]*%?(?:\s*[,/\s]\s*\d[\d.]*%?){2,3}\s*\)|[a-zA-Z]{1,30})$/;
+  // Built from the canonical VALID_CSS_COLOR_REGEX in src/parser.ts,
+  // injected into <body data-valid-css-color-re=...> by src/template.ts.
+  const VALID_CSS_COLOR_RE = new RegExp(document.body.dataset.validCssColorRe);
 
   /** Deterministic color from tag name, or explicit color from map */
   function getTagColor(tagName, tagColorsMap) {

--- a/media/main.js
+++ b/media/main.js
@@ -216,12 +216,12 @@
       viewTimeline.classList.remove('hidden');
       viewCalendar.classList.add('hidden');
       monthNav?.classList.add('hidden');
-      zoomControls?.classList.remove('hidden');
+      zoomControls.classList.remove('hidden');
     } else {
       viewTimeline.classList.add('hidden');
       viewCalendar.classList.remove('hidden');
       monthNav?.classList.remove('hidden');
-      zoomControls?.classList.add('hidden');
+      zoomControls.classList.add('hidden');
     }
   }
 
@@ -293,23 +293,20 @@
   window.addEventListener('blur', stopPanning);
 
   // Gantt zoom
-  viewTimeline?.addEventListener('wheel', (e) => {
+  function applyZoom(factor) {
+    ganttZoom *= factor;
+    renderTimeline();
+  }
+
+  viewTimeline.addEventListener('wheel', (e) => {
     if (e.ctrlKey) {
       e.preventDefault();
-      ganttZoom *= (e.deltaY < 0 ? GANTT_ZOOM_IN_FACTOR : GANTT_ZOOM_OUT_FACTOR);
-      renderTimeline();
+      applyZoom(e.deltaY < 0 ? GANTT_ZOOM_IN_FACTOR : GANTT_ZOOM_OUT_FACTOR);
     }
   });
 
-  btnZoomIn?.addEventListener('click', () => {
-    ganttZoom *= GANTT_ZOOM_IN_FACTOR;
-    renderTimeline();
-  });
-
-  btnZoomOut?.addEventListener('click', () => {
-    ganttZoom *= GANTT_ZOOM_OUT_FACTOR;
-    renderTimeline();
-  });
+  btnZoomIn.addEventListener('click', () => applyZoom(GANTT_ZOOM_IN_FACTOR));
+  btnZoomOut.addEventListener('click', () => applyZoom(GANTT_ZOOM_OUT_FACTOR));
 
   // Date navigation
   function navigateDate(direction) {

--- a/media/main.js
+++ b/media/main.js
@@ -267,7 +267,8 @@
     render();
   });
 
-  viewCalendar?.addEventListener('dblclick', (e) => {
+  viewCalendar?.addEventListener('click', (e) => {
+    if (e.target.closest('.tm-checkbox[data-raw-line]')) return;
     const wrap = e.target.closest('.clickable-date');
     if (wrap && wrap.dataset.date) {
       currentDate = parseLocalDate(wrap.dataset.date);
@@ -509,10 +510,7 @@
       dStr ? 'clickable-date' : ''
     ].filter(Boolean).join(' ');
 
-    if (dStr) {
-      el.dataset.date = dStr;
-      el.title = 'Double-click to view daily';
-    }
+    if (dStr) el.dataset.date = dStr;
     if (dayNo !== '') {
       el.innerHTML = `<div class="tm-cal-date-wrap"><span class="tm-cal-date">${dayNo}</span></div>`;
     }

--- a/media/main.js
+++ b/media/main.js
@@ -104,6 +104,15 @@
     return 'var(--tm-accent)';
   }
 
+  /** Build HTML for a list of tag pills */
+  function createTagPillsHtml(tags, tagColorsMap) {
+    if (!tags || tags.length === 0) return '';
+    return tags.map(t => {
+      const color = getTagColor(t, tagColorsMap);
+      return `<span class="tm-tag" style="background-color: ${color}">${escapeHtml(t)}</span>`;
+    }).join('');
+  }
+
   /** Escape special HTML characters to prevent XSS when embedding user content */
   function escapeHtml(str) {
     return str
@@ -394,12 +403,7 @@
     });
 
     const renderItem = (item) => {
-      const tagsHtml = (item.tags && item.tags.length > 0)
-        ? item.tags.map(t => {
-          const color = getTagColor(t, tagColorsMap);
-          return `<span class="tm-tag" style="background-color: ${color}">${escapeHtml(t)}</span>`;
-        }).join('')
-        : '';
+      const tagsHtml = createTagPillsHtml(item.tags, tagColorsMap);
 
       const cbHtml = item.type === 'task' ? '<span class="tm-checkbox"></span>' : '';
       const timeHtml = itemHasTime(item) ? `<span class="tm-time">${item.time}</span>` : '';

--- a/media/main.js
+++ b/media/main.js
@@ -351,7 +351,7 @@
 
   // ─── Calendar Items HTML ─────────────────────────────────────
 
-  function createItemsHtml(items, tagColorsMap, isMonthly = false) {
+  function createItemsHtml(items, tagColorsMap, isMonthly = false, dateStr = '') {
     if (!items || items.length === 0) return '';
 
     const sortedItems = [...items].sort((a, b) => {
@@ -398,7 +398,18 @@
       </div>`;
     };
 
-    const renderTaskSummary = (itemList, titleFallback) => {
+    const getGroupBorderColor = (gName, itemList) => {
+      if (dateStr && currentTaskMarkData.groupTags) {
+        const gTags = currentTaskMarkData.groupTags[`${dateStr}::${gName}`];
+        if (gTags && gTags.length > 0) {
+          return getTagColor(gTags[0], tagColorsMap);
+        }
+      }
+      const firstTagItem = itemList.find(i => i.tags && i.tags.length > 0);
+      return firstTagItem ? getTagColor(firstTagItem.tags[0], tagColorsMap) : 'var(--tm-accent)';
+    };
+
+    const renderTaskSummary = (itemList, titleFallback, gName = '') => {
       const tasks = itemList.filter(i => i.type === 'task');
       const schedules = itemList.filter(i => i.type === 'schedule');
       let outHtml = schedules.map(renderItem).join('');
@@ -407,10 +418,7 @@
         const doneCount = tasks.filter(t => t.status === 'done').length;
         const totalCount = tasks.length;
         const isAllDone = doneCount === totalCount;
-        const firstTagTask = tasks.find(t => t.tags && t.tags.length > 0);
-        const borderColor = firstTagTask
-          ? getTagColor(firstTagTask.tags[0], tagColorsMap)
-          : 'var(--tm-accent)';
+        const borderColor = getGroupBorderColor(gName, tasks);
         const classNames = `tm-item task ${isAllDone ? 'done' : ''}`;
 
         outHtml += `<div class="${classNames}" style="border-left-color: ${borderColor}">
@@ -424,10 +432,11 @@
     let html = '<div class="tm-items-list">';
 
     Object.keys(grouped).forEach(gName => {
+      const groupBorderColor = getGroupBorderColor(gName, grouped[gName]);
       const groupContent = isMonthly
-        ? renderTaskSummary(grouped[gName], 'Tasks')
+        ? renderTaskSummary(grouped[gName], 'Tasks', gName)
         : grouped[gName].map(renderItem).join('');
-      html += `<div class="tm-group-box">
+      html += `<div class="tm-group-box" style="border-left-color: ${groupBorderColor}">
         <div class="tm-group-title">${escapeHtml(gName)}</div>
         ${groupContent}
       </div>`;
@@ -688,7 +697,7 @@
         const regularItems = dayItems.filter(item => !item.endDate);
         const el = createCell(cell.dayNo, cell.isOtherMonth, cell.isToday, cell.dayOfWeek, cell.dStr);
         el.innerHTML += createCellBandsHtml(bandMap[colIndex], maxRow, tagColors);
-        el.innerHTML += createItemsHtml(regularItems, tagColors, true);
+        el.innerHTML += createItemsHtml(regularItems, tagColors, true, cell.dStr);
         viewCalendar.appendChild(el);
       });
     }
@@ -722,7 +731,7 @@
       const cell = createCell(d.getDate(), false, dStr === todayStr, dayOfWeek, dStr);
       cell.style.flex = '1';
       cell.innerHTML += createCellBandsHtml(bandMap[colIndex], maxRow, tagColors);
-      cell.innerHTML += createItemsHtml(regularItems, tagColors);
+      cell.innerHTML += createItemsHtml(regularItems, tagColors, false, dStr);
       viewCalendar.appendChild(cell);
       d.setDate(d.getDate() + 1);
     }
@@ -745,7 +754,7 @@
     const dayData = getDayData(dStr);
     const cell = createCell('', false, dStr === todayStr, dayOfWeek);
     cell.style.flex = '1';
-    cell.innerHTML += createItemsHtml(dayData.items, currentTaskMarkData.tagColors);
+    cell.innerHTML += createItemsHtml(dayData.items, currentTaskMarkData.tagColors, false, dStr);
     viewCalendar.appendChild(cell);
   }
 

--- a/media/main.js
+++ b/media/main.js
@@ -42,6 +42,9 @@
   const viewTimeline = document.getElementById('tm-timeline');
   const monthNav = document.querySelector('.tm-month-nav');
   const monthDisplay = document.getElementById('current-month-display');
+  const zoomControls = document.getElementById('tm-zoom-controls');
+  const btnZoomIn = document.getElementById('btn-zoom-in');
+  const btnZoomOut = document.getElementById('btn-zoom-out');
 
   // ─── Utility Functions ───────────────────────────────────────
 
@@ -211,10 +214,12 @@
       viewTimeline.classList.remove('hidden');
       viewCalendar.classList.add('hidden');
       monthNav?.classList.add('hidden');
+      zoomControls?.classList.remove('hidden');
     } else {
       viewTimeline.classList.add('hidden');
       viewCalendar.classList.remove('hidden');
       monthNav?.classList.remove('hidden');
+      zoomControls?.classList.add('hidden');
     }
   }
 
@@ -292,6 +297,16 @@
       ganttZoom *= (e.deltaY < 0 ? 1.2 : 0.8);
       renderTimeline();
     }
+  });
+
+  btnZoomIn?.addEventListener('click', () => {
+    ganttZoom *= 1.2;
+    renderTimeline();
+  });
+
+  btnZoomOut?.addEventListener('click', () => {
+    ganttZoom *= 0.8;
+    renderTimeline();
   });
 
   // Date navigation

--- a/media/main.js
+++ b/media/main.js
@@ -888,7 +888,7 @@
 
     // Label (outside bar, to the right)
     const progText = entity.tasksTotal > 0 ? ` [${entity.tasksDone}/${entity.tasksTotal}]` : '';
-    container.appendChild(createGanttLabel(entity.name + progText, left + width, yOffset, entity.tags, currentTaskMarkData.tagColors));
+    container.appendChild(createGanttLabel(entity.name + progText, left + width, yOffset));
   }
 
   function renderStandaloneBars(container, entity, startDate, pxPerMs, yOffset, bgColor) {
@@ -910,7 +910,7 @@
       container.appendChild(bar);
 
       // Label (outside bar, to the right)
-      container.appendChild(createGanttLabel(entity.name, left + width, yOffset, entity.tags, currentTaskMarkData.tagColors));
+      container.appendChild(createGanttLabel(entity.name, left + width, yOffset));
     });
   }
 
@@ -965,26 +965,13 @@
     return bar;
   }
 
-  /** Create a label element positioned outside the bar, optionally with tag pills */
-  function createGanttLabel(text, leftPx, yOffset, tags, tagColorsMap) {
+  /** Create a label element positioned outside the bar */
+  function createGanttLabel(text, leftPx, yOffset) {
     const label = document.createElement('span');
     label.className = 'tm-gantt-bar-label';
     label.style.left = (leftPx + GANTT_LABEL_OFFSET_X) + 'px';
     label.style.top = (yOffset + GANTT_LABEL_OFFSET_Y) + 'px';
-
-    const textNode = document.createElement('span');
-    textNode.className = 'tm-gantt-bar-label-text';
-    textNode.textContent = text;
-    label.appendChild(textNode);
-
-    const pillsHtml = createTagPillsHtml(tags, tagColorsMap);
-    if (pillsHtml) {
-      const pills = document.createElement('span');
-      pills.className = 'tm-gantt-bar-label-tags';
-      pills.innerHTML = pillsHtml;
-      label.appendChild(pills);
-    }
-
+    label.textContent = text;
     return label;
   }
 

--- a/media/main.js
+++ b/media/main.js
@@ -838,19 +838,18 @@
     pBar.style.backgroundColor = bgColor;
     bar.appendChild(pBar);
 
-    const entityKey = entity.id !== undefined ? entity.id : entity.name;
     const indicator = document.createElement('span');
     indicator.className = 'tm-gantt-group-indicator';
-    indicator.textContent = expandedGroups.has(entityKey) ? '▼' : '▶';
+    indicator.textContent = expandedGroups.has(entity.id) ? '▼' : '▶';
     bar.appendChild(indicator);
 
     bar.addEventListener('click', (e) => {
       e.stopPropagation();
       if (hasDragged) return;
-      if (expandedGroups.has(entityKey)) {
-        expandedGroups.delete(entityKey);
+      if (expandedGroups.has(entity.id)) {
+        expandedGroups.delete(entity.id);
       } else {
-        expandedGroups.add(entityKey);
+        expandedGroups.add(entity.id);
       }
       renderTimeline();
     });
@@ -983,26 +982,25 @@
     const laneGroups = [];
     const seenLanes = new Map();
     entityArray.forEach(entity => {
-      const lane = entity.lane !== undefined ? entity.lane : entity.name;
-      if (!seenLanes.has(lane)) {
-        seenLanes.set(lane, laneGroups.length);
+      if (!seenLanes.has(entity.lane)) {
+        seenLanes.set(entity.lane, laneGroups.length);
         laneGroups.push([entity]);
       } else {
-        laneGroups[seenLanes.get(lane)].push(entity);
+        laneGroups[seenLanes.get(entity.lane)].push(entity);
       }
     });
+
+    // Precompute max expanded child count per lane (reused for height and rendering)
+    const laneMaxChildCounts = laneGroups.map(laneEntities =>
+      laneEntities.reduce((max, e) =>
+        e.isGroup && expandedGroups.has(e.id) ? Math.max(max, e.children.length) : max, 0)
+    );
 
     // Build container
     const ganttContainer = document.createElement('div');
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
-    const totalRowCount = laneGroups.reduce((sum, laneEntities) => {
-      const maxChildren = laneEntities.reduce((max, e) => {
-        const key = e.id !== undefined ? e.id : e.name;
-        return e.isGroup && expandedGroups.has(key) ? Math.max(max, e.children.length) : max;
-      }, 0);
-      return sum + 1 + maxChildren;
-    }, 0);
+    const totalRowCount = laneGroups.reduce((sum, _, i) => sum + 1 + laneMaxChildCounts[i], 0);
     ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
 
     // Render axis and column backgrounds
@@ -1010,26 +1008,22 @@
 
     // Render entity bars grouped by lane (same lane = same row)
     let yOffset = GANTT_HEADER_HEIGHT;
-    laneGroups.forEach(laneEntities => {
+    laneGroups.forEach((laneEntities, laneIdx) => {
       const laneYOffset = yOffset;
       yOffset += GANTT_ROW_HEIGHT + 4;
 
       // Render all bars for this lane first
-      laneEntities.forEach((entity, laneIdx) => {
-        renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth, laneIdx > 0);
+      laneEntities.forEach((entity, i) => {
+        renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth, i > 0);
       });
 
       // Render children of each expanded entity relative to laneYOffset.
       // Row backgrounds are rendered once for the full child area depth.
-      const maxChildCount = laneEntities.reduce((max, e) => {
-        const key = e.id !== undefined ? e.id : e.name;
-        return e.isGroup && expandedGroups.has(key) ? Math.max(max, e.children.length) : max;
-      }, 0);
+      const maxChildCount = laneMaxChildCounts[laneIdx];
       if (maxChildCount > 0) {
         renderGroupChildRowBgs(ganttContainer, maxChildCount, laneYOffset, totalWidth);
         laneEntities.forEach(entity => {
-          const entityKey = entity.id !== undefined ? entity.id : entity.name;
-          if (entity.isGroup && expandedGroups.has(entityKey)) {
+          if (entity.isGroup && expandedGroups.has(entity.id)) {
             renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
           }
         });

--- a/media/main.js
+++ b/media/main.js
@@ -11,7 +11,7 @@
   const GANTT_LABEL_OFFSET_Y = 4;
   const GANTT_ZOOM_IN_FACTOR = 1.25;
   const GANTT_ZOOM_OUT_FACTOR = 0.8;
-  const GANTT_DEFAULT_ZOOM = Math.pow(GANTT_ZOOM_IN_FACTOR, 3); // ≈1.95, three zoom-in steps
+  const GANTT_DEFAULT_ZOOM = Math.pow(GANTT_ZOOM_IN_FACTOR, 5); // ≈3.05, five zoom-in steps
 
   // ─── State ───────────────────────────────────────────────────
   let baseView = 'calendar'; // 'calendar' | 'timeline'

--- a/media/main.js
+++ b/media/main.js
@@ -399,10 +399,13 @@
     };
 
     const getGroupBorderColor = (gName, itemList) => {
-      if (dateStr && currentTaskMarkData.groupTags) {
-        const gTags = currentTaskMarkData.groupTags[`${dateStr}::${gName}`];
-        if (gTags && gTags.length > 0) {
-          return getTagColor(gTags[0], tagColorsMap);
+      if (currentTaskMarkData.groupTags) {
+        const lookupDates = new Set();
+        if (dateStr) lookupDates.add(dateStr);
+        itemList.forEach(i => { if (i.startDate) lookupDates.add(i.startDate); });
+        for (const d of lookupDates) {
+          const gTags = currentTaskMarkData.groupTags[`${d}::${gName}`];
+          if (gTags && gTags.length > 0) return getTagColor(gTags[0], tagColorsMap);
         }
       }
       const firstTagItem = itemList.find(i => i.tags && i.tags.length > 0);

--- a/media/main.js
+++ b/media/main.js
@@ -888,7 +888,7 @@
 
     // Label (outside bar, to the right)
     const progText = entity.tasksTotal > 0 ? ` [${entity.tasksDone}/${entity.tasksTotal}]` : '';
-    container.appendChild(createGanttLabel(entity.name + progText, left + width, yOffset));
+    container.appendChild(createGanttLabel(entity.name + progText, left + width, yOffset, entity.tags, currentTaskMarkData.tagColors));
   }
 
   function renderStandaloneBars(container, entity, startDate, pxPerMs, yOffset, bgColor) {
@@ -910,7 +910,7 @@
       container.appendChild(bar);
 
       // Label (outside bar, to the right)
-      container.appendChild(createGanttLabel(entity.name, left + width, yOffset));
+      container.appendChild(createGanttLabel(entity.name, left + width, yOffset, entity.tags, currentTaskMarkData.tagColors));
     });
   }
 
@@ -965,13 +965,26 @@
     return bar;
   }
 
-  /** Create a label element positioned outside the bar */
-  function createGanttLabel(text, leftPx, yOffset) {
+  /** Create a label element positioned outside the bar, optionally with tag pills */
+  function createGanttLabel(text, leftPx, yOffset, tags, tagColorsMap) {
     const label = document.createElement('span');
     label.className = 'tm-gantt-bar-label';
     label.style.left = (leftPx + GANTT_LABEL_OFFSET_X) + 'px';
     label.style.top = (yOffset + GANTT_LABEL_OFFSET_Y) + 'px';
-    label.textContent = text;
+
+    const textNode = document.createElement('span');
+    textNode.className = 'tm-gantt-bar-label-text';
+    textNode.textContent = text;
+    label.appendChild(textNode);
+
+    const pillsHtml = createTagPillsHtml(tags, tagColorsMap);
+    if (pillsHtml) {
+      const pills = document.createElement('span');
+      pills.className = 'tm-gantt-bar-label-tags';
+      pills.innerHTML = pillsHtml;
+      label.appendChild(pills);
+    }
+
     return label;
   }
 

--- a/media/main.js
+++ b/media/main.js
@@ -885,11 +885,10 @@
     });
   }
 
-  /** Render child task rows below the group bar.
-   *  childStartYOffset is the absolute top of the first child row. */
-  function renderGroupChildren(container, entity, startDate, pxPerMs, childStartYOffset, totalWidth) {
+  /** Render child task rows below the group bar. */
+  function renderGroupChildren(container, entity, startDate, pxPerMs, groupYOffset, totalWidth) {
     entity.children.forEach((child, i) => {
-      const childYOffset = childStartYOffset + (GANTT_ROW_HEIGHT + 4) * i;
+      const childYOffset = groupYOffset + (GANTT_ROW_HEIGHT + 4) * (i + 1);
 
       // Child row background
       const rowBg = document.createElement('div');
@@ -994,11 +993,11 @@
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
     const totalRowCount = laneGroups.reduce((sum, laneEntities) => {
-      const expandedChildCount = laneEntities.reduce((childSum, e) => {
+      const maxChildren = laneEntities.reduce((max, e) => {
         const key = e.id !== undefined ? e.id : e.name;
-        return childSum + (e.isGroup && expandedGroups.has(key) ? e.children.length : 0);
+        return e.isGroup && expandedGroups.has(key) ? Math.max(max, e.children.length) : max;
       }, 0);
-      return sum + 1 + expandedChildCount;
+      return sum + 1 + maxChildren;
     }, 0);
     ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
 
@@ -1016,14 +1015,17 @@
         renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth, laneIdx > 0);
       });
 
-      // Then render children of each expanded entity sequentially below the lane
+      // Render children of each expanded entity relative to laneYOffset,
+      // then advance yOffset by the largest child count in this lane
+      let maxChildCount = 0;
       laneEntities.forEach(entity => {
         const entityKey = entity.id !== undefined ? entity.id : entity.name;
         if (entity.isGroup && expandedGroups.has(entityKey)) {
-          renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, yOffset, totalWidth);
-          yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
+          renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
+          maxChildCount = Math.max(maxChildCount, entity.children.length);
         }
       });
+      yOffset += (GANTT_ROW_HEIGHT + 4) * maxChildCount;
     });
 
     viewTimeline.appendChild(ganttContainer);

--- a/media/main.js
+++ b/media/main.js
@@ -460,11 +460,7 @@
       </div>`;
     });
 
-    if (isMonthly) {
-      html += renderTaskSummary(standalone, 'Tasks');
-    } else {
-      html += standalone.map(renderItem).join('');
-    }
+    html += standalone.map(renderItem).join('');
 
     html += '</div>';
     return html;

--- a/media/main.js
+++ b/media/main.js
@@ -885,17 +885,21 @@
     });
   }
 
-  /** Render child task rows below the group bar. */
+  /** Render row backgrounds for the child area below a lane (called once per lane). */
+  function renderGroupChildRowBgs(container, childCount, groupYOffset, totalWidth) {
+    for (let i = 0; i < childCount; i++) {
+      const rowBg = document.createElement('div');
+      rowBg.className = 'tm-gantt-row-bg tm-gantt-child-row-bg';
+      rowBg.style.top = (groupYOffset + (GANTT_ROW_HEIGHT + 4) * (i + 1)) + 'px';
+      rowBg.style.width = totalWidth + 'px';
+      container.appendChild(rowBg);
+    }
+  }
+
+  /** Render child task bars below the group bar (row backgrounds are rendered separately). */
   function renderGroupChildren(container, entity, startDate, pxPerMs, groupYOffset, totalWidth) {
     entity.children.forEach((child, i) => {
       const childYOffset = groupYOffset + (GANTT_ROW_HEIGHT + 4) * (i + 1);
-
-      // Child row background
-      const rowBg = document.createElement('div');
-      rowBg.className = 'tm-gantt-row-bg tm-gantt-child-row-bg';
-      rowBg.style.top = childYOffset + 'px';
-      rowBg.style.width = totalWidth + 'px';
-      container.appendChild(rowBg);
 
       const childColor = getItemBorderColor(child.tags, currentTaskMarkData.tagColors);
       const left = (child.startMs - startDate.getTime()) * pxPerMs;
@@ -1015,17 +1019,22 @@
         renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth, laneIdx > 0);
       });
 
-      // Render children of each expanded entity relative to laneYOffset,
-      // then advance yOffset by the largest child count in this lane
-      let maxChildCount = 0;
-      laneEntities.forEach(entity => {
-        const entityKey = entity.id !== undefined ? entity.id : entity.name;
-        if (entity.isGroup && expandedGroups.has(entityKey)) {
-          renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
-          maxChildCount = Math.max(maxChildCount, entity.children.length);
-        }
-      });
-      yOffset += (GANTT_ROW_HEIGHT + 4) * maxChildCount;
+      // Render children of each expanded entity relative to laneYOffset.
+      // Row backgrounds are rendered once for the full child area depth.
+      const maxChildCount = laneEntities.reduce((max, e) => {
+        const key = e.id !== undefined ? e.id : e.name;
+        return e.isGroup && expandedGroups.has(key) ? Math.max(max, e.children.length) : max;
+      }, 0);
+      if (maxChildCount > 0) {
+        renderGroupChildRowBgs(ganttContainer, maxChildCount, laneYOffset, totalWidth);
+        laneEntities.forEach(entity => {
+          const entityKey = entity.id !== undefined ? entity.id : entity.name;
+          if (entity.isGroup && expandedGroups.has(entityKey)) {
+            renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
+          }
+        });
+        yOffset += (GANTT_ROW_HEIGHT + 4) * maxChildCount;
+      }
     });
 
     viewTimeline.appendChild(ganttContainer);

--- a/media/main.js
+++ b/media/main.js
@@ -186,6 +186,9 @@
       currentTaskMarkData = message.data;
       currentGanttData = message.ganttData;
       rangeItemIndex = buildRangeItemIndex(currentTaskMarkData);
+      if (typeof message.fontSize === 'number') {
+        document.documentElement.style.setProperty('--tm-font-size', `${message.fontSize}px`);
+      }
       if (errorBanner) {
         errorBanner.textContent = '';
         errorBanner.classList.add('hidden');

--- a/media/main.js
+++ b/media/main.js
@@ -446,7 +446,7 @@
 
         outHtml += `<div class="${classNames}" style="border-left-color: ${borderColor}">
           <span class="tm-checkbox"></span>
-          <div class="tm-item-body"><span class="tm-item-text"><strong>${doneCount}/${totalCount}</strong> ${titleFallback}</span></div>
+          <div class="tm-item-body"><span class="tm-time">${doneCount}/${totalCount}</span> <span class="tm-item-text">${titleFallback}</span></div>
         </div>`;
       }
       return outHtml;

--- a/media/main.js
+++ b/media/main.js
@@ -407,12 +407,13 @@
 
       const cbHtml = item.type === 'task' ? '<span class="tm-checkbox"></span>' : '';
       const timeHtml = itemHasTime(item) ? `<span class="tm-time">${item.time}</span>` : '';
-      const classNames = `tm-item ${item.type} ${item.status || ''}`;
+      const compactClass = isMonthly ? ' compact' : '';
+      const classNames = `tm-item ${item.type} ${item.status || ''}${compactClass}`;
       const borderColor = getItemBorderColor(item.tags, tagColorsMap);
 
       return `<div class="${classNames}" style="border-left-color: ${borderColor}">
         ${cbHtml}
-        <div>${timeHtml} ${escapeHtml(item.text)} ${tagsHtml}</div>
+        <div class="tm-item-body">${timeHtml} <span class="tm-item-text">${escapeHtml(item.text)}</span> ${tagsHtml}</div>
       </div>`;
     };
 
@@ -441,11 +442,11 @@
         const totalCount = tasks.length;
         const isAllDone = doneCount === totalCount;
         const borderColor = getGroupBorderColor(gName, itemList);
-        const classNames = `tm-item task ${isAllDone ? 'done' : ''}`;
+        const classNames = `tm-item task compact ${isAllDone ? 'done' : ''}`;
 
         outHtml += `<div class="${classNames}" style="border-left-color: ${borderColor}">
           <span class="tm-checkbox"></span>
-          <div><strong>${doneCount}/${totalCount}</strong> ${titleFallback}</div>
+          <div class="tm-item-body"><span class="tm-item-text"><strong>${doneCount}/${totalCount}</strong> ${titleFallback}</span></div>
         </div>`;
       }
       return outHtml;

--- a/media/main.js
+++ b/media/main.js
@@ -399,7 +399,7 @@
     };
 
     const getGroupBorderColor = (gName, itemList) => {
-      if (currentTaskMarkData.groupTags) {
+      if (gName && currentTaskMarkData.groupTags) {
         const lookupDates = new Set();
         if (dateStr) lookupDates.add(dateStr);
         itemList.forEach(i => { if (i.startDate) lookupDates.add(i.startDate); });
@@ -407,8 +407,10 @@
           const gTags = currentTaskMarkData.groupTags[`${d}::${gName}`];
           if (gTags && gTags.length > 0) return getTagColor(gTags[0], tagColorsMap);
         }
+        return 'var(--tm-accent)';
       }
-      return 'var(--tm-accent)';
+      const firstTagItem = itemList.find(i => i.tags && i.tags.length > 0);
+      return firstTagItem ? getTagColor(firstTagItem.tags[0], tagColorsMap) : 'var(--tm-accent)';
     };
 
     const renderTaskSummary = (itemList, titleFallback, gName = '') => {

--- a/media/main.js
+++ b/media/main.js
@@ -267,7 +267,7 @@
     render();
   });
 
-  viewCalendar?.addEventListener('click', (e) => {
+  viewCalendar?.addEventListener('dblclick', (e) => {
     const wrap = e.target.closest('.clickable-date');
     if (wrap && wrap.dataset.date) {
       currentDate = parseLocalDate(wrap.dataset.date);
@@ -509,7 +509,10 @@
       dStr ? 'clickable-date' : ''
     ].filter(Boolean).join(' ');
 
-    if (dStr) el.dataset.date = dStr;
+    if (dStr) {
+      el.dataset.date = dStr;
+      el.title = 'Double-click to view daily';
+    }
     if (dayNo !== '') {
       el.innerHTML = `<div class="tm-cal-date-wrap"><span class="tm-cal-date">${dayNo}</span></div>`;
     }

--- a/media/main.js
+++ b/media/main.js
@@ -9,6 +9,8 @@
   const GANTT_MIN_BAR_WIDTH = 12;
   const GANTT_LABEL_OFFSET_X = 6;
   const GANTT_LABEL_OFFSET_Y = 4;
+  const GANTT_ZOOM_IN_FACTOR = 1.25;
+  const GANTT_ZOOM_OUT_FACTOR = 0.8;
 
   // ─── State ───────────────────────────────────────────────────
   let baseView = 'calendar'; // 'calendar' | 'timeline'
@@ -294,18 +296,18 @@
   viewTimeline?.addEventListener('wheel', (e) => {
     if (e.ctrlKey) {
       e.preventDefault();
-      ganttZoom *= (e.deltaY < 0 ? 1.25 : 0.8);
+      ganttZoom *= (e.deltaY < 0 ? GANTT_ZOOM_IN_FACTOR : GANTT_ZOOM_OUT_FACTOR);
       renderTimeline();
     }
   });
 
   btnZoomIn?.addEventListener('click', () => {
-    ganttZoom *= 1.25;
+    ganttZoom *= GANTT_ZOOM_IN_FACTOR;
     renderTimeline();
   });
 
   btnZoomOut?.addEventListener('click', () => {
-    ganttZoom *= 0.8;
+    ganttZoom *= GANTT_ZOOM_OUT_FACTOR;
     renderTimeline();
   });
 

--- a/media/main.js
+++ b/media/main.js
@@ -408,8 +408,7 @@
           if (gTags && gTags.length > 0) return getTagColor(gTags[0], tagColorsMap);
         }
       }
-      const firstTagItem = itemList.find(i => i.tags && i.tags.length > 0);
-      return firstTagItem ? getTagColor(firstTagItem.tags[0], tagColorsMap) : 'var(--tm-accent)';
+      return 'var(--tm-accent)';
     };
 
     const renderTaskSummary = (itemList, titleFallback, gName = '') => {
@@ -421,7 +420,7 @@
         const doneCount = tasks.filter(t => t.status === 'done').length;
         const totalCount = tasks.length;
         const isAllDone = doneCount === totalCount;
-        const borderColor = getGroupBorderColor(gName, tasks);
+        const borderColor = getGroupBorderColor(gName, itemList);
         const classNames = `tm-item task ${isAllDone ? 'done' : ''}`;
 
         outHtml += `<div class="${classNames}" style="border-left-color: ${borderColor}">
@@ -510,7 +509,7 @@
           const key = item.group;
           if (!groupMerged[key]) {
             const groupTags = currentTaskMarkData.groupTags && currentTaskMarkData.groupTags[`${date}::${item.group}`];
-            const tags = groupTags ? groupTags : item.tags;
+            const tags = groupTags || [];
             groupMerged[key] = { date, item: { ...item, text: item.group, tags } };
           } else {
             const existing = groupMerged[key];

--- a/media/main.js
+++ b/media/main.js
@@ -488,7 +488,7 @@
    *  using the group name as the label and the widest date span across the group. */
   function collectAllRangeItems() {
     const rangeItems = [];
-    const groupMerged = {};
+    const groupMerged = Object.create(null);
 
     Object.entries(currentTaskMarkData.days).forEach(([date, dayData]) => {
       dayData.items.forEach(item => {

--- a/media/main.js
+++ b/media/main.js
@@ -29,6 +29,9 @@
   let initialScrollL = 0;
   let initialScrollT = 0;
 
+  // ─── VS Code API ─────────────────────────────────────────────
+  const vscode = acquireVsCodeApi();
+
   // ─── DOM References ──────────────────────────────────────────
   const errorBanner = document.getElementById('tm-parse-error-banner');
   const warningBanner = document.getElementById('tm-warning-banner');
@@ -207,6 +210,16 @@
         warningBanner.classList.add('hidden');
       }
     }
+  });
+
+  // ─── Checkbox Toggle ─────────────────────────────────────────
+
+  document.addEventListener('click', event => {
+    const cb = event.target.closest('.tm-checkbox[data-raw-line]');
+    if (!cb || !currentUri) return;
+    const rawLine = Number(cb.dataset.rawLine);
+    if (!Number.isInteger(rawLine) || rawLine < 0) return;
+    vscode.postMessage({ type: 'toggleTask', uri: currentUri, rawLine });
   });
 
   // ─── UI State Management ─────────────────────────────────────
@@ -405,7 +418,9 @@
     const renderItem = (item) => {
       const tagsHtml = createTagPillsHtml(item.tags, tagColorsMap);
 
-      const cbHtml = item.type === 'task' ? '<span class="tm-checkbox"></span>' : '';
+      const cbHtml = item.type === 'task'
+        ? `<span class="tm-checkbox" data-raw-line="${item.rawLine}"></span>`
+        : '';
       const timeHtml = itemHasTime(item) ? `<span class="tm-time">${item.time}</span>` : '';
       const compactClass = isMonthly ? ' compact' : '';
       const classNames = `tm-item ${item.type} ${item.status || ''}${compactClass}`;

--- a/media/main.js
+++ b/media/main.js
@@ -294,7 +294,7 @@
   viewTimeline?.addEventListener('wheel', (e) => {
     if (e.ctrlKey) {
       e.preventDefault();
-      ganttZoom *= (e.deltaY < 0 ? 1.2 : 0.8);
+      ganttZoom *= (e.deltaY < 0 ? 1.25 : 0.8);
       renderTimeline();
     }
   });

--- a/media/main.js
+++ b/media/main.js
@@ -798,13 +798,14 @@
   }
 
   /** Render a single Gantt bar (group or standalone) */
-  function renderGanttEntityBar(container, entity, startDate, pxPerMs, yOffset, totalWidth) {
-    // Row background
-    const rowBg = document.createElement('div');
-    rowBg.className = 'tm-gantt-row-bg';
-    rowBg.style.top = yOffset + 'px';
-    rowBg.style.width = totalWidth + 'px';
-    container.appendChild(rowBg);
+  function renderGanttEntityBar(container, entity, startDate, pxPerMs, yOffset, totalWidth, skipRowBg) {
+    if (!skipRowBg) {
+      const rowBg = document.createElement('div');
+      rowBg.className = 'tm-gantt-row-bg';
+      rowBg.style.top = yOffset + 'px';
+      rowBg.style.width = totalWidth + 'px';
+      container.appendChild(rowBg);
+    }
 
     const bgColor = getItemBorderColor(entity.tags, currentTaskMarkData.tagColors);
 
@@ -1008,8 +1009,8 @@
     laneGroups.forEach(laneEntities => {
       const laneYOffset = yOffset;
       yOffset += GANTT_ROW_HEIGHT + 4;
-      laneEntities.forEach(entity => {
-        renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
+      laneEntities.forEach((entity, laneIdx) => {
+        renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth, laneIdx > 0);
         const entityKey = entity.id !== undefined ? entity.id : entity.name;
         if (entity.isGroup && expandedGroups.has(entityKey)) {
           renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);

--- a/media/main.js
+++ b/media/main.js
@@ -300,7 +300,7 @@
   });
 
   btnZoomIn?.addEventListener('click', () => {
-    ganttZoom *= 1.2;
+    ganttZoom *= 1.25;
     renderTimeline();
   });
 

--- a/media/main.js
+++ b/media/main.js
@@ -538,8 +538,9 @@
   // ─── Multi-Day Band Rendering ────────────────────────────────
 
   /** Collect all range items from the dataset (items with endDate).
-   *  Grouped range items are merged into one representative entry per group,
-   *  using the group name as the label and the widest date span across the group. */
+   *  Children of a grouped range are collapsed into a single representative entry
+   *  keyed by `${date}::${group}`, so same-named groups in different date sections
+   *  remain distinct. */
   function collectAllRangeItems() {
     const rangeItems = [];
     const groupMerged = Object.create(null);
@@ -549,15 +550,11 @@
         if (!item.endDate) return;
 
         if (item.group) {
-          const key = item.group;
+          const key = `${date}::${item.group}`;
           if (!groupMerged[key]) {
-            const groupTags = currentTaskMarkData.groupTags && currentTaskMarkData.groupTags[`${date}::${item.group}`];
+            const groupTags = currentTaskMarkData.groupTags && currentTaskMarkData.groupTags[key];
             const tags = groupTags || [];
             groupMerged[key] = { date, item: { ...item, text: item.group, tags } };
-          } else {
-            const existing = groupMerged[key];
-            if (date < existing.date) { existing.date = date; }
-            if (item.endDate > existing.item.endDate) { existing.item.endDate = item.endDate; }
           }
         } else {
           rangeItems.push({ date, item });

--- a/media/main.js
+++ b/media/main.js
@@ -506,7 +506,9 @@
         if (item.group) {
           const key = item.group;
           if (!groupMerged[key]) {
-            groupMerged[key] = { date, item: { ...item, text: item.group } };
+            const groupTags = currentTaskMarkData.groupTags && currentTaskMarkData.groupTags[`${date}::${item.group}`];
+            const tags = groupTags ? groupTags : item.tags;
+            groupMerged[key] = { date, item: { ...item, text: item.group, tags } };
           } else {
             const existing = groupMerged[key];
             if (date < existing.date) { existing.date = date; }

--- a/media/main.js
+++ b/media/main.js
@@ -837,18 +837,19 @@
     pBar.style.backgroundColor = bgColor;
     bar.appendChild(pBar);
 
+    const entityKey = entity.id !== undefined ? entity.id : entity.name;
     const indicator = document.createElement('span');
     indicator.className = 'tm-gantt-group-indicator';
-    indicator.textContent = expandedGroups.has(entity.name) ? '▼' : '▶';
+    indicator.textContent = expandedGroups.has(entityKey) ? '▼' : '▶';
     bar.appendChild(indicator);
 
     bar.addEventListener('click', (e) => {
       e.stopPropagation();
       if (hasDragged) return;
-      if (expandedGroups.has(entity.name)) {
-        expandedGroups.delete(entity.name);
+      if (expandedGroups.has(entityKey)) {
+        expandedGroups.delete(entityKey);
       } else {
-        expandedGroups.add(entity.name);
+        expandedGroups.add(entityKey);
       }
       renderTimeline();
     });
@@ -973,29 +974,48 @@
     const totalWidth = totalMs * pxPerMs;
     const totalRenderDays = Math.ceil(totalMs / MS_PER_DAY);
 
+    // Group entities by lane while preserving order of first occurrence
+    const laneGroups = [];
+    const seenLanes = new Map();
+    entityArray.forEach(entity => {
+      const lane = entity.lane !== undefined ? entity.lane : entity.name;
+      if (!seenLanes.has(lane)) {
+        seenLanes.set(lane, laneGroups.length);
+        laneGroups.push([entity]);
+      } else {
+        laneGroups[seenLanes.get(lane)].push(entity);
+      }
+    });
+
     // Build container
     const ganttContainer = document.createElement('div');
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
-    const totalRowCount = entityArray.reduce((sum, e) => {
-      const childCount = e.isGroup && expandedGroups.has(e.name) ? e.children.length : 0;
-      return sum + 1 + childCount;
+    const totalRowCount = laneGroups.reduce((sum, laneEntities) => {
+      const maxChildren = laneEntities.reduce((max, e) => {
+        return e.isGroup && expandedGroups.has(e.id !== undefined ? e.id : e.name)
+          ? Math.max(max, e.children.length) : max;
+      }, 0);
+      return sum + 1 + maxChildren;
     }, 0);
     ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
 
     // Render axis and column backgrounds
     renderGanttAxis(ganttContainer, startDate, totalRenderDays, pxPerMs);
 
-    // Render entity bars
+    // Render entity bars grouped by lane (same lane = same row)
     let yOffset = GANTT_HEADER_HEIGHT;
-    entityArray.forEach(entity => {
-      const entityYOffset = yOffset;
-      renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
+    laneGroups.forEach(laneEntities => {
+      const laneYOffset = yOffset;
       yOffset += GANTT_ROW_HEIGHT + 4;
-      if (entity.isGroup && expandedGroups.has(entity.name)) {
-        renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, entityYOffset, totalWidth);
-        yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
-      }
+      laneEntities.forEach(entity => {
+        renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
+        const entityKey = entity.id !== undefined ? entity.id : entity.name;
+        if (entity.isGroup && expandedGroups.has(entityKey)) {
+          renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
+          yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
+        }
+      });
     });
 
     viewTimeline.appendChild(ganttContainer);

--- a/media/main.js
+++ b/media/main.js
@@ -11,6 +11,7 @@
   const GANTT_LABEL_OFFSET_Y = 4;
   const GANTT_ZOOM_IN_FACTOR = 1.25;
   const GANTT_ZOOM_OUT_FACTOR = 0.8;
+  const GANTT_DEFAULT_ZOOM = Math.pow(GANTT_ZOOM_IN_FACTOR, 3); // ≈1.95, three zoom-in steps
 
   // ─── State ───────────────────────────────────────────────────
   let baseView = 'calendar'; // 'calendar' | 'timeline'
@@ -20,7 +21,7 @@
   let currentTaskMarkData = null;
   let currentGanttData = null;
   let rangeItemIndex = null; // Pre-built index: date string -> range items spanning that date
-  let ganttZoom = 1; // 1 = 100px per day
+  let ganttZoom = GANTT_DEFAULT_ZOOM; // 1 = 100px per day
   let expandedGroups = new Set();
   let isPanning = false;
   let hasDragged = false;
@@ -177,7 +178,7 @@
       if (message.uri && message.uri !== currentUri) {
         currentUri = message.uri;
         expandedGroups = new Set();
-        ganttZoom = 1;
+        ganttZoom = GANTT_DEFAULT_ZOOM;
         if (viewTimeline) {
           viewTimeline.scrollLeft = 0;
           viewTimeline.scrollTop = 0;

--- a/media/main.js
+++ b/media/main.js
@@ -483,14 +483,33 @@
 
   // ─── Multi-Day Band Rendering ────────────────────────────────
 
-  /** Collect all range items from the dataset (items with endDate). */
+  /** Collect all range items from the dataset (items with endDate).
+   *  Grouped range items are merged into one representative entry per group,
+   *  using the group name as the label and the widest date span across the group. */
   function collectAllRangeItems() {
     const rangeItems = [];
+    const groupMerged = {};
+
     Object.entries(currentTaskMarkData.days).forEach(([date, dayData]) => {
       dayData.items.forEach(item => {
-        if (item.endDate) rangeItems.push({ date, item });
+        if (!item.endDate) return;
+
+        if (item.group) {
+          const key = item.group;
+          if (!groupMerged[key]) {
+            groupMerged[key] = { date, item: { ...item, text: item.group } };
+          } else {
+            const existing = groupMerged[key];
+            if (date < existing.date) { existing.date = date; }
+            if (item.endDate > existing.item.endDate) { existing.item.endDate = item.endDate; }
+          }
+        } else {
+          rangeItems.push({ date, item });
+        }
       });
     });
+
+    Object.values(groupMerged).forEach(({ date, item }) => rangeItems.push({ date, item }));
     return rangeItems;
   }
 

--- a/media/main.js
+++ b/media/main.js
@@ -219,7 +219,9 @@
     if (!cb || !currentUri) return;
     const rawLine = Number(cb.dataset.rawLine);
     if (!Number.isInteger(rawLine) || rawLine < 0) return;
-    vscode.postMessage({ type: 'toggleTask', uri: currentUri, rawLine });
+    const sourceLine = cb.dataset.sourceLine;
+    if (typeof sourceLine !== 'string') return;
+    vscode.postMessage({ type: 'toggleTask', uri: currentUri, rawLine, sourceLine });
   });
 
   // ─── UI State Management ─────────────────────────────────────
@@ -420,7 +422,7 @@
       const tagsHtml = createTagPillsHtml(item.tags, tagColorsMap);
 
       const cbHtml = item.type === 'task'
-        ? `<span class="tm-checkbox" data-raw-line="${item.rawLine}"></span>`
+        ? `<span class="tm-checkbox" data-raw-line="${item.rawLine}" data-source-line="${escapeHtml(item.sourceLine)}"></span>`
         : '';
       const timeHtml = itemHasTime(item) ? `<span class="tm-time">${item.time}</span>` : '';
       const compactClass = isMonthly ? ' compact' : '';

--- a/media/main.js
+++ b/media/main.js
@@ -54,7 +54,10 @@
 
   // ─── Utility Functions ───────────────────────────────────────
 
-  /** Format date parts into 'YYYY-MM-DD' string */
+  /** Format date parts into 'YYYY-MM-DD' string.
+   *  Intentionally separate from src/parser.ts#toLocaleDateStr: this one takes
+   *  (y, m, d) numbers so loops like buildRangeItemIndex can avoid repeated
+   *  Date allocations, while the parser variant takes a Date instance. */
   function formatDateStr(year, month, day) {
     return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
   }

--- a/media/main.js
+++ b/media/main.js
@@ -885,10 +885,11 @@
     });
   }
 
-  /** Render child task rows below the group bar */
-  function renderGroupChildren(container, entity, startDate, pxPerMs, groupYOffset, totalWidth) {
+  /** Render child task rows below the group bar.
+   *  childStartYOffset is the absolute top of the first child row. */
+  function renderGroupChildren(container, entity, startDate, pxPerMs, childStartYOffset, totalWidth) {
     entity.children.forEach((child, i) => {
-      const childYOffset = groupYOffset + (GANTT_ROW_HEIGHT + 4) * (i + 1);
+      const childYOffset = childStartYOffset + (GANTT_ROW_HEIGHT + 4) * i;
 
       // Child row background
       const rowBg = document.createElement('div');
@@ -993,11 +994,11 @@
     ganttContainer.className = 'tm-gantt-container';
     ganttContainer.style.width = totalWidth + 'px';
     const totalRowCount = laneGroups.reduce((sum, laneEntities) => {
-      const maxChildren = laneEntities.reduce((max, e) => {
-        return e.isGroup && expandedGroups.has(e.id !== undefined ? e.id : e.name)
-          ? Math.max(max, e.children.length) : max;
+      const expandedChildCount = laneEntities.reduce((childSum, e) => {
+        const key = e.id !== undefined ? e.id : e.name;
+        return childSum + (e.isGroup && expandedGroups.has(key) ? e.children.length : 0);
       }, 0);
-      return sum + 1 + maxChildren;
+      return sum + 1 + expandedChildCount;
     }, 0);
     ganttContainer.style.height = (totalRowCount * (GANTT_ROW_HEIGHT + 4) + GANTT_HEADER_HEIGHT + 10) + 'px';
 
@@ -1009,11 +1010,17 @@
     laneGroups.forEach(laneEntities => {
       const laneYOffset = yOffset;
       yOffset += GANTT_ROW_HEIGHT + 4;
+
+      // Render all bars for this lane first
       laneEntities.forEach((entity, laneIdx) => {
         renderGanttEntityBar(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth, laneIdx > 0);
+      });
+
+      // Then render children of each expanded entity sequentially below the lane
+      laneEntities.forEach(entity => {
         const entityKey = entity.id !== undefined ? entity.id : entity.name;
         if (entity.isGroup && expandedGroups.has(entityKey)) {
-          renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, laneYOffset, totalWidth);
+          renderGroupChildren(ganttContainer, entity, startDate, pxPerMs, yOffset, totalWidth);
           yOffset += (GANTT_ROW_HEIGHT + 4) * entity.children.length;
         }
       });

--- a/media/style.css
+++ b/media/style.css
@@ -401,6 +401,7 @@ body {
 
 .tm-group-box {
   border: 1px dashed var(--tm-group-border);
+  border-left: 3px solid var(--tm-accent);
   background: var(--tm-group-bg);
   border-radius: var(--tm-radius);
   padding: 8px;

--- a/media/style.css
+++ b/media/style.css
@@ -708,20 +708,6 @@ body {
   font-weight: bold;
   white-space: nowrap;
   pointer-events: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.tm-gantt-bar-label-tags {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.tm-gantt-bar-label-tags .tm-tag {
-  margin-left: 0;
-  line-height: 1.4;
 }
 
 /* Child rows (group task members) */

--- a/media/style.css
+++ b/media/style.css
@@ -708,6 +708,20 @@ body {
   font-weight: bold;
   white-space: nowrap;
   pointer-events: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tm-gantt-bar-label-tags {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.tm-gantt-bar-label-tags .tm-tag {
+  margin-left: 0;
+  line-height: 1.4;
 }
 
 /* Child rows (group task members) */

--- a/media/style.css
+++ b/media/style.css
@@ -608,6 +608,7 @@ body {
   box-sizing: border-box;
   padding: 4px;
   color: var(--tm-fg);
+  font-size: var(--tm-font-size);
 }
 
 .tm-gantt-axis-day.sat-text strong {
@@ -624,7 +625,7 @@ body {
   left: 0;
   width: 100%;
   height: 20px;
-  font-size: 10px;
+  font-size: calc(var(--tm-font-size) - 4px);
   opacity: 0.5;
   border-top: 1px dashed var(--tm-axis-line);
 }
@@ -689,7 +690,7 @@ body {
   position: relative;
   z-index: 2;
   padding: 0 6px;
-  font-size: 9px;
+  font-size: calc(var(--tm-font-size) - 5px);
   color: var(--tm-fg);
   pointer-events: none;
 }
@@ -712,7 +713,7 @@ body {
   position: absolute;
   z-index: 7;
   padding: 0 8px;
-  font-size: 13px;
+  font-size: calc(var(--tm-font-size) - 1px);
   line-height: 32px;
   color: var(--tm-fg);
   font-weight: bold;

--- a/media/style.css
+++ b/media/style.css
@@ -498,6 +498,69 @@ body {
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
+/* ─── Compact Items (Monthly View) ──────────────────────────── */
+.tm-item.compact {
+  font-size: 12px;
+  padding: 2px 6px;
+  gap: 4px;
+  align-items: center;
+  min-width: 0;
+}
+
+.tm-item.compact .tm-item-body {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.tm-item.compact .tm-item-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tm-item.compact .tm-time {
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.tm-item.compact .tm-tag {
+  flex-shrink: 0;
+  padding: 1px 5px;
+  font-size: 10px;
+  margin-left: 0;
+}
+
+.tm-item.compact .tm-checkbox {
+  width: 12px;
+  height: 12px;
+  margin-top: 0;
+}
+
+.tm-item.compact.task.done .tm-checkbox::after {
+  top: -3px;
+  left: 0;
+  font-size: 11px;
+}
+
+.tm-calendar-grid.monthly .tm-items-list {
+  gap: 2px;
+}
+
+.tm-calendar-grid.monthly .tm-group-box {
+  padding: 4px 6px;
+  margin: 2px 0;
+}
+
+.tm-calendar-grid.monthly .tm-group-title {
+  font-size: 11px;
+  margin-bottom: 2px;
+}
+
 /* ─── Gantt / Timeline View ─────────────────────────────────── */
 .tm-gantt-view {
   width: 100%;

--- a/media/style.css
+++ b/media/style.css
@@ -162,6 +162,35 @@ body {
   background: var(--tm-card-border);
 }
 
+/* ─── Zoom Controls ─────────────────────────────────────────── */
+.tm-zoom-controls {
+  display: flex;
+  gap: 4px;
+  padding: 4px 24px;
+  background: var(--tm-bg);
+  border-bottom: 1px solid var(--tm-card-border);
+}
+
+.tm-zoom-controls button {
+  background: var(--tm-card-bg);
+  border: 1px solid var(--tm-card-border);
+  color: var(--tm-fg);
+  width: 28px;
+  height: 28px;
+  border-radius: var(--tm-radius);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--tm-transition);
+}
+
+.tm-zoom-controls button:hover {
+  background: var(--tm-card-border);
+}
+
 /* ─── Main Content Area ─────────────────────────────────────── */
 .tm-content {
   flex: 1;

--- a/media/style.css
+++ b/media/style.css
@@ -351,6 +351,7 @@ body {
 
 .clickable-date {
   cursor: pointer;
+  user-select: none;
 }
 
 .clickable-date:hover .tm-cal-date {

--- a/media/style.css
+++ b/media/style.css
@@ -351,7 +351,6 @@ body {
 
 .clickable-date {
   cursor: pointer;
-  user-select: none;
 }
 
 .clickable-date:hover .tm-cal-date {

--- a/media/style.css
+++ b/media/style.css
@@ -260,8 +260,8 @@ body {
 }
 
 .tm-cell-band {
-  height: 20px;
-  line-height: 20px;
+  height: calc(var(--tm-font-size) + 6px);
+  line-height: calc(var(--tm-font-size) + 6px);
   font-size: calc(var(--tm-font-size) - 3px);
   font-weight: 600;
   overflow: hidden;
@@ -290,7 +290,7 @@ body {
 }
 
 .tm-cell-band-spacer {
-  height: 20px;
+  height: calc(var(--tm-font-size) + 6px);
 }
 
 .tm-calendar-grid.daily {
@@ -381,9 +381,9 @@ body {
   font-size: calc(var(--tm-font-size) + 2px);
   font-weight: 600;
   display: inline-block;
-  width: 24px;
-  height: 24px;
-  line-height: 24px;
+  width: 1.5em;
+  height: 1.5em;
+  line-height: 1.5em;
   text-align: center;
   border-radius: 50%;
   transition: var(--tm-transition);
@@ -541,7 +541,7 @@ body {
 .tm-item.compact .tm-tag {
   flex-shrink: 0;
   padding: 1px 5px;
-  font-size: calc(var(--tm-font-size) - 4px);
+  font-size: max(9px, calc(var(--tm-font-size) - 4px));
   margin-left: 0;
 }
 
@@ -625,7 +625,7 @@ body {
   left: 0;
   width: 100%;
   height: 20px;
-  font-size: calc(var(--tm-font-size) - 4px);
+  font-size: max(9px, calc(var(--tm-font-size) - 4px));
   opacity: 0.5;
   border-top: 1px dashed var(--tm-axis-line);
 }

--- a/media/style.css
+++ b/media/style.css
@@ -472,6 +472,10 @@ body {
   position: relative;
 }
 
+.tm-checkbox[data-raw-line] {
+  cursor: pointer;
+}
+
 .tm-item.task.done .tm-checkbox::after {
   content: '✓';
   position: absolute;

--- a/media/style.css
+++ b/media/style.css
@@ -690,7 +690,7 @@ body {
   position: relative;
   z-index: 2;
   padding: 0 6px;
-  font-size: calc(var(--tm-font-size) - 5px);
+  font-size: 9px;
   color: var(--tm-fg);
   pointer-events: none;
 }

--- a/media/style.css
+++ b/media/style.css
@@ -166,9 +166,7 @@ body {
 .tm-zoom-controls {
   display: flex;
   gap: 4px;
-  padding: 4px 24px;
-  background: var(--tm-bg);
-  border-bottom: 1px solid var(--tm-card-border);
+  align-items: center;
 }
 
 .tm-zoom-controls button {

--- a/media/style.css
+++ b/media/style.css
@@ -214,6 +214,11 @@ body {
   overflow: hidden;
 }
 
+.tm-calendar-grid.monthly {
+  grid-template-rows: max-content;
+  grid-auto-rows: 1fr;
+}
+
 .tm-calendar-grid.weekly {
   grid-template-rows: max-content 1fr;
 }

--- a/media/style.css
+++ b/media/style.css
@@ -173,9 +173,9 @@ body {
   background: var(--tm-card-bg);
   border: 1px solid var(--tm-card-border);
   color: var(--tm-fg);
-  width: 28px;
-  height: 28px;
-  border-radius: var(--tm-radius);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
   cursor: pointer;
   font-size: 16px;
   line-height: 1;

--- a/media/style.css
+++ b/media/style.css
@@ -19,6 +19,7 @@
   --tm-radius: 8px;
   --tm-transition: all 0.2s ease-in-out;
   --tm-font: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif);
+  --tm-font-size: 14px;
   --tm-sat-color: #3498db;
   --tm-sun-color: #e74c3c;
   --tm-sat-bg: rgba(52, 152, 219, 0.08);
@@ -220,7 +221,7 @@ body {
 .tm-calendar-grid.monthly .tm-day-header,
 .tm-calendar-grid.weekly .tm-day-header {
   background-color: var(--tm-bg);
-  padding: 10px 0 8px;
+  padding: 4px 0 3px;
 }
 
 .tm-calendar-grid.monthly .tm-cal-cell,
@@ -256,7 +257,7 @@ body {
 .tm-cell-band {
   height: 20px;
   line-height: 20px;
-  font-size: 11px;
+  font-size: calc(var(--tm-font-size) - 3px);
   font-weight: 600;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -295,12 +296,12 @@ body {
 /* ─── Day Headers ───────────────────────────────────────────── */
 .tm-day-header {
   text-align: center;
-  font-size: 14px;
+  font-size: var(--tm-font-size);
   font-weight: 600;
   text-transform: uppercase;
   color: var(--tm-fg);
   opacity: 0.7;
-  padding-bottom: 8px;
+  padding-bottom: 3px;
 }
 
 .tm-day-header.sat {
@@ -365,19 +366,19 @@ body {
   background: var(--tm-bg);
   width: 100%;
   box-sizing: border-box;
-  padding: 8px;
-  margin-bottom: 4px;
+  padding: 3px 6px;
+  margin-bottom: 2px;
   border-bottom: 1px solid var(--tm-separator);
   flex-shrink: 0;
 }
 
 .tm-cal-date {
-  font-size: 16px;
+  font-size: calc(var(--tm-font-size) + 2px);
   font-weight: 600;
   display: inline-block;
-  width: 28px;
-  height: 28px;
-  line-height: 28px;
+  width: 24px;
+  height: 24px;
+  line-height: 24px;
   text-align: center;
   border-radius: 50%;
   transition: var(--tm-transition);
@@ -437,7 +438,7 @@ body {
 }
 
 .tm-group-title {
-  font-size: 13px;
+  font-size: calc(var(--tm-font-size) - 1px);
   font-weight: bold;
   opacity: 0.7;
   margin-bottom: 6px;
@@ -445,7 +446,7 @@ body {
 }
 
 .tm-item {
-  font-size: 14px;
+  font-size: var(--tm-font-size);
   padding: 8px 10px;
   border-radius: 4px;
   background: var(--tm-item-bg);
@@ -495,7 +496,7 @@ body {
   display: inline-block;
   padding: 2px 6px;
   border-radius: 10px;
-  font-size: 11px;
+  font-size: calc(var(--tm-font-size) - 3px);
   font-weight: 600;
   margin-left: 4px;
   color: #fff;
@@ -504,7 +505,7 @@ body {
 
 /* ─── Compact Items (Monthly View) ──────────────────────────── */
 .tm-item.compact {
-  font-size: 12px;
+  font-size: calc(var(--tm-font-size) - 2px);
   padding: 2px 6px;
   gap: 4px;
   align-items: center;
@@ -528,14 +529,14 @@ body {
 }
 
 .tm-item.compact .tm-time {
-  font-size: 11px;
+  font-size: calc(var(--tm-font-size) - 3px);
   flex-shrink: 0;
 }
 
 .tm-item.compact .tm-tag {
   flex-shrink: 0;
   padding: 1px 5px;
-  font-size: 10px;
+  font-size: calc(var(--tm-font-size) - 4px);
   margin-left: 0;
 }
 
@@ -561,7 +562,7 @@ body {
 }
 
 .tm-calendar-grid.monthly .tm-group-title {
-  font-size: 11px;
+  font-size: calc(var(--tm-font-size) - 3px);
   margin-bottom: 2px;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "taskmark",
-  "version": "1.2.0",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskmark",
-      "version": "1.2.0",
+      "version": "1.3.2",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "25.x",
-        "@types/vscode": "^1.115.0",
+        "@types/vscode": "^1.116.0",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
         "@typescript-eslint/parser": "^7.11.0",
         "@vscode/test-electron": "^2.5.2",
@@ -342,9 +342,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.115.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.115.0.tgz",
-      "integrity": "sha512-/M8cdznOlqtMqduHKKlIF00v4eum4ZWKgn8YoPRKcN6PDdvoWeeqDaQSnw63ipDbq1Uzz78Wndk/d0uSPwORfA==",
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
+      "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskmark",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskmark",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "25.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "25.x",
-        "@types/vscode": "^1.116.0",
+        "@types/vscode": "^1.109.1",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
         "@typescript-eslint/parser": "^7.11.0",
         "@vscode/test-electron": "^2.5.2",
@@ -20,7 +20,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "vscode": "^1.115.0"
+        "vscode": "^1.109.1"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "taskmark",
   "displayName": "TaskMark",
   "description": "Schedule and Task Management with Markdown and Calendar/Timeline Views",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "icon": "media/icon.png",
   "publisher": "Yadecode",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "25.x",
-    "@types/vscode": "^1.115.0",
+    "@types/vscode": "^1.116.0",
     "@typescript-eslint/eslint-plugin": "^7.11.0",
     "@typescript-eslint/parser": "^7.11.0",
     "@vscode/test-electron": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/tom-yade/taskmark.git"
   },
   "engines": {
-    "vscode": "^1.74.0"
+    "vscode": "^1.109.1"
   },
   "categories": [
     "Other"
@@ -91,7 +91,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "25.x",
-    "@types/vscode": "^1.116.0",
+    "@types/vscode": "^1.109.1",
     "@typescript-eslint/eslint-plugin": "^7.11.0",
     "@typescript-eslint/parser": "^7.11.0",
     "@vscode/test-electron": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,13 @@
           "type": "object",
           "default": {},
           "description": "Custom color mapping for tags (e.g. {\"meeting\": \"#ff0000\"})"
+        },
+        "taskmark.fontSize": {
+          "type": "number",
+          "default": 14,
+          "minimum": 10,
+          "maximum": 24,
+          "description": "Font size (in px) applied to the calendar views (Monthly/Weekly/Daily). Values outside 10–24 are clamped."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
           "default": 14,
           "minimum": 10,
           "maximum": 24,
-          "description": "Font size (in px) applied to the calendar views (Monthly/Weekly/Daily). Values outside 10–24 are clamped."
+          "description": "Font size (in px) applied to the calendar views (Monthly/Weekly/Daily) and Gantt timeline labels. Values outside 10–24 are clamped."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/tom-yade/taskmark.git"
   },
   "engines": {
-    "vscode": "^1.115.0"
+    "vscode": "^1.74.0"
   },
   "categories": [
     "Other"

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -138,6 +138,7 @@ export class TaskmarkPanel {
       edit.replace(uri, line.range, toggled);
       const applied = await vscode.workspace.applyEdit(edit);
       if (applied) {
+        this._debouncedUpdateFromDocument.cancel();
         this.updateFromDocument(document);
       } else {
         vscode.window.showErrorMessage(

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -139,7 +139,8 @@ export class TaskmarkPanel {
       const applied = await vscode.workspace.applyEdit(edit);
       if (applied) {
         this._debouncedUpdateFromDocument.cancel();
-        this.updateFromDocument(document);
+        const latest = await vscode.workspace.openTextDocument(uri);
+        this.updateFromDocument(latest);
       } else {
         vscode.window.showErrorMessage(
           'TaskMark: Failed to toggle task. The file may be read-only or locked by another process.'

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -7,15 +7,9 @@ import {
   TaskMarkUpdateMessage,
   TaskMarkErrorMessage,
   ToggleTaskMessage,
-  toggleCheckboxInLine
+  toggleCheckboxInLine,
+  resolveToggleTargetLineIndex
 } from './messages';
-
-export {
-  TaskMarkUpdateMessage,
-  TaskMarkErrorMessage,
-  ToggleTaskMessage,
-  toggleCheckboxInLine
-};
 
 export class TaskmarkPanel {
   public static currentPanel: TaskmarkPanel | undefined;
@@ -115,21 +109,38 @@ export class TaskmarkPanel {
     const msg = message as { type?: unknown };
     if (msg.type === 'toggleTask') {
       const toggle = message as ToggleTaskMessage;
-      if (typeof toggle.uri !== 'string' || typeof toggle.rawLine !== 'number') {
+      if (
+        typeof toggle.uri !== 'string' ||
+        typeof toggle.rawLine !== 'number' ||
+        typeof toggle.sourceLine !== 'string'
+      ) {
         return;
       }
-      void this.toggleTaskInDocument(toggle.uri, toggle.rawLine);
+      void this.toggleTaskInDocument(toggle.uri, toggle.rawLine, toggle.sourceLine);
     }
   }
 
-  private async toggleTaskInDocument(uriString: string, rawLine: number): Promise<void> {
+  private async toggleTaskInDocument(
+    uriString: string,
+    rawLine: number,
+    sourceLine: string
+  ): Promise<void> {
     try {
       const uri = vscode.Uri.parse(uriString);
       const document = await vscode.workspace.openTextDocument(uri);
-      if (rawLine < 0 || rawLine >= document.lineCount) {
+      const resolved = resolveToggleTargetLineIndex(
+        document.lineCount,
+        i => document.lineAt(i).text,
+        rawLine,
+        sourceLine
+      );
+      if (resolved === null) {
+        vscode.window.showInformationMessage(
+          'TaskMark: That task no longer matches the file (it may have been edited). Open TaskMark again or toggle from the editor.'
+        );
         return;
       }
-      const line = document.lineAt(rawLine);
+      const line = document.lineAt(resolved);
       const toggled = toggleCheckboxInLine(line.text);
       if (toggled === null || toggled === line.text) {
         return;

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -139,9 +139,15 @@ export class TaskmarkPanel {
       const applied = await vscode.workspace.applyEdit(edit);
       if (applied) {
         this.updateFromDocument(document);
+      } else {
+        vscode.window.showErrorMessage(
+          'TaskMark: Failed to toggle task. The file may be read-only or locked by another process.'
+        );
       }
     } catch (e) {
       console.error('TaskMark toggleTask error', e);
+      const detail = e instanceof Error ? e.message : String(e);
+      vscode.window.showErrorMessage(`TaskMark: Failed to toggle task. ${detail}`);
     }
   }
 

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -139,8 +139,7 @@ export class TaskmarkPanel {
       const applied = await vscode.workspace.applyEdit(edit);
       if (applied) {
         this._debouncedUpdateFromDocument.cancel();
-        const latest = await vscode.workspace.openTextDocument(uri);
-        this.updateFromDocument(latest);
+        this.updateFromDocument(document);
       } else {
         vscode.window.showErrorMessage(
           'TaskMark: Failed to toggle task. The file may be read-only or locked by another process.'

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -1,21 +1,21 @@
 import * as vscode from 'vscode';
-import { parseTmd, TaskMarkData, VALID_CSS_COLOR_REGEX } from './parser';
-import { buildGanttEntities, GanttData } from './gantt';
+import { parseTmd, VALID_CSS_COLOR_REGEX } from './parser';
+import { buildGanttEntities } from './gantt';
 import { getWebviewHtml } from './template';
 import { debounce, DebouncedFn } from './utils/debounce';
+import {
+  TaskMarkUpdateMessage,
+  TaskMarkErrorMessage,
+  ToggleTaskMessage,
+  toggleCheckboxInLine
+} from './messages';
 
-export interface TaskMarkUpdateMessage {
-  type: 'update';
-  uri: string;
-  data: TaskMarkData;
-  ganttData: GanttData;
-  warnings: string[];
-}
-
-export interface TaskMarkErrorMessage {
-  type: 'parseError';
-  message: string;
-}
+export {
+  TaskMarkUpdateMessage,
+  TaskMarkErrorMessage,
+  ToggleTaskMessage,
+  toggleCheckboxInLine
+};
 
 export class TaskmarkPanel {
   public static currentPanel: TaskmarkPanel | undefined;
@@ -100,6 +100,49 @@ export class TaskmarkPanel {
       null,
       this._disposables
     );
+
+    this._panel.webview.onDidReceiveMessage(
+      msg => this.handleWebviewMessage(msg),
+      null,
+      this._disposables
+    );
+  }
+
+  private handleWebviewMessage(message: unknown): void {
+    if (!message || typeof message !== 'object') {
+      return;
+    }
+    const msg = message as { type?: unknown };
+    if (msg.type === 'toggleTask') {
+      const toggle = message as ToggleTaskMessage;
+      if (typeof toggle.uri !== 'string' || typeof toggle.rawLine !== 'number') {
+        return;
+      }
+      void this.toggleTaskInDocument(toggle.uri, toggle.rawLine);
+    }
+  }
+
+  private async toggleTaskInDocument(uriString: string, rawLine: number): Promise<void> {
+    try {
+      const uri = vscode.Uri.parse(uriString);
+      const document = await vscode.workspace.openTextDocument(uri);
+      if (rawLine < 0 || rawLine >= document.lineCount) {
+        return;
+      }
+      const line = document.lineAt(rawLine);
+      const toggled = toggleCheckboxInLine(line.text);
+      if (toggled === null || toggled === line.text) {
+        return;
+      }
+      const edit = new vscode.WorkspaceEdit();
+      edit.replace(uri, line.range, toggled);
+      const applied = await vscode.workspace.applyEdit(edit);
+      if (applied) {
+        this.updateFromDocument(document);
+      }
+    } catch (e) {
+      console.error('TaskMark toggleTask error', e);
+    }
   }
 
   private updateFromActiveEditor() {

--- a/src/TaskmarkPanel.ts
+++ b/src/TaskmarkPanel.ts
@@ -8,7 +8,8 @@ import {
   TaskMarkErrorMessage,
   ToggleTaskMessage,
   toggleCheckboxInLine,
-  resolveToggleTargetLineIndex
+  resolveToggleTargetLineIndex,
+  resolveFontSize
 } from './messages';
 
 export class TaskmarkPanel {
@@ -87,7 +88,10 @@ export class TaskmarkPanel {
 
     vscode.workspace.onDidChangeConfiguration(
       e => {
-        if (e.affectsConfiguration('taskmark.tagColors')) {
+        if (
+          e.affectsConfiguration('taskmark.tagColors') ||
+          e.affectsConfiguration('taskmark.fontSize')
+        ) {
           this.updateFromActiveEditor();
         }
       },
@@ -174,7 +178,8 @@ export class TaskmarkPanel {
     try {
       const text = document.getText();
       const { data: parsedData, warnings } = parseTmd(text);
-      const configColors = vscode.workspace.getConfiguration('taskmark').get<Record<string, string>>('tagColors', {});
+      const config = vscode.workspace.getConfiguration('taskmark');
+      const configColors = config.get<Record<string, string>>('tagColors', {});
       for (const [tag, color] of Object.entries(configColors)) {
         if (VALID_CSS_COLOR_REGEX.test(color)) {
           if (!parsedData.tagColors[tag]) {
@@ -184,12 +189,14 @@ export class TaskmarkPanel {
           warnings.push(`Setting tagColors: invalid color '${color}' for tag '${tag}', skipped`);
         }
       }
+      const fontSize = resolveFontSize(config.get<number>('fontSize'));
       const message: TaskMarkUpdateMessage = {
         type: 'update',
         uri: document.uri.toString(),
         data: parsedData,
         ganttData: buildGanttEntities(parsedData),
-        warnings: [...new Set(warnings)]
+        warnings: [...new Set(warnings)],
+        fontSize
       };
       this._panel.webview.postMessage(message);
     } catch (e) {

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -13,7 +13,9 @@ export interface GanttChildItem {
 }
 
 export interface GanttEntity {
+  id: string;
   name: string;
+  lane: string;
   isGroup: boolean;
   minTime: number;
   maxTime: number;
@@ -78,10 +80,13 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
       }
 
       const bucket = item.group ? groupEntities : standaloneEntities;
-      const key = item.group ?? item.text;
+      const displayName = item.group ?? item.text;
+      const key = `${dStr}::${displayName}`;
       if (!bucket[key]) {
         bucket[key] = {
-          name: key,
+          id: key,
+          name: displayName,
+          lane: displayName,
           isGroup: !!item.group,
           minTime: startMs,
           maxTime: endMs,

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -92,7 +92,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
           isGroup: !!item.group,
           minTime: startMs,
           maxTime: endMs,
-          tags: groupHeaderTags ? [...groupHeaderTags] : [...item.tags],
+          tags: groupHeaderTags ? [...groupHeaderTags] : [],
           tasksTotal: 0,
           tasksDone: 0,
           children: []

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -84,6 +84,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
       const typePrefix = item.group ? 'g' : 's';
       const key = `${typePrefix}::${dStr}::${displayName}`;
       if (!bucket[key]) {
+        const groupHeaderTags = item.group ? (data.groupTags[`${dStr}::${displayName}`] ?? null) : null;
         bucket[key] = {
           id: key,
           name: displayName,
@@ -91,7 +92,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
           isGroup: !!item.group,
           minTime: startMs,
           maxTime: endMs,
-          tags: [...item.tags],
+          tags: groupHeaderTags ? [...groupHeaderTags] : [...item.tags],
           tasksTotal: 0,
           tasksDone: 0,
           children: []

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -81,7 +81,8 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
 
       const bucket = item.group ? groupEntities : standaloneEntities;
       const displayName = item.group ?? item.text;
-      const key = `${dStr}::${displayName}`;
+      const typePrefix = item.group ? 'g' : 's';
+      const key = `${typePrefix}::${dStr}::${displayName}`;
       if (!bucket[key]) {
         bucket[key] = {
           id: key,

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -92,7 +92,9 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
           isGroup: !!item.group,
           minTime: startMs,
           maxTime: endMs,
-          tags: groupHeaderTags ? [...groupHeaderTags] : [],
+          tags: item.group
+            ? (groupHeaderTags ? [...groupHeaderTags] : [])
+            : [...item.tags],
           tasksTotal: 0,
           tasksDone: 0,
           children: []

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -84,7 +84,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
       const typePrefix = item.group ? 'g' : 's';
       const key = `${typePrefix}::${dStr}::${displayName}`;
       if (!bucket[key]) {
-        const groupHeaderTags = item.group ? (data.groupTags[`${dStr}::${displayName}`] ?? null) : null;
+        const groupHeaderTags = item.group ? (data.groupTags[`${item.startDate}::${displayName}`] ?? null) : null;
         bucket[key] = {
           id: key,
           name: displayName,

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,4 +1,4 @@
-import { TaskMarkData, TASK_LINE_PREFIX_SRC } from './parser';
+import { TaskMarkData, TASK_LINE_PREFIX_NC } from './parser';
 import { GanttData } from './gantt';
 
 export interface TaskMarkUpdateMessage {
@@ -22,28 +22,31 @@ export interface ToggleTaskMessage {
   sourceLine: string;
 }
 
-// Anchored to the start of the line and built from the same
-// TASK_LINE_PREFIX_SRC as parser.ts ITEM_REGEX, so that only the leading
-// status checkbox of a line that parser would recognise as a task is
-// ever matched. Leading indentation is intentionally rejected because
-// parser.ts ITEM_REGEX does not accept indented task lines either.
-// Capture layout:
-//   1: full prefix up to and including '[' and optional inner space
-//   2: group marker '>\s*' (nested within group 1)
-//   3: bullet '-'         (nested within group 1)
-//   4: the checkbox character (' ' | 'x' | 'X')
-//   5: optional inner space + ']'
-const CHECKBOX_REGEX = new RegExp(
-  `^(${TASK_LINE_PREFIX_SRC}\\s*\\[\\s*)([ xX])(\\s*\\])`
+// Leading line prefix matches parser ITEM_REGEX (TASK_LINE_PREFIX_NC + \s*).
+// Bracket interior mirrors ITEM: \[\s*([xX\s])\s*\] — one mark character
+// with flexible inner whitespace. Only that mark is swapped ('x' todo→done,
+// ASCII space done→todo) so surrounding spaces inside the brackets are kept.
+const CHECKBOX_LINE_REGEX = new RegExp(
+  `^(${TASK_LINE_PREFIX_NC}\\s*)(\\[)(\\s*)([xX\\s])(\\s*)(\\])`
 );
 
 export function toggleCheckboxInLine(line: string): string | null {
-  const match = CHECKBOX_REGEX.exec(line);
+  const match = CHECKBOX_LINE_REGEX.exec(line);
   if (!match) {
     return null;
   }
-  const toggled = match[4] === ' ' ? 'x' : ' ';
-  return line.replace(CHECKBOX_REGEX, `$1${toggled}$5`);
+  const mark = match[4];
+  const isDone = mark.trim().toLowerCase() === 'x';
+  const newMark = isDone ? ' ' : 'x';
+  return (
+    match[1] +
+    match[2] +
+    match[3] +
+    newMark +
+    match[5] +
+    match[6] +
+    line.slice(match[0].length)
+  );
 }
 
 /**

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -22,9 +22,9 @@ export interface ToggleTaskMessage {
 
 // Anchored to the start of the line and built from the same
 // TASK_LINE_PREFIX_SRC as parser.ts ITEM_REGEX, so that only the leading
-// status checkbox is ever matched — never a bracketed token that happens
-// to appear inside the task text — and the prefix definition stays in
-// sync with the parser.
+// status checkbox of a line that parser would recognise as a task is
+// ever matched. Leading indentation is intentionally rejected because
+// parser.ts ITEM_REGEX does not accept indented task lines either.
 // Capture layout:
 //   1: full prefix up to and including '[' and optional inner space
 //   2: group marker '>\s*' (nested within group 1)
@@ -32,7 +32,7 @@ export interface ToggleTaskMessage {
 //   4: the checkbox character (' ' | 'x' | 'X')
 //   5: optional inner space + ']'
 const CHECKBOX_REGEX = new RegExp(
-  `^(\\s*${TASK_LINE_PREFIX_SRC}\\s*\\[\\s*)([ xX])(\\s*\\])`
+  `^(${TASK_LINE_PREFIX_SRC}\\s*\\[\\s*)([ xX])(\\s*\\])`
 );
 
 export function toggleCheckboxInLine(line: string): string | null {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,4 +1,4 @@
-import { TaskMarkData } from './parser';
+import { TaskMarkData, TASK_LINE_PREFIX_SRC } from './parser';
 import { GanttData } from './gantt';
 
 export interface TaskMarkUpdateMessage {
@@ -20,17 +20,26 @@ export interface ToggleTaskMessage {
   rawLine: number;
 }
 
-// Anchored to the start of the line, matching the same prefix shape as
-// parser.ts ITEM_REGEX (optional indent, optional group marker, optional
-// bullet) so only the status checkbox is touched — never a bracketed token
-// that appears inside the task text.
-const CHECKBOX_REGEX = /^(\s*(?:>\s*)?(?:-\s*)?\[\s*)([ xX])(\s*\])/;
+// Anchored to the start of the line and built from the same
+// TASK_LINE_PREFIX_SRC as parser.ts ITEM_REGEX, so that only the leading
+// status checkbox is ever matched — never a bracketed token that happens
+// to appear inside the task text — and the prefix definition stays in
+// sync with the parser.
+// Capture layout:
+//   1: full prefix up to and including '[' and optional inner space
+//   2: group marker '>\s*' (nested within group 1)
+//   3: bullet '-'         (nested within group 1)
+//   4: the checkbox character (' ' | 'x' | 'X')
+//   5: optional inner space + ']'
+const CHECKBOX_REGEX = new RegExp(
+  `^(\\s*${TASK_LINE_PREFIX_SRC}\\s*\\[\\s*)([ xX])(\\s*\\])`
+);
 
 export function toggleCheckboxInLine(line: string): string | null {
   const match = CHECKBOX_REGEX.exec(line);
   if (!match) {
     return null;
   }
-  const toggled = match[2] === ' ' ? 'x' : ' ';
-  return line.replace(CHECKBOX_REGEX, `$1${toggled}$3`);
+  const toggled = match[4] === ' ' ? 'x' : ' ';
+  return line.replace(CHECKBOX_REGEX, `$1${toggled}$5`);
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -20,13 +20,17 @@ export interface ToggleTaskMessage {
   rawLine: number;
 }
 
-const CHECKBOX_REGEX = /\[([ xX])\]/;
+// Anchored to the start of the line, matching the same prefix shape as
+// parser.ts ITEM_REGEX (optional indent, optional group marker, optional
+// bullet) so only the status checkbox is touched — never a bracketed token
+// that appears inside the task text.
+const CHECKBOX_REGEX = /^(\s*(?:>\s*)?(?:-\s*)?\[\s*)([ xX])(\s*\])/;
 
 export function toggleCheckboxInLine(line: string): string | null {
   const match = CHECKBOX_REGEX.exec(line);
   if (!match) {
     return null;
   }
-  const toggled = match[1] === ' ' ? 'x' : ' ';
-  return line.replace(CHECKBOX_REGEX, `[${toggled}]`);
+  const toggled = match[2] === ' ' ? 'x' : ' ';
+  return line.replace(CHECKBOX_REGEX, `$1${toggled}$3`);
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -18,6 +18,8 @@ export interface ToggleTaskMessage {
   type: 'toggleTask';
   uri: string;
   rawLine: number;
+  /** Full document line as captured when the panel last parsed the file. */
+  sourceLine: string;
 }
 
 // Anchored to the start of the line and built from the same
@@ -42,4 +44,47 @@ export function toggleCheckboxInLine(line: string): string | null {
   }
   const toggled = match[4] === ' ' ? 'x' : ' ';
   return line.replace(CHECKBOX_REGEX, `$1${toggled}$5`);
+}
+
+/**
+ * Resolves which zero-based line index to toggle when `rawLine` may be stale
+ * (e.g. the document changed since the webview rendered). Uses exact line text
+ * equality with the value captured at parse time. When multiple lines match,
+ * picks the index closest to `rawLine`, breaking ties toward a lower line number.
+ */
+export function resolveToggleTargetLineIndex(
+  lineCount: number,
+  getLineText: (index: number) => string,
+  rawLine: number,
+  sourceLine: string
+): number | null {
+  if (lineCount <= 0 || rawLine < 0) {
+    return null;
+  }
+  if (rawLine < lineCount && getLineText(rawLine) === sourceLine) {
+    return rawLine;
+  }
+  const matches: number[] = [];
+  for (let j = 0; j < lineCount; j++) {
+    if (getLineText(j) === sourceLine) {
+      matches.push(j);
+    }
+  }
+  if (matches.length === 0) {
+    return null;
+  }
+  if (matches.length === 1) {
+    return matches[0];
+  }
+  let best = matches[0];
+  let bestDist = Math.abs(best - rawLine);
+  for (let k = 1; k < matches.length; k++) {
+    const m = matches[k];
+    const d = Math.abs(m - rawLine);
+    if (d < bestDist || (d === bestDist && m < best)) {
+      best = m;
+      bestDist = d;
+    }
+  }
+  return best;
 }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,32 @@
+import { TaskMarkData } from './parser';
+import { GanttData } from './gantt';
+
+export interface TaskMarkUpdateMessage {
+  type: 'update';
+  uri: string;
+  data: TaskMarkData;
+  ganttData: GanttData;
+  warnings: string[];
+}
+
+export interface TaskMarkErrorMessage {
+  type: 'parseError';
+  message: string;
+}
+
+export interface ToggleTaskMessage {
+  type: 'toggleTask';
+  uri: string;
+  rawLine: number;
+}
+
+const CHECKBOX_REGEX = /\[([ xX])\]/;
+
+export function toggleCheckboxInLine(line: string): string | null {
+  const match = CHECKBOX_REGEX.exec(line);
+  if (!match) {
+    return null;
+  }
+  const toggled = match[1] === ' ' ? 'x' : ' ';
+  return line.replace(CHECKBOX_REGEX, `[${toggled}]`);
+}

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -18,20 +18,8 @@ export function resolveFontSize(value: unknown, fallback: number = FONT_SIZE_DEF
   if (typeof value !== 'number' || Number.isNaN(value)) {
     return fallback;
   }
-  if (value === Infinity) {
-    return FONT_SIZE_MAX;
-  }
-  if (value === -Infinity) {
-    return FONT_SIZE_MIN;
-  }
   const floored = Math.floor(value);
-  if (floored < FONT_SIZE_MIN) {
-    return FONT_SIZE_MIN;
-  }
-  if (floored > FONT_SIZE_MAX) {
-    return FONT_SIZE_MAX;
-  }
-  return floored;
+  return Math.max(FONT_SIZE_MIN, Math.min(FONT_SIZE_MAX, floored));
 }
 
 export interface TaskMarkErrorMessage {

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -7,6 +7,31 @@ export interface TaskMarkUpdateMessage {
   data: TaskMarkData;
   ganttData: GanttData;
   warnings: string[];
+  fontSize: number;
+}
+
+export const FONT_SIZE_MIN = 10;
+export const FONT_SIZE_MAX = 24;
+export const FONT_SIZE_DEFAULT = 14;
+
+export function resolveFontSize(value: unknown, fallback: number = FONT_SIZE_DEFAULT): number {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return fallback;
+  }
+  if (value === Infinity) {
+    return FONT_SIZE_MAX;
+  }
+  if (value === -Infinity) {
+    return FONT_SIZE_MIN;
+  }
+  const floored = Math.floor(value);
+  if (floored < FONT_SIZE_MIN) {
+    return FONT_SIZE_MIN;
+  }
+  if (floored > FONT_SIZE_MAX) {
+    return FONT_SIZE_MAX;
+  }
+  return floored;
 }
 
 export interface TaskMarkErrorMessage {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -233,6 +233,10 @@ export function parseTmd(text: string): ParseResult {
     const groupMatch = line.match(GROUP_REGEX);
     if (groupMatch) {
       const { tags: gTags, cleaned: gName } = extractTags(groupMatch[1].trim());
+      if (!gName) {
+        warnings.push(`Line ${i + 1}: group header has no name, skipped`);
+        continue;
+      }
       currentGroup = gName;
       if (gTags.length > 0 && currentDate) {
         data.groupTags[`${currentDate}::${currentGroup}`] = gTags;

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,6 @@
 export interface TaskMarkData {
   tagColors: Record<string, string>;
+  groupTags: Record<string, string[]>; // Key is "YYYY-MM-DD::groupName"
   days: Record<string, DayData>; // Key is YYYY-MM-DD
 }
 
@@ -167,7 +168,7 @@ function parseRepeatOptions(repeatStr: string, lineNum: number, warnings: string
 
 export function parseTmd(text: string): ParseResult {
   const lines = text.split(/\r?\n/);
-  const data: TaskMarkData = { tagColors: {}, days: {} };
+  const data: TaskMarkData = { tagColors: {}, groupTags: {}, days: {} };
   const warnings: string[] = [];
 
   let inTagsBlock = false;
@@ -231,7 +232,11 @@ export function parseTmd(text: string): ParseResult {
     // 3. Group header
     const groupMatch = line.match(GROUP_REGEX);
     if (groupMatch) {
-      currentGroup = groupMatch[1].trim();
+      const { tags: gTags, cleaned: gName } = extractTags(groupMatch[1].trim());
+      currentGroup = gName;
+      if (gTags.length > 0 && currentDate) {
+        data.groupTags[`${currentDate}::${currentGroup}`] = gTags;
+      }
       continue;
     }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -39,9 +39,10 @@ const TAG_COLOR_REGEX = /^#([^\s:]+)\s*:\s*(.+)$/;
 export const VALID_CSS_COLOR_REGEX = /^(?:#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|(?:rgb|hsl)a?\(\s*\d[\d.]*%?(?:\s*[,/\s]\s*\d[\d.]*%?){2,3}\s*\)|[a-zA-Z]{1,30})$/;
 const DATE_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})(?:\s*:\s*(\d{4}-\d{1,2}-\d{1,2}))?/;
 const GROUP_REGEX = /^>\s*([^-\s].+)$/;
-// Shared with messages.ts toggleCheckboxInLine — modify both together.
-export const TASK_LINE_PREFIX_SRC = '(>\\s*)?(-)?';
-/** Non-capturing form of TASK_LINE_PREFIX_SRC for toggle / search helpers. */
+// Capturing form, used locally to build ITEM_REGEX.
+const TASK_LINE_PREFIX_SRC = '(>\\s*)?(-)?';
+/** Non-capturing form of the same prefix — shared with messages.ts
+ *  toggleCheckboxInLine. Keep the two regex shapes in sync. */
 export const TASK_LINE_PREFIX_NC = '(?:>\\s*)?(?:-)?';
 const ITEM_REGEX = new RegExp(
   `^${TASK_LINE_PREFIX_SRC}\\s*(\\[\\s*([xX\\s])\\s*\\])?\\s*((\\d{1,2}:\\d{1,2})(?:-(\\d{1,2}:\\d{1,2}))?)?\\s*(.*)$`

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -27,6 +27,7 @@ export interface MarkItem {
   repeat?: string;
   group?: string;
   rawLine: number;
+  startDate: string;
   endDate?: string;
 }
 
@@ -303,6 +304,7 @@ function createMarkItem(
     repeat: repeatStr,
     group: newGroup || undefined,
     rawLine: lineIndex,
+    startDate: currentDate,
     endDate: endDate || undefined,
   };
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -41,6 +41,8 @@ const DATE_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})(?:\s*:\s*(\d{4}-\d{1,2}-\d{1,2}
 const GROUP_REGEX = /^>\s*([^-\s].+)$/;
 // Shared with messages.ts toggleCheckboxInLine — modify both together.
 export const TASK_LINE_PREFIX_SRC = '(>\\s*)?(-)?';
+/** Non-capturing form of TASK_LINE_PREFIX_SRC for toggle / search helpers. */
+export const TASK_LINE_PREFIX_NC = '(?:>\\s*)?(?:-)?';
 const ITEM_REGEX = new RegExp(
   `^${TASK_LINE_PREFIX_SRC}\\s*(\\[\\s*([xX\\s])\\s*\\])?\\s*((\\d{1,2}:\\d{1,2})(?:-(\\d{1,2}:\\d{1,2}))?)?\\s*(.*)$`
 );

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -21,6 +21,8 @@ export interface MarkItem {
   id: string;
   type: ItemType;
   text: string;
+  /** Exact document line text at parse time; used to verify toggles after edits. */
+  sourceLine: string;
   time?: string;
   tags: string[];
   status?: TaskStatus;
@@ -252,7 +254,7 @@ export function parseTmd(text: string): ParseResult {
     // 4. Item (schedule or task)
     const itemMatch = rawLine.match(ITEM_REGEX);
     if (itemMatch && itemMatch[2]) {
-      const result = createMarkItem(itemMatch, i, currentDate, currentGroup, currentEndDate);
+      const result = createMarkItem(itemMatch, i, rawLine, currentDate, currentGroup, currentEndDate);
       if (result) {
         data.days[currentDate].items.push(result.item);
         currentGroup = result.newGroup;
@@ -266,6 +268,7 @@ export function parseTmd(text: string): ParseResult {
 function createMarkItem(
   itemMatch: RegExpMatchArray,
   lineIndex: number,
+  sourceLine: string,
   currentDate: string,
   currentGroup: string,
   endDate = '',
@@ -302,6 +305,7 @@ function createMarkItem(
     id: `item-${lineIndex}-${currentDate}`,
     type,
     text: cleaned,
+    sourceLine,
     time: timeString,
     tags,
     status,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -37,7 +37,11 @@ const TAG_COLOR_REGEX = /^#([^\s:]+)\s*:\s*(.+)$/;
 export const VALID_CSS_COLOR_REGEX = /^(?:#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})|(?:rgb|hsl)a?\(\s*\d[\d.]*%?(?:\s*[,/\s]\s*\d[\d.]*%?){2,3}\s*\)|[a-zA-Z]{1,30})$/;
 const DATE_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})(?:\s*:\s*(\d{4}-\d{1,2}-\d{1,2}))?/;
 const GROUP_REGEX = /^>\s*([^-\s].+)$/;
-const ITEM_REGEX = /^(>\s*)?(-)?\s*(\[\s*([xX\s])\s*\])?\s*((\d{1,2}:\d{1,2})(?:-(\d{1,2}:\d{1,2}))?)?\s*(.*)$/;
+// Shared with messages.ts toggleCheckboxInLine — modify both together.
+export const TASK_LINE_PREFIX_SRC = '(>\\s*)?(-)?';
+const ITEM_REGEX = new RegExp(
+  `^${TASK_LINE_PREFIX_SRC}\\s*(\\[\\s*([xX\\s])\\s*\\])?\\s*((\\d{1,2}:\\d{1,2})(?:-(\\d{1,2}:\\d{1,2}))?)?\\s*(.*)$`
+);
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
 const TAG_SPLIT_REGEX = /#([^\s#]+)/g;
 const EVERY_REGEX = /^(\d+)(days?|weeks?|months?)$/;

--- a/src/template.ts
+++ b/src/template.ts
@@ -2,7 +2,12 @@ import * as vscode from 'vscode';
 import { VALID_CSS_COLOR_REGEX } from './parser';
 
 function escapeHtmlAttr(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, cspSource: string): string {

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,6 +1,15 @@
 import * as vscode from 'vscode';
+import { VALID_CSS_COLOR_REGEX } from './parser';
+
+function escapeHtmlAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+}
 
 export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, cspSource: string): string {
+  // Expose the canonical color validation regex to the webview so main.js
+  // does not duplicate it. Embedded via a data-* attribute (no inline script)
+  // to keep the strict CSP intact.
+  const colorReAttr = escapeHtmlAttr(VALID_CSS_COLOR_REGEX.source);
   return `<!DOCTYPE html>
       <html lang="en">
       <head>
@@ -10,7 +19,7 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
         <title>TaskMark</title>
         <link href="${stylesUri}" rel="stylesheet">
       </head>
-      <body>
+      <body data-valid-css-color-re="${colorReAttr}">
         <div id="tm-parse-error-banner" class="tm-error-banner hidden"></div>
         <div id="tm-warning-banner" class="tm-warning-banner hidden"></div>
         <div class="tm-header">

--- a/src/template.ts
+++ b/src/template.ts
@@ -29,10 +29,10 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
              <h2 id="current-month-display"></h2>
              <button id="btn-next-month">&gt;</button>
           </div>
-        </div>
-        <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
-          <button id="btn-zoom-in">+</button>
-          <button id="btn-zoom-out">-</button>
+          <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
+            <button id="btn-zoom-out">-</button>
+            <button id="btn-zoom-in">+</button>
+          </div>
         </div>
         <div class="tm-content" id="tm-content-area">
           <div class="tm-calendar-grid" id="tm-calendar"></div>

--- a/src/template.ts
+++ b/src/template.ts
@@ -30,6 +30,10 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
              <button id="btn-next-month">&gt;</button>
           </div>
         </div>
+        <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
+          <button id="btn-zoom-in">+</button>
+          <button id="btn-zoom-out">-</button>
+        </div>
         <div class="tm-content" id="tm-content-area">
           <div class="tm-calendar-grid" id="tm-calendar"></div>
           <div class="tm-timeline-view hidden" id="tm-timeline"></div>

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,20 +1,11 @@
 import * as vscode from 'vscode';
 import { VALID_CSS_COLOR_REGEX } from './parser';
 
-function escapeHtmlAttr(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
 export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, cspSource: string): string {
   // Expose the canonical color validation regex to the webview so main.js
   // does not duplicate it. Embedded via a data-* attribute (no inline script)
   // to keep the strict CSP intact.
-  const colorReAttr = escapeHtmlAttr(VALID_CSS_COLOR_REGEX.source);
+  const colorReAttr = VALID_CSS_COLOR_REGEX.source;
   return `<!DOCTYPE html>
       <html lang="en">
       <head>

--- a/src/template.ts
+++ b/src/template.ts
@@ -30,8 +30,8 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
              <button id="btn-next-month">&gt;</button>
           </div>
           <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
-            <button id="btn-zoom-out">-</button>
-            <button id="btn-zoom-in">+</button>
+            <button id="btn-zoom-out" title="Zoom Out">-</button>
+            <button id="btn-zoom-in" title="Zoom In">+</button>
           </div>
         </div>
         <div class="tm-content" id="tm-content-area">

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -4,7 +4,8 @@ import {
   TaskMarkErrorMessage,
   ToggleTaskMessage,
   toggleCheckboxInLine,
-  resolveToggleTargetLineIndex
+  resolveToggleTargetLineIndex,
+  resolveFontSize
 } from '../../messages';
 
 suite('TaskmarkPanel message types', () => {
@@ -14,7 +15,8 @@ suite('TaskmarkPanel message types', () => {
       uri: 'file:///test.tmd',
       data: { tagColors: {}, groupTags: {}, days: {} },
       ganttData: { entities: [], lastDateStr: '' },
-      warnings: []
+      warnings: [],
+      fontSize: 14
     };
     assert.strictEqual(msg.type, 'update');
   });
@@ -25,10 +27,24 @@ suite('TaskmarkPanel message types', () => {
       uri: 'file:///test.tmd',
       data: { tagColors: {}, groupTags: {}, days: {} },
       ganttData: { entities: [], lastDateStr: '' },
-      warnings: ["Line 5: invalid date '2026-99-99', skipped"]
+      warnings: ["Line 5: invalid date '2026-99-99', skipped"],
+      fontSize: 14
     };
     assert.strictEqual(msg.warnings.length, 1);
     assert.ok(msg.warnings[0].includes('2026-99-99'));
+  });
+
+  test('TaskMarkUpdateMessage carries a numeric fontSize', () => {
+    const msg: TaskMarkUpdateMessage = {
+      type: 'update',
+      uri: 'file:///test.tmd',
+      data: { tagColors: {}, groupTags: {}, days: {} },
+      ganttData: { entities: [], lastDateStr: '' },
+      warnings: [],
+      fontSize: 18
+    };
+    assert.strictEqual(typeof msg.fontSize, 'number');
+    assert.strictEqual(msg.fontSize, 18);
   });
 
   test('TaskMarkErrorMessage has type "parseError" and a message field', () => {
@@ -150,5 +166,56 @@ suite('toggleCheckboxInLine', () => {
 
   test('returns null when non-bullet text precedes the checkbox', () => {
     assert.strictEqual(toggleCheckboxInLine('foo - [ ] bar'), null);
+  });
+});
+
+suite('resolveFontSize', () => {
+  test('returns default (14) when value is undefined', () => {
+    assert.strictEqual(resolveFontSize(undefined), 14);
+  });
+
+  test('returns default (14) when value is null', () => {
+    assert.strictEqual(resolveFontSize(null), 14);
+  });
+
+  test('returns the value unchanged when within allowed range', () => {
+    assert.strictEqual(resolveFontSize(16), 16);
+    assert.strictEqual(resolveFontSize(10), 10);
+    assert.strictEqual(resolveFontSize(24), 24);
+  });
+
+  test('clamps below-minimum values up to 10', () => {
+    assert.strictEqual(resolveFontSize(4), 10);
+    assert.strictEqual(resolveFontSize(0), 10);
+    assert.strictEqual(resolveFontSize(-5), 10);
+  });
+
+  test('clamps above-maximum values down to 24', () => {
+    assert.strictEqual(resolveFontSize(99), 24);
+    assert.strictEqual(resolveFontSize(25), 24);
+  });
+
+  test('returns fallback when value is a non-number string', () => {
+    assert.strictEqual(resolveFontSize('big'), 14);
+    assert.strictEqual(resolveFontSize('16'), 14);
+  });
+
+  test('returns fallback for NaN', () => {
+    assert.strictEqual(resolveFontSize(NaN), 14);
+  });
+
+  test('clamps Infinity to the max bound', () => {
+    assert.strictEqual(resolveFontSize(Infinity), 24);
+    assert.strictEqual(resolveFontSize(-Infinity), 10);
+  });
+
+  test('respects a custom fallback', () => {
+    assert.strictEqual(resolveFontSize(undefined, 18), 18);
+    assert.strictEqual(resolveFontSize('nope', 20), 20);
+  });
+
+  test('floors fractional values before clamping', () => {
+    assert.strictEqual(resolveFontSize(14.7), 14);
+    assert.strictEqual(resolveFontSize(10.9), 10);
   });
 });

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -1,5 +1,10 @@
 import * as assert from 'assert';
-import { TaskMarkUpdateMessage, TaskMarkErrorMessage } from '../../TaskmarkPanel';
+import {
+  TaskMarkUpdateMessage,
+  TaskMarkErrorMessage,
+  ToggleTaskMessage,
+  toggleCheckboxInLine
+} from '../../messages';
 
 suite('TaskmarkPanel message types', () => {
   test('TaskMarkUpdateMessage has type "update"', () => {
@@ -32,5 +37,56 @@ suite('TaskmarkPanel message types', () => {
     };
     assert.strictEqual(msg.type, 'parseError');
     assert.strictEqual(msg.message, 'unexpected token at line 3');
+  });
+
+  test('ToggleTaskMessage has type "toggleTask" with uri and rawLine', () => {
+    const msg: ToggleTaskMessage = {
+      type: 'toggleTask',
+      uri: 'file:///test.tmd',
+      rawLine: 4
+    };
+    assert.strictEqual(msg.type, 'toggleTask');
+    assert.strictEqual(msg.uri, 'file:///test.tmd');
+    assert.strictEqual(msg.rawLine, 4);
+  });
+});
+
+suite('toggleCheckboxInLine', () => {
+  test('flips unchecked task to checked', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [ ] foo'), '- [x] foo');
+  });
+
+  test('flips checked task to unchecked', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [x] foo'), '- [ ] foo');
+  });
+
+  test('flips uppercase checked task to unchecked', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [X] foo'), '- [ ] foo');
+  });
+
+  test('preserves leading indent and group marker', () => {
+    assert.strictEqual(
+      toggleCheckboxInLine('  > - [ ] nested'),
+      '  > - [x] nested'
+    );
+  });
+
+  test('preserves content after checkbox including time and tags', () => {
+    assert.strictEqual(
+      toggleCheckboxInLine('- [ ] 10:00-11:00 Meeting #work'),
+      '- [x] 10:00-11:00 Meeting #work'
+    );
+  });
+
+  test('returns null for a line with no checkbox', () => {
+    assert.strictEqual(toggleCheckboxInLine('- plain schedule'), null);
+  });
+
+  test('returns null for a date header', () => {
+    assert.strictEqual(toggleCheckboxInLine('# 2026-04-18'), null);
+  });
+
+  test('returns null for an empty line', () => {
+    assert.strictEqual(toggleCheckboxInLine(''), null);
   });
 });

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -3,7 +3,8 @@ import {
   TaskMarkUpdateMessage,
   TaskMarkErrorMessage,
   ToggleTaskMessage,
-  toggleCheckboxInLine
+  toggleCheckboxInLine,
+  resolveToggleTargetLineIndex
 } from '../../messages';
 
 suite('TaskmarkPanel message types', () => {
@@ -39,15 +40,44 @@ suite('TaskmarkPanel message types', () => {
     assert.strictEqual(msg.message, 'unexpected token at line 3');
   });
 
-  test('ToggleTaskMessage has type "toggleTask" with uri and rawLine', () => {
+  test('ToggleTaskMessage has type "toggleTask" with uri, rawLine, and sourceLine', () => {
     const msg: ToggleTaskMessage = {
       type: 'toggleTask',
       uri: 'file:///test.tmd',
-      rawLine: 4
+      rawLine: 4,
+      sourceLine: '- [ ] task'
     };
     assert.strictEqual(msg.type, 'toggleTask');
     assert.strictEqual(msg.uri, 'file:///test.tmd');
     assert.strictEqual(msg.rawLine, 4);
+    assert.strictEqual(msg.sourceLine, '- [ ] task');
+  });
+});
+
+suite('resolveToggleTargetLineIndex', () => {
+  const lines = ['# 2026-01-01', '- [ ] a', '- [ ] b', '- [ ] c'];
+  const get = (i: number) => lines[i];
+
+  test('returns rawLine when the line still matches', () => {
+    assert.strictEqual(resolveToggleTargetLineIndex(lines.length, get, 2, '- [ ] b'), 2);
+  });
+
+  test('relocates when content moved but source line text is unchanged', () => {
+    const shifted = ['intro', '# 2026-01-01', '- [ ] a', '- [ ] b', '- [ ] c'];
+    const g = (i: number) => shifted[i];
+    assert.strictEqual(resolveToggleTargetLineIndex(shifted.length, g, 2, '- [ ] b'), 3);
+  });
+
+  test('returns null when no line matches sourceLine', () => {
+    assert.strictEqual(resolveToggleTargetLineIndex(lines.length, get, 2, '- [ ] gone'), null);
+  });
+
+  test('picks closest index among duplicate matching lines', () => {
+    const dup = ['- [ ] same', 'x', '- [ ] same'];
+    const g = (i: number) => dup[i];
+    assert.strictEqual(resolveToggleTargetLineIndex(dup.length, g, 0, '- [ ] same'), 0);
+    assert.strictEqual(resolveToggleTargetLineIndex(dup.length, g, 1, '- [ ] same'), 0);
+    assert.strictEqual(resolveToggleTargetLineIndex(dup.length, g, 2, '- [ ] same'), 2);
   });
 });
 

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -6,7 +6,7 @@ suite('TaskmarkPanel message types', () => {
     const msg: TaskMarkUpdateMessage = {
       type: 'update',
       uri: 'file:///test.tmd',
-      data: { tagColors: {}, days: {} },
+      data: { tagColors: {}, groupTags: {}, days: {} },
       ganttData: { entities: [], lastDateStr: '' },
       warnings: []
     };
@@ -17,7 +17,7 @@ suite('TaskmarkPanel message types', () => {
     const msg: TaskMarkUpdateMessage = {
       type: 'update',
       uri: 'file:///test.tmd',
-      data: { tagColors: {}, days: {} },
+      data: { tagColors: {}, groupTags: {}, days: {} },
       ganttData: { entities: [], lastDateStr: '' },
       warnings: ["Line 5: invalid date '2026-99-99', skipped"]
     };

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -89,4 +89,26 @@ suite('toggleCheckboxInLine', () => {
   test('returns null for an empty line', () => {
     assert.strictEqual(toggleCheckboxInLine(''), null);
   });
+
+  test('only toggles the leading status checkbox when text contains bracketed content', () => {
+    assert.strictEqual(
+      toggleCheckboxInLine('- [ ] Check the [ ] box'),
+      '- [x] Check the [ ] box'
+    );
+  });
+
+  test('does not toggle a checked checkbox that appears inside text', () => {
+    assert.strictEqual(
+      toggleCheckboxInLine('- [ ] see [x] below'),
+      '- [x] see [x] below'
+    );
+  });
+
+  test('returns null when bracket pair is not at the start of the line', () => {
+    assert.strictEqual(toggleCheckboxInLine('random [ ] text'), null);
+  });
+
+  test('returns null when non-bullet text precedes the checkbox', () => {
+    assert.strictEqual(toggleCheckboxInLine('foo - [ ] bar'), null);
+  });
 });

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -101,6 +101,11 @@ suite('toggleCheckboxInLine', () => {
     );
   });
 
+  test('preserves extra spaces inside brackets (matches ITEM_REGEX split)', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [  ] foo'), '- [ x] foo');
+    assert.strictEqual(toggleCheckboxInLine('- [  x  ] foo'), '- [     ] foo');
+  });
+
   test('returns null for indented task lines (parser does not accept them)', () => {
     assert.strictEqual(toggleCheckboxInLine('  - [ ] indented'), null);
     assert.strictEqual(toggleCheckboxInLine('  > - [ ] indented group'), null);

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -64,11 +64,16 @@ suite('toggleCheckboxInLine', () => {
     assert.strictEqual(toggleCheckboxInLine('- [X] foo'), '- [ ] foo');
   });
 
-  test('preserves leading indent and group marker', () => {
+  test('preserves group marker without indentation', () => {
     assert.strictEqual(
-      toggleCheckboxInLine('  > - [ ] nested'),
-      '  > - [x] nested'
+      toggleCheckboxInLine('> - [ ] grouped'),
+      '> - [x] grouped'
     );
+  });
+
+  test('returns null for indented task lines (parser does not accept them)', () => {
+    assert.strictEqual(toggleCheckboxInLine('  - [ ] indented'), null);
+    assert.strictEqual(toggleCheckboxInLine('  > - [ ] indented group'), null);
   });
 
   test('preserves content after checkbox including time and tags', () => {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -39,11 +39,6 @@ suite('Extension Test Suite', () => {
     await extension?.activate();
   });
 
-  test('Sample test', () => {
-    assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-    assert.strictEqual(-1, [1, 2, 3].indexOf(0));
-  });
-
   test('taskmark.openView command is registered', async () => {
     const commands = await vscode.commands.getCommands(true);
     assert.ok(commands.includes('taskmark.openView'), 'taskmark.openView command should be registered');

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -140,7 +140,7 @@ suite('Gantt Test Suite', () => {
     assert.strictEqual(standalone!.name, 'Sprint');
   });
 
-  test('group minTime and maxTime span all child items', () => {
+  test('same-named groups in different date sections produce separate entities each with correct time range', () => {
     const { data } = parseTmd(`
 # 2026-03-01
 > Sprint
@@ -151,12 +151,13 @@ suite('Gantt Test Suite', () => {
 > - [ ] 14:00-15:00 Afternoon Task
 `);
     const { entities } = buildGanttEntities(data);
-    assert.strictEqual(entities.length, 1);
+    assert.strictEqual(entities.length, 2, 'same-named groups in different date sections must be separate entities');
 
-    const sprint = entities[0];
-    assert.strictEqual(sprint.children.length, 2);
-    assert.ok(sprint.minTime < sprint.maxTime, 'minTime should be before maxTime');
-    assert.ok(sprint.children[0].startMs < sprint.children[1].startMs, 'children should be in chronological order');
+    assert.ok(entities.every(e => e.lane === 'Sprint'), 'all entities should share the Sprint lane');
+    assert.strictEqual(entities[0].children.length, 1);
+    assert.strictEqual(entities[1].children.length, 1);
+    assert.ok(entities[0].minTime < entities[1].minTime, 'entities should be ordered by start time');
+    assert.ok(entities[0].minTime < entities[0].maxTime, 'each entity minTime should be before maxTime');
   });
 
   test('range item child spans correct time in gantt entity', () => {
@@ -227,15 +228,43 @@ suite('Gantt Test Suite', () => {
 > - [ ] Task B
 `);
     const { entities } = buildGanttEntities(data);
-    assert.strictEqual(entities.length, 1, 'same group across different date ranges should be one entity');
+    assert.strictEqual(entities.length, 2, 'same group across different date ranges should produce separate entities');
 
-    const sprint = entities[0];
-    assert.strictEqual(sprint.name, 'Sprint');
-    assert.strictEqual(sprint.children.length, 2);
+    assert.ok(entities.every(e => e.name === 'Sprint'), 'all entities should be named Sprint');
+    assert.ok(entities.every(e => e.lane === 'Sprint'), 'all entities should be on the Sprint lane');
+    assert.notStrictEqual(entities[0].id, entities[1].id, 'entities should have different ids');
+    assert.strictEqual(entities[0].children.length, 1);
+    assert.strictEqual(entities[1].children.length, 1);
+  });
 
-    const expectedMinTime = new Date(2026, 2, 1).getTime();
-    const expectedMaxTime = new Date(2026, 2, 8).getTime() - 1;
-    assert.strictEqual(sprint.minTime, expectedMinTime, 'minTime should be earliest start');
-    assert.strictEqual(sprint.maxTime, expectedMaxTime, 'maxTime should be latest end');
+  test('same-named groups in different date sections produce separate entities on the same lane', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+> Sprint
+> - [ ] Task A
+
+# 2026-03-10
+> Sprint
+> - [ ] Task B
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 2, 'same-named groups across date sections should be separate entities');
+
+    assert.ok(entities.every(e => e.lane === 'Sprint'), 'all entities should share the Sprint lane');
+    assert.notStrictEqual(entities[0].id, entities[1].id, 'entities should have unique ids');
+    assert.strictEqual(entities[0].tasksTotal, 1, 'first entity task count should be independent');
+    assert.strictEqual(entities[1].tasksTotal, 1, 'second entity task count should be independent');
+  });
+
+  test('entity has id and lane fields', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+> Sprint
+> - [ ] Task A
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.ok(entities[0].id, 'entity should have an id');
+    assert.strictEqual(entities[0].lane, 'Sprint');
+    assert.strictEqual(entities[0].name, 'Sprint');
   });
 });

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -198,4 +198,44 @@ suite('Gantt Test Suite', () => {
     assert.ok(workshopB, 'Workshop B entity should exist');
     assert.ok(workshopA!.minTime < workshopB!.minTime, 'Workshop A should start before Workshop B');
   });
+
+  test('grouped range items merge into one entity per group in gantt', () => {
+    const { data } = parseTmd(`
+# 2026-03-01 : 2026-03-05
+> Sprint
+> - [ ] Task A
+> - [ ] Task B
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 1, 'both group range items should merge into one entity');
+
+    const sprint = entities[0];
+    assert.strictEqual(sprint.isGroup, true);
+    assert.strictEqual(sprint.name, 'Sprint');
+    assert.strictEqual(sprint.children.length, 2);
+    assert.strictEqual(sprint.tasksTotal, 2);
+  });
+
+  test('grouped range items across different date sections merge into one entity per group', () => {
+    const { data } = parseTmd(`
+# 2026-03-01 : 2026-03-05
+> Sprint
+> - [ ] Task A
+
+# 2026-03-03 : 2026-03-07
+> Sprint
+> - [ ] Task B
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 1, 'same group across different date ranges should be one entity');
+
+    const sprint = entities[0];
+    assert.strictEqual(sprint.name, 'Sprint');
+    assert.strictEqual(sprint.children.length, 2);
+
+    const expectedMinTime = new Date(2026, 2, 1).getTime();
+    const expectedMaxTime = new Date(2026, 2, 8).getTime() - 1;
+    assert.strictEqual(sprint.minTime, expectedMinTime, 'minTime should be earliest start');
+    assert.strictEqual(sprint.maxTime, expectedMaxTime, 'maxTime should be latest end');
+  });
 });

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -314,4 +314,13 @@ suite('Gantt Test Suite', () => {
       assert.deepStrictEqual(entity.tags, ['backend'], 'repeat-expanded entity should use group header tags from original date');
     });
   });
+
+  test('standalone task entity uses its own tags', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+- [ ] Lone Task #urgent
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.deepStrictEqual(entities[0].tags, ['urgent'], 'standalone entity should use its own tags');
+  });
 });

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -57,7 +57,7 @@ suite('Gantt Test Suite', () => {
   });
 
   test('empty data returns empty entities and empty lastDateStr', () => {
-    const { entities, lastDateStr } = buildGanttEntities({ tagColors: {}, days: {} });
+    const { entities, lastDateStr } = buildGanttEntities({ tagColors: {}, groupTags: {}, days: {} });
     assert.strictEqual(entities.length, 0);
     assert.strictEqual(lastDateStr, '');
   });
@@ -266,5 +266,39 @@ suite('Gantt Test Suite', () => {
     assert.ok(entities[0].id, 'entity should have an id');
     assert.strictEqual(entities[0].lane, 'Sprint');
     assert.strictEqual(entities[0].name, 'Sprint');
+  });
+
+  test('group entity uses group-header tags when present', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+> Sprint #backend
+> - [ ] Task A #frontend
+`);
+    const { entities } = buildGanttEntities(data);
+    const group = entities[0];
+    assert.deepStrictEqual(group.tags, ['backend'], 'group entity should use the group header tags, not child item tags');
+  });
+
+  test('group entity falls back to first child tags when no group-header tags', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+> Sprint
+> - [ ] Task A #frontend
+`);
+    const { entities } = buildGanttEntities(data);
+    const group = entities[0];
+    assert.deepStrictEqual(group.tags, ['frontend'], 'group entity should fall back to first child item tags');
+  });
+
+  test('group entity with header tags ignores empty child tags', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+> Sprint #design
+> - [ ] Task A
+> - [ ] Task B
+`);
+    const { entities } = buildGanttEntities(data);
+    const group = entities[0];
+    assert.deepStrictEqual(group.tags, ['design'], 'group entity should use header tags even when children have no tags');
   });
 });

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -279,7 +279,7 @@ suite('Gantt Test Suite', () => {
     assert.deepStrictEqual(group.tags, ['backend'], 'group entity should use the group header tags, not child item tags');
   });
 
-  test('group entity falls back to first child tags when no group-header tags', () => {
+  test('group entity has empty tags when no group-header tags', () => {
     const { data } = parseTmd(`
 # 2026-03-01
 > Sprint
@@ -287,7 +287,7 @@ suite('Gantt Test Suite', () => {
 `);
     const { entities } = buildGanttEntities(data);
     const group = entities[0];
-    assert.deepStrictEqual(group.tags, ['frontend'], 'group entity should fall back to first child item tags');
+    assert.deepStrictEqual(group.tags, [], 'group entity should have no tags when group header has no tags');
   });
 
   test('group entity with header tags ignores empty child tags', () => {

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -301,4 +301,17 @@ suite('Gantt Test Suite', () => {
     const group = entities[0];
     assert.deepStrictEqual(group.tags, ['design'], 'group entity should use header tags even when children have no tags');
   });
+
+  test('repeat-expanded group entity inherits group-header tags from original date', () => {
+    const { data } = parseTmd(`
+# 2026-03-01
+> Sprint #backend
+> - 9:00-10:00 Daily Standup @repeat(weekly, count:2)
+`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities.length, 2, 'should produce two entities');
+    entities.forEach(entity => {
+      assert.deepStrictEqual(entity.tags, ['backend'], 'repeat-expanded entity should use group header tags from original date');
+    });
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -245,7 +245,12 @@ suite('Parser Test Suite', () => {
       try {
         c.check(data);
       } catch (e) {
-        throw new Error(`case "${c.label}" failed: ${(e as Error).message}`);
+        // Preserve the original assertion's stack trace so the failing
+        // `assert` line stays visible; only prefix the message with the case label.
+        if (e instanceof Error) {
+          e.message = `case "${c.label}" failed: ${e.message}`;
+        }
+        throw e;
       }
     }
   });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -537,4 +537,25 @@ not a valid tag line
     assert.strictEqual(warnings.length, 1, 'Should warn for empty group name');
     assert.ok(warnings[0].includes('Line 3'), 'Warning should reference line number');
   });
+
+  test('parseTmd item has startDate matching the date header', () => {
+    const text = `
+# 2026-03-01
+- Meeting
+`;
+    const { data } = parseTmd(text);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.startDate, '2026-03-01');
+  });
+
+  test('parseTmd range item has startDate matching the range start date', () => {
+    const text = `
+# 2026-03-01 : 2026-03-10
+> Sprint #backend
+> - [ ] Task A
+`;
+    const { data } = parseTmd(text);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.startDate, '2026-03-01');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -28,9 +28,11 @@ suite('Parser Test Suite', () => {
     assert.strictEqual(items[0].type, 'task');
     assert.strictEqual(items[0].status, 'todo');
     assert.strictEqual(items[0].text, 'Meeting');
+    assert.strictEqual(items[0].sourceLine, '- [ ] 09:00-10:00 Meeting');
 
     assert.strictEqual(items[1].type, 'schedule');
     assert.strictEqual(items[1].text, 'Schedule item');
+    assert.strictEqual(items[1].sourceLine, '- Schedule item');
   });
 
   test('parseTmd parses @tags block', () => {

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -526,4 +526,15 @@ not a valid tag line
     const { data } = parseTmd(text);
     assert.deepStrictEqual(data.groupTags, {});
   });
+
+  test('parseTmd warns when group header has only tags and no group name', () => {
+    const text = `
+# 2026-03-01
+> #backend
+> - [ ] Task A
+`;
+    const { warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1, 'Should warn for empty group name');
+    assert.ok(warnings[0].includes('Line 3'), 'Warning should reference line number');
+  });
 });

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -180,25 +180,74 @@ suite('Parser Test Suite', () => {
     assert.ok(!data.days['2026-03-02'], 'Repeat should not expand when endDate is set');
   });
 
-  test('parseTmd date header without zero-padding is normalized and parsed', () => {
-    const text = `
+  test('parseTmd normalizes unpadded dates and times across every position', () => {
+    // All positions that accept a date or time string should normalize
+    // unpadded forms (e.g. `2026-3-1`, `9:0`) to zero-padded forms.
+    const cases: Array<{ label: string; text: string; check: (data: ReturnType<typeof parseTmd>['data']) => void }> = [
+      {
+        label: 'date header',
+        text: `
 # 2026-3-1
 - Meeting
-`;
-    const { data } = parseTmd(text);
-    assert.ok(data.days['2026-03-01'], 'Day should be stored with zero-padded key');
-    assert.strictEqual(data.days['2026-03-01'].items.length, 1);
-    assert.strictEqual(data.days['2026-03-01'].items[0].text, 'Meeting');
-  });
-
-  test('parseTmd date range end date without zero-padding is normalized', () => {
-    const text = `
+`,
+        check: data => {
+          assert.ok(data.days['2026-03-01'], 'day stored under zero-padded key');
+          assert.strictEqual(data.days['2026-03-01'].items[0].text, 'Meeting');
+        },
+      },
+      {
+        label: 'date range end date',
+        text: `
 # 2026-3-1 : 2026-3-10
 - Conference
-`;
-    const { data } = parseTmd(text);
-    assert.ok(data.days['2026-03-01'], 'Start day should be zero-padded');
-    assert.strictEqual(data.days['2026-03-01'].items[0].endDate, '2026-03-10');
+`,
+        check: data => {
+          assert.ok(data.days['2026-03-01']);
+          assert.strictEqual(data.days['2026-03-01'].items[0].endDate, '2026-03-10');
+        },
+      },
+      {
+        label: 'time range with unpadded minutes',
+        text: `
+# 2026-03-01
+- 9:0-17:0 Conference
+`,
+        check: data => {
+          assert.strictEqual(data.days['2026-03-01'].items[0].time, '9:00-17:00');
+        },
+      },
+      {
+        label: 'start-only time with unpadded minutes',
+        text: `
+# 2026-03-01
+- 9:0 Meeting
+`,
+        check: data => {
+          assert.strictEqual(data.days['2026-03-01'].items[0].time, '9:00');
+        },
+      },
+      {
+        label: 'repeat except with unpadded date',
+        text: `
+# 2026-03-16
+- Weekly Sync @repeat(weekly, count:3, except:2026-3-23)
+`,
+        check: data => {
+          assert.ok(data.days['2026-03-16']);
+          assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
+          assert.ok(data.days['2026-03-30']);
+        },
+      },
+    ];
+
+    for (const c of cases) {
+      const { data } = parseTmd(c.text);
+      try {
+        c.check(data);
+      } catch (e) {
+        throw new Error(`case "${c.label}" failed: ${(e as Error).message}`);
+      }
+    }
   });
 
   test('parseTmd date header with invalid month is ignored', () => {
@@ -208,39 +257,6 @@ suite('Parser Test Suite', () => {
 `;
     const { data } = parseTmd(text);
     assert.strictEqual(Object.keys(data.days).length, 0, 'Invalid date header should be ignored');
-  });
-
-  test('parseTmd time with unpadded minutes is normalized', () => {
-    const text = `
-# 2026-03-01
-- 9:0-17:0 Conference
-`;
-    const { data } = parseTmd(text);
-    const items = data.days['2026-03-01'].items;
-    assert.strictEqual(items.length, 1);
-    assert.strictEqual(items[0].time, '9:00-17:00');
-  });
-
-  test('parseTmd start time only with unpadded minutes is normalized', () => {
-    const text = `
-# 2026-03-01
-- 9:0 Meeting
-`;
-    const { data } = parseTmd(text);
-    const items = data.days['2026-03-01'].items;
-    assert.strictEqual(items.length, 1);
-    assert.strictEqual(items[0].time, '9:00');
-  });
-
-  test('parseTmd repeat except with unpadded date skips the correct day', () => {
-    const text = `
-# 2026-03-16
-- Weekly Sync @repeat(weekly, count:3, except:2026-3-23)
-`;
-    const { data } = parseTmd(text);
-    assert.ok(data.days['2026-03-16'], '2026-03-16 should exist');
-    assert.ok(!data.days['2026-03-23'], '2026-03-23 should be skipped');
-    assert.ok(data.days['2026-03-30'], '2026-03-30 should still exist');
   });
 
   // ─── Warning Collection Tests ────────────────────────────────

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -457,17 +457,14 @@ not a valid tag line
     assert.ok(data.days['2026-03-01'], 'Valid date should still parse');
   });
 
-  test('parseTmd deduplicates identical warnings across multiple invalid headers', () => {
+  test('parseTmd deduplicates identical warnings', () => {
     const text = `
-# 2026-99-99
-- Item A
-# 2026-88-88
-- Item B
+# 2026-03-01
+- Weekly @repeat(weekly, count:3, except:2026-99-99 2026-99-99)
 `;
     const { warnings } = parseTmd(text);
-    assert.ok(warnings.length > 0, 'Should have warnings');
-    const uniqueWarnings = [...new Set(warnings)];
-    assert.deepStrictEqual(warnings, uniqueWarnings, 'warnings should be deduplicated');
+    assert.strictEqual(warnings.length, 1, 'identical warnings should be deduplicated to one');
+    assert.match(warnings[0], /invalid except date '2026-99-99'/);
   });
 
   // ─── Group Tags Tests ────────────────────────────────────────

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -13,7 +13,7 @@ suite('Parser Test Suite', () => {
     assert.ok(Array.isArray(result.warnings), 'warnings should be an array');
   });
 
-  test('parseTmd basically works for tasks and schedules', () => {
+  test('parseTmd distinguishes timed task lines from plain schedule lines', () => {
     const text = `
 # 2026-03-26
 - [ ] 09:00-10:00 Meeting
@@ -65,7 +65,7 @@ suite('Parser Test Suite', () => {
     assert.strictEqual(data.days['2026-03-26'].items[0].text, 'Task item');
   });
 
-  test('parseTmd basic repetition handling', () => {
+  test('parseTmd @repeat count expands the item into that many consecutive days', () => {
     const text = `
 # 2026-03-26
 - Daily habit @repeat(daily, count:3)
@@ -452,7 +452,7 @@ not a valid tag line
     assert.ok(data.days['2026-03-01'], 'Valid date should still parse');
   });
 
-  test('parseTmd returns deduplicated warnings', () => {
+  test('parseTmd deduplicates identical warnings across multiple invalid headers', () => {
     const text = `
 # 2026-99-99
 - Item A

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -65,18 +65,6 @@ suite('Parser Test Suite', () => {
     assert.strictEqual(data.days['2026-03-26'].items[0].text, 'Task item');
   });
 
-  test('parseTmd empty @tags block produces empty tagColors', () => {
-    const text = `
-@tags
-@end
-
-# 2026-03-26
-- Task
-`;
-    const { data } = parseTmd(text);
-    assert.deepStrictEqual(data.tagColors, {});
-  });
-
   test('parseTmd basic repetition handling', () => {
     const text = `
 # 2026-03-26
@@ -448,22 +436,6 @@ not a valid tag line
     assert.ok(data.days['2026-03-01'], 'Valid date should still parse');
   });
 
-  test('parseTmd valid input has empty warnings array', () => {
-    const text = `
-@tags
-#work : #0088ff
-@end
-
-# 2026-03-01
-- 9:00-10:00 Meeting #work
-- Standup @repeat(daily, count:2)
-`;
-    const { data, warnings } = parseTmd(text);
-    assert.strictEqual(warnings.length, 0);
-    assert.ok(data.days['2026-03-01']);
-    assert.ok(data.days['2026-03-02']);
-  });
-
   test('parseTmd returns deduplicated warnings', () => {
     const text = `
 # 2026-99-99
@@ -518,15 +490,6 @@ not a valid tag line
 `;
     const { data } = parseTmd(text);
     assert.deepStrictEqual(data.groupTags['2026-03-01::Sprint'], ['backend', 'mobile']);
-  });
-
-  test('parseTmd groupTags is empty object when no group tags exist', () => {
-    const text = `
-# 2026-03-01
-- Task
-`;
-    const { data } = parseTmd(text);
-    assert.deepStrictEqual(data.groupTags, {});
   });
 
   test('parseTmd warns when group header has only tags and no group name', () => {

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -474,4 +474,56 @@ not a valid tag line
     const uniqueWarnings = [...new Set(warnings)];
     assert.deepStrictEqual(warnings, uniqueWarnings, 'warnings should be deduplicated');
   });
+
+  // ─── Group Tags Tests ────────────────────────────────────────
+
+  test('parseTmd group header with tag stores groupTags entry', () => {
+    const text = `
+# 2026-03-01
+> Sprint #backend
+> - [ ] Task A
+`;
+    const { data } = parseTmd(text);
+    assert.deepStrictEqual(data.groupTags['2026-03-01::Sprint'], ['backend']);
+  });
+
+  test('parseTmd group header without tag produces no groupTags entry', () => {
+    const text = `
+# 2026-03-01
+> Sprint
+> - [ ] Task A
+`;
+    const { data } = parseTmd(text);
+    assert.strictEqual(data.groupTags['2026-03-01::Sprint'], undefined);
+  });
+
+  test('parseTmd group header tag is stripped from group name', () => {
+    const text = `
+# 2026-03-01
+> Sprint #backend
+> - [ ] Task A
+`;
+    const { data } = parseTmd(text);
+    const items = data.days['2026-03-01'].items;
+    assert.strictEqual(items[0].group, 'Sprint', 'group name should not include the tag');
+  });
+
+  test('parseTmd group header with multiple tags stores all tags', () => {
+    const text = `
+# 2026-03-01
+> Sprint #backend #mobile
+> - [ ] Task A
+`;
+    const { data } = parseTmd(text);
+    assert.deepStrictEqual(data.groupTags['2026-03-01::Sprint'], ['backend', 'mobile']);
+  });
+
+  test('parseTmd groupTags is empty object when no group tags exist', () => {
+    const text = `
+# 2026-03-01
+- Task
+`;
+    const { data } = parseTmd(text);
+    assert.deepStrictEqual(data.groupTags, {});
+  });
 });

--- a/src/test/suite/template.test.ts
+++ b/src/test/suite/template.test.ts
@@ -1,0 +1,45 @@
+import * as assert from 'assert';
+import { getWebviewHtml } from '../../template';
+
+suite('Template Test Suite', () => {
+  function getHtml(): string {
+    const fakeUri = { toString: () => 'vscode-resource://fake/script.js' } as any;
+    const fakeStyles = { toString: () => 'vscode-resource://fake/style.css' } as any;
+    return getWebviewHtml(fakeUri, fakeStyles, 'vscode-resource:');
+  }
+
+  test('template contains zoom-in button', () => {
+    const html = getHtml();
+    assert.ok(html.includes('id="btn-zoom-in"'), 'template should include a zoom-in button with id="btn-zoom-in"');
+  });
+
+  test('template contains zoom-out button', () => {
+    const html = getHtml();
+    assert.ok(html.includes('id="btn-zoom-out"'), 'template should include a zoom-out button with id="btn-zoom-out"');
+  });
+
+  test('zoom controls are inside tm-zoom-controls container', () => {
+    const html = getHtml();
+    assert.ok(html.includes('tm-zoom-controls'), 'template should include tm-zoom-controls container');
+    const zoomStart = html.indexOf('tm-zoom-controls');
+    const zoomSection = html.slice(zoomStart, zoomStart + 200);
+    assert.ok(zoomSection.includes('btn-zoom-in'), 'zoom controls container should include zoom-in button');
+    assert.ok(zoomSection.includes('btn-zoom-out'), 'zoom controls container should include zoom-out button');
+  });
+
+  test('zoom-in button label is +', () => {
+    const html = getHtml();
+    const zoomInIdx = html.indexOf('id="btn-zoom-in"');
+    assert.ok(zoomInIdx !== -1, 'btn-zoom-in should exist');
+    const snippet = html.slice(zoomInIdx, zoomInIdx + 60);
+    assert.ok(snippet.includes('+'), 'zoom-in button should have + label');
+  });
+
+  test('zoom-out button label is -', () => {
+    const html = getHtml();
+    const zoomOutIdx = html.indexOf('id="btn-zoom-out"');
+    assert.ok(zoomOutIdx !== -1, 'btn-zoom-out should exist');
+    const snippet = html.slice(zoomOutIdx, zoomOutIdx + 60);
+    assert.ok(snippet.includes('-'), 'zoom-out button should have - label');
+  });
+});

--- a/src/test/suite/template.test.ts
+++ b/src/test/suite/template.test.ts
@@ -48,9 +48,14 @@ suite('Template Test Suite', () => {
     const html = getHtml();
     const match = html.match(/<body\s+data-valid-css-color-re="([^"]+)"/);
     assert.ok(match, 'body should expose data-valid-css-color-re');
-    // The attribute value is HTML-escaped; & is the only char in the regex
-    // source that needs unescaping for this comparison.
-    const decoded = match![1].replace(/&amp;/g, '&');
+    // Decode every character that escapeHtmlAttr encodes so the comparison
+    // stays correct if the regex source later contains any of them.
+    const decoded = match![1]
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+      .replace(/&amp;/g, '&');
     assert.strictEqual(decoded, VALID_CSS_COLOR_REGEX.source);
   });
 });

--- a/src/test/suite/template.test.ts
+++ b/src/test/suite/template.test.ts
@@ -48,14 +48,6 @@ suite('Template Test Suite', () => {
     const html = getHtml();
     const match = html.match(/<body\s+data-valid-css-color-re="([^"]+)"/);
     assert.ok(match, 'body should expose data-valid-css-color-re');
-    // Decode every character that escapeHtmlAttr encodes so the comparison
-    // stays correct if the regex source later contains any of them.
-    const decoded = match![1]
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'")
-      .replace(/&amp;/g, '&');
-    assert.strictEqual(decoded, VALID_CSS_COLOR_REGEX.source);
+    assert.strictEqual(match![1], VALID_CSS_COLOR_REGEX.source);
   });
 });

--- a/src/test/suite/template.test.ts
+++ b/src/test/suite/template.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import { getWebviewHtml } from '../../template';
+import { VALID_CSS_COLOR_REGEX } from '../../parser';
 
 suite('Template Test Suite', () => {
   function getHtml(): string {
@@ -41,5 +42,15 @@ suite('Template Test Suite', () => {
     assert.ok(zoomOutIdx !== -1, 'btn-zoom-out should exist');
     const snippet = html.slice(zoomOutIdx, zoomOutIdx + 60);
     assert.ok(snippet.includes('-'), 'zoom-out button should have - label');
+  });
+
+  test('body carries the canonical color regex for the webview', () => {
+    const html = getHtml();
+    const match = html.match(/<body\s+data-valid-css-color-re="([^"]+)"/);
+    assert.ok(match, 'body should expose data-valid-css-color-re');
+    // The attribute value is HTML-escaped; & is the only char in the regex
+    // source that needs unescaping for this comparison.
+    const decoded = match![1].replace(/&amp;/g, '&');
+    assert.strictEqual(decoded, VALID_CSS_COLOR_REGEX.source);
   });
 });


### PR DESCRIPTION
## 関連Issue
Closes #32, Closes #51, Closes #65, Closes #66, Closes #68, Closes #75, Closes #79

## 概要
v1.3.2 以降の develop を main に取り込み、v1.4.0 としてリリースするための PR です。
カレンダービューでのタスク完了トグル、フォントサイズ設定、Gantt ズームボタン、グループヘッダータグ色などの新機能に加え、色解決・範囲表示・同名グループに関する不具合修正を含みます。

## 変更内容
### Added
- カレンダービューのチェックボックスクリックでタスク完了をトグル（`.tmd` ファイルに反映） (#32)
- `taskmark.fontSize` 設定（10–24px）を追加し、Calendar / Gantt のラベルに適用 (#79)
- Gantt タイムラインヘッダーにズームイン / ズームアウトボタンを追加 (#51)
- グループヘッダーのタグでグループ表示色を指定可能に (Calendar / Gantt 両対応) (#66)
- Monthly カレンダーのアイテムを省略付きのコンパクトバンドで表示 (#75)

### Fixed
- Gantt の単独バーと Monthly の単独タスクが自身のタグで色解決されない問題を修正 (#66)
- 異なる日付セクション内の同名グループを別エンティティとして描画するよう修正 (#68)
- カレンダーでグループ範囲アイテムを単一の連続バンドにマージ (#65)
- Monthly の日付ヘッダー行が縦方向に伸びてしまう問題を修正
- チェックボックス正規表現を行頭アンカーに変更し、テキスト中の `[]` を誤検出しないよう修正
- セルバンド高、日付バッジ、最小可読サイズが `taskmark.fontSize` に応じて正しくスケールするよう修正

### Changed
- Gantt のデフォルトズーム倍率を引き上げ、初期表示でのラベル重なりを軽減
- VS Code エンジンの最低バージョンを `1.109.1` に設定

### Docs / Chore
- README に新機能（チェックボックストグル、ズームボタン、`taskmark.fontSize`、グループ色、タグ色の対応フォーマット）を反映
- CHANGELOG に v1.4.0 セクションを追加
- `package.json` / `package-lock.json` を `1.4.0` にバンプ
- 不要なテスト・コメントの整理とリファクタリング (#73)

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した
- [x] `npm run test:unit` が成功することを確認した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| （必要に応じて画像を貼る） | （必要に応じて画像を貼る） |

## 備考・次やること
- リリース後、`v1.4.0` タグを打ち、Marketplace への公開作業を実施する
- タグ付け完了後、`taskmark-1.4.0.vsix` を生成してアーティファクトとして残す

🤖 Generated with [Claude Code](https://claude.com/claude-code)