### PR TITLE
feat: ガントチャートのタスクバーから完了/未完了を切り替え

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Visualize schedule durations and project spans as a Gantt chart.
 - **Progress Bars** — Group task completion rates are displayed visually on the bars
 - **Weekend Colors** — Colored backgrounds corresponding to the calendar view
 - **Sub-rows** — Tasks inside a group are displayed as individual sub-rows beneath the group bar; click the group bar to collapse or expand them
+- **Toggle Tasks** — Click a task bar to toggle completion (`- [ ]` / `- [x]`) directly in the `.tmd` file
 - Grouped schedules appear as a single connected bar, while standalone items with the same name appear as separate blocks on the same row
 
 ### 🏷️ Tags & Colors

--- a/media/main.js
+++ b/media/main.js
@@ -345,6 +345,17 @@
   btnZoomIn.addEventListener('click', () => applyZoom(GANTT_ZOOM_IN_FACTOR));
   btnZoomOut.addEventListener('click', () => applyZoom(GANTT_ZOOM_OUT_FACTOR));
 
+  // Delegated task-bar toggle: one listener handles every task bar in the gantt.
+  viewTimeline?.addEventListener('click', (e) => {
+    const bar = e.target.closest('.tm-gantt-task-bar[data-raw-line]');
+    if (!bar || hasDragged || !currentUri) return;
+    const rawLine = Number(bar.dataset.rawLine);
+    if (!Number.isInteger(rawLine) || rawLine < 0) return;
+    const sourceLine = bar.dataset.sourceLine;
+    if (typeof sourceLine !== 'string') return;
+    vscode.postMessage({ type: 'toggleTask', uri: currentUri, rawLine, sourceLine });
+  });
+
   // Date navigation
   function navigateDate(direction) {
     if (baseView === 'timeline' || activeView === 'monthly') {
@@ -1006,21 +1017,11 @@
     });
   }
 
-  /** Wire a gantt bar to toggle its backing task when clicked (ignored during panning). */
+  /** Tag a gantt bar as a toggleable task. Click handling is delegated on viewTimeline. */
   function attachTaskToggle(bar, child) {
     bar.classList.add('tm-gantt-task-bar');
     bar.dataset.rawLine = String(child.rawLine);
     bar.dataset.sourceLine = child.sourceLine;
-    bar.addEventListener('click', (e) => {
-      e.stopPropagation();
-      if (hasDragged || !currentUri) return;
-      vscode.postMessage({
-        type: 'toggleTask',
-        uri: currentUri,
-        rawLine: child.rawLine,
-        sourceLine: child.sourceLine
-      });
-    });
   }
 
   /** Create a positioned Gantt bar element */

--- a/media/main.js
+++ b/media/main.js
@@ -954,6 +954,9 @@
       }
       pBar.style.backgroundColor = bgColor;
       bar.appendChild(pBar);
+      if (child.isTask) {
+        attachTaskToggle(bar, child);
+      }
       container.appendChild(bar);
 
       // Label (outside bar, to the right)
@@ -993,10 +996,30 @@
       }
       pBar.style.backgroundColor = childColor;
       bar.appendChild(pBar);
+      if (child.isTask) {
+        attachTaskToggle(bar, child);
+      }
       container.appendChild(bar);
 
       // Label (outside bar, to the right)
       container.appendChild(createGanttLabel(child.text, left + width, childYOffset));
+    });
+  }
+
+  /** Wire a gantt bar to toggle its backing task when clicked (ignored during panning). */
+  function attachTaskToggle(bar, child) {
+    bar.classList.add('tm-gantt-task-bar');
+    bar.dataset.rawLine = String(child.rawLine);
+    bar.dataset.sourceLine = child.sourceLine;
+    bar.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (hasDragged || !currentUri) return;
+      vscode.postMessage({
+        type: 'toggleTask',
+        uri: currentUri,
+        rawLine: child.rawLine,
+        sourceLine: child.sourceLine
+      });
     });
   }
 

--- a/media/style.css
+++ b/media/style.css
@@ -692,6 +692,10 @@ body {
   cursor: pointer;
 }
 
+.tm-gantt-task-bar {
+  cursor: pointer;
+}
+
 .tm-gantt-group-indicator {
   position: relative;
   z-index: 2;

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -10,6 +10,8 @@ export interface GanttChildItem {
   endMs: number;
   isTask: boolean;
   isDone: boolean;
+  rawLine: number;
+  sourceLine: string;
 }
 
 export interface GanttEntity {
@@ -110,7 +112,9 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
         startMs,
         endMs,
         isTask: item.type === 'task',
-        isDone: item.status === 'done'
+        isDone: item.status === 'done',
+        rawLine: item.rawLine,
+        sourceLine: item.sourceLine
       });
 
       if (item.type === 'task') {

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -323,4 +323,41 @@ suite('Gantt Test Suite', () => {
     const { entities } = buildGanttEntities(data);
     assert.deepStrictEqual(entities[0].tags, ['urgent'], 'standalone entity should use its own tags');
   });
+
+  test('task children expose rawLine and sourceLine for toggling', () => {
+    const { data } = parseTmd(`# 2026-03-01
+- [ ] Standalone Task
+`);
+    const { entities } = buildGanttEntities(data);
+    const entity = entities[0];
+    const child = entity.children[0];
+    assert.strictEqual(child.isTask, true);
+    assert.strictEqual(child.rawLine, 1);
+    assert.strictEqual(child.sourceLine, '- [ ] Standalone Task');
+  });
+
+  test('grouped task children expose rawLine and sourceLine for toggling', () => {
+    const { data } = parseTmd(`# 2026-03-01
+> Sprint
+> - [ ] Task A
+> - [x] Task B
+`);
+    const { entities } = buildGanttEntities(data);
+    const group = entities[0];
+    assert.strictEqual(group.children[0].rawLine, 2);
+    assert.strictEqual(group.children[0].sourceLine, '> - [ ] Task A');
+    assert.strictEqual(group.children[1].rawLine, 3);
+    assert.strictEqual(group.children[1].sourceLine, '> - [x] Task B');
+  });
+
+  test('schedule children also carry rawLine and sourceLine from source item', () => {
+    const { data } = parseTmd(`# 2026-03-01
+- 9:00-10:00 Meeting
+`);
+    const { entities } = buildGanttEntities(data);
+    const child = entities[0].children[0];
+    assert.strictEqual(child.isTask, false);
+    assert.strictEqual(child.rawLine, 1);
+    assert.strictEqual(child.sourceLine, '- 9:00-10:00 Meeting');
+  });
 });


### PR DESCRIPTION
## 関連Issue
Closes #84

## 概要
ガントチャートに表示されているタスクバーをクリックするとタスクの完了/未完了が切り替わるようにしました。これまでカレンダービューからのみ可能だった切り替え操作がガントチャートでも行えるようになり、タスク管理の操作性が向上します。

## 変更内容
- `GanttChildItem` に `rawLine` / `sourceLine` フィールドを追加し、バーからトグル対象の行を特定できるようにした
- スタンドアロンバーと展開中のグループ子バーが task の場合、クリックで `toggleTask` メッセージを送信するよう Webview を更新
- ドラッグ中（パン操作）やドキュメント URI が未取得のときはトグルを発火しない
- タスクバーに `cursor: pointer` を付与してクリック可能であることを可視化
- Gantt エンティティに関する新しいテストケースを追加

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] `npm run lint` と `npm run test:unit` が全てパスすることを確認した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| ガントチャートのタスクバーをクリックしても何も起きない | ガントチャートのタスクバーをクリックすると完了/未完了が切り替わる |

## 備考・次やること
特になし。