### PR TITLE
feat: タイムラインに「今日」ラインを表示 (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Visualize schedule durations and project spans as a Gantt chart.
 
 - **Pan** — Move smoothly in any direction by clicking and dragging
 - **Zoom** — Zoom in/out (from days to hours) with `Ctrl + Mouse Wheel`, or the zoom buttons in the view header
+- **Today Marker** — A red vertical line indicates the current date; click the `Today` button to scroll to it
 - **Progress Bars** — Group task completion rates are displayed visually on the bars
 - **Weekend Colors** — Colored backgrounds corresponding to the calendar view
 - **Sub-rows** — Tasks inside a group are displayed as individual sub-rows beneath the group bar; click the group bar to collapse or expand them

--- a/media/main.js
+++ b/media/main.js
@@ -850,6 +850,28 @@
     container.appendChild(axisRow);
   }
 
+  /** Render a vertical line marking the current date on the Gantt container */
+  function renderGanttTodayMarker(container, startDate, totalRenderDays, pxPerMs) {
+    const nowMs = Date.now();
+    const offsetMs = nowMs - startDate.getTime();
+    const endMs = totalRenderDays * MS_PER_DAY;
+    if (offsetMs < 0 || offsetMs > endMs) return;
+
+    const left = offsetMs * pxPerMs;
+
+    const line = document.createElement('div');
+    line.className = 'tm-gantt-today-line';
+    line.style.left = left + 'px';
+    line.style.height = '100%';
+    container.appendChild(line);
+
+    const label = document.createElement('div');
+    label.className = 'tm-gantt-today-label';
+    label.style.left = left + 'px';
+    label.textContent = 'Today';
+    container.appendChild(label);
+  }
+
   /** Render a single Gantt bar (group or standalone) */
   function renderGanttEntityBar(container, entity, startDate, pxPerMs, yOffset, totalWidth, skipRowBg) {
     if (!skipRowBg) {
@@ -1058,6 +1080,7 @@
 
     // Render axis and column backgrounds
     renderGanttAxis(ganttContainer, startDate, totalRenderDays, pxPerMs);
+    renderGanttTodayMarker(ganttContainer, startDate, totalRenderDays, pxPerMs);
 
     // Render entity bars grouped by lane (same lane = same row)
     let yOffset = GANTT_HEADER_HEIGHT;

--- a/media/main.js
+++ b/media/main.js
@@ -22,6 +22,7 @@
   let currentGanttData = null;
   let rangeItemIndex = null; // Pre-built index: date string -> range items spanning that date
   let ganttZoom = GANTT_DEFAULT_ZOOM; // 1 = 100px per day
+  let ganttTodayLeft = null; // px offset of the today marker, or null if out of range
   let expandedGroups = new Set();
   let isPanning = false;
   let hasDragged = false;
@@ -275,6 +276,9 @@
   btnToday?.addEventListener('click', () => {
     currentDate = new Date();
     render();
+    if (baseView === 'timeline' && ganttTodayLeft !== null) {
+      viewTimeline.scrollLeft = Math.max(0, ganttTodayLeft - viewTimeline.clientWidth / 2);
+    }
   });
 
   viewCalendar?.addEventListener('click', (e) => {
@@ -855,9 +859,13 @@
     const nowMs = Date.now();
     const offsetMs = nowMs - startDate.getTime();
     const endMs = totalRenderDays * MS_PER_DAY;
-    if (offsetMs < 0 || offsetMs > endMs) return;
+    if (offsetMs < 0 || offsetMs > endMs) {
+      ganttTodayLeft = null;
+      return;
+    }
 
     const left = offsetMs * pxPerMs;
+    ganttTodayLeft = left;
 
     const line = document.createElement('div');
     line.className = 'tm-gantt-today-line';

--- a/media/main.js
+++ b/media/main.js
@@ -872,12 +872,6 @@
     line.style.left = left + 'px';
     line.style.height = '100%';
     container.appendChild(line);
-
-    const label = document.createElement('div');
-    label.className = 'tm-gantt-today-label';
-    label.style.left = left + 'px';
-    label.textContent = 'Today';
-    container.appendChild(label);
   }
 
   /** Render a single Gantt bar (group or standalone) */

--- a/media/style.css
+++ b/media/style.css
@@ -737,21 +737,6 @@ body {
   pointer-events: none;
 }
 
-.tm-gantt-today-label {
-  position: absolute;
-  top: 2px;
-  z-index: 9;
-  padding: 1px 4px;
-  font-size: max(9px, calc(var(--tm-font-size) - 4px));
-  font-weight: bold;
-  color: #fff;
-  background: #e53935;
-  border-radius: 2px;
-  transform: translateX(-50%);
-  pointer-events: none;
-  white-space: nowrap;
-}
-
 /* Child rows (group task members) */
 .tm-gantt-child-row-bg {
   border-left: 2px solid var(--tm-card-border);

--- a/media/style.css
+++ b/media/style.css
@@ -733,7 +733,7 @@ body {
   top: 0;
   width: 2px;
   background: #e53935;
-  z-index: 8;
+  z-index: 0;
   pointer-events: none;
 }
 

--- a/media/style.css
+++ b/media/style.css
@@ -129,6 +129,12 @@ body {
   color: var(--tm-accent-fg);
 }
 
+.tm-nav-group {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
 .tm-month-nav {
   display: flex;
   align-items: center;

--- a/media/style.css
+++ b/media/style.css
@@ -129,7 +129,7 @@ body {
   color: var(--tm-accent-fg);
 }
 
-.tm-nav-group {
+.tm-header-right {
   display: flex;
   align-items: center;
   gap: 16px;

--- a/media/style.css
+++ b/media/style.css
@@ -733,7 +733,7 @@ body {
   top: 0;
   width: 2px;
   background: #e53935;
-  z-index: 0;
+  z-index: 8;
   pointer-events: none;
 }
 

--- a/media/style.css
+++ b/media/style.css
@@ -721,6 +721,31 @@ body {
   pointer-events: none;
 }
 
+/* Today marker */
+.tm-gantt-today-line {
+  position: absolute;
+  top: 0;
+  width: 2px;
+  background: #e53935;
+  z-index: 8;
+  pointer-events: none;
+}
+
+.tm-gantt-today-label {
+  position: absolute;
+  top: 2px;
+  z-index: 9;
+  padding: 1px 4px;
+  font-size: max(9px, calc(var(--tm-font-size) - 4px));
+  font-weight: bold;
+  color: #fff;
+  background: #e53935;
+  border-radius: 2px;
+  transform: translateX(-50%);
+  pointer-events: none;
+  white-space: nowrap;
+}
+
 /* Child rows (group task members) */
 .tm-gantt-child-row-bg {
   border-left: 2px solid var(--tm-card-border);

--- a/src/template.ts
+++ b/src/template.ts
@@ -23,16 +23,18 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
             <button class="tm-view-toggle active" id="btn-calendar">Calendar</button>
             <button class="tm-view-toggle" id="btn-timeline">Timeline</button>
           </div>
-          <button class="tm-view-toggle" id="btn-today">Today</button>
-          <div class="tm-month-nav">
-             <div class="tm-toggle-container" id="calendar-granularity-toggles">
-                <button class="tm-view-toggle active" id="btn-monthly">Monthly</button>
-                <button class="tm-view-toggle" id="btn-weekly">Weekly</button>
-                <button class="tm-view-toggle" id="btn-daily">Daily</button>
-             </div>
-             <button id="btn-prev-month">&lt;</button>
-             <h2 id="current-month-display"></h2>
-             <button id="btn-next-month">&gt;</button>
+          <div class="tm-nav-group">
+            <button class="tm-view-toggle" id="btn-today">Today</button>
+            <div class="tm-month-nav">
+               <div class="tm-toggle-container" id="calendar-granularity-toggles">
+                  <button class="tm-view-toggle active" id="btn-monthly">Monthly</button>
+                  <button class="tm-view-toggle" id="btn-weekly">Weekly</button>
+                  <button class="tm-view-toggle" id="btn-daily">Daily</button>
+               </div>
+               <button id="btn-prev-month">&lt;</button>
+               <h2 id="current-month-display"></h2>
+               <button id="btn-next-month">&gt;</button>
+            </div>
           </div>
           <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
             <button id="btn-zoom-out" title="Zoom Out">-</button>

--- a/src/template.ts
+++ b/src/template.ts
@@ -23,8 +23,8 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
             <button class="tm-view-toggle active" id="btn-calendar">Calendar</button>
             <button class="tm-view-toggle" id="btn-timeline">Timeline</button>
           </div>
+          <button class="tm-view-toggle" id="btn-today">Today</button>
           <div class="tm-month-nav">
-             <button class="tm-view-toggle" id="btn-today">Today</button>
              <div class="tm-toggle-container" id="calendar-granularity-toggles">
                 <button class="tm-view-toggle active" id="btn-monthly">Monthly</button>
                 <button class="tm-view-toggle" id="btn-weekly">Weekly</button>

--- a/src/template.ts
+++ b/src/template.ts
@@ -23,7 +23,7 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
             <button class="tm-view-toggle active" id="btn-calendar">Calendar</button>
             <button class="tm-view-toggle" id="btn-timeline">Timeline</button>
           </div>
-          <div class="tm-nav-group">
+          <div class="tm-header-right">
             <button class="tm-view-toggle" id="btn-today">Today</button>
             <div class="tm-month-nav">
                <div class="tm-toggle-container" id="calendar-granularity-toggles">
@@ -35,10 +35,10 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
                <h2 id="current-month-display"></h2>
                <button id="btn-next-month">&gt;</button>
             </div>
-          </div>
-          <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
-            <button id="btn-zoom-out" title="Zoom Out">-</button>
-            <button id="btn-zoom-in" title="Zoom In">+</button>
+            <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
+              <button id="btn-zoom-out" title="Zoom Out">-</button>
+              <button id="btn-zoom-in" title="Zoom In">+</button>
+            </div>
           </div>
         </div>
         <div class="tm-content" id="tm-content-area">


### PR DESCRIPTION
## 関連Issue
Closes #34

## 概要
Gantt タイムラインビューで現在日時がどこにあるか一目でわかるよう、赤色の縦線（Today ライン）を追加した。合わせて既存の Today ボタンを Timeline ビューでも表示し、押下で Today ラインの位置までスクロールできるようにした。

## 変更内容
- `renderGanttTodayMarker` を追加し、`renderTimeline` 内で `renderGanttAxis` の直後に呼び出す
- 今日の日付を `startDate` からのオフセットで `left` を計算し、赤色の縦線を `tm-gantt-container` に追加（表示範囲外では描画しない）
- ズーム変更時は `renderTimeline` が再実行されるため自動で位置が再計算される
- `.tm-gantt-today-line` のスタイルを `media/style.css` に追加
- Today ボタン押下時、Timeline ビューでは Today ラインが画面中央に来るよう `scrollLeft` を更新する
- `btn-today` を `.tm-month-nav` の外に出し、Timeline ビューでも表示されるようにする
- ヘッダーを `.tm-toggle-container`（左）/ `.tm-header-right`（右、Today + month-nav + zoom-controls）の 2 ブロック構成にして、Today ボタンが両ビューで右側に維持されるようにする

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] `npm run lint` / `npm run test:unit` がすべてパスすることを確認した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| Today ラインなし / Timeline に Today ボタンなし | Today の位置に赤い縦線、Timeline でも Today ボタンが表示されスクロール可能 |

## 備考・次やること
- Today ラインは Webview 側（`media/main.js`）の DOM レンダリングで実装しているため、既存の TS 単体テストインフラではカバーしていない。ロジック自体はトリビアル（`offsetMs = now - startMs`）なため、目視確認で担保する。