### PR TITLE
Release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "TaskMark" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.5.0] - 2026-04-23
+
+### Added
+- Today indicator line is rendered on the Gantt timeline view, and the Today button is now available in the Timeline view to scroll to the current date (#34).
+- Click a task bar in the Gantt chart to toggle its completion state; the change is written back to the underlying `.tmd` file (#84).
+
 ## [1.4.0] - 2026-04-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Visualize schedule durations and project spans as a Gantt chart.
 - **Progress Bars** — Group task completion rates are displayed visually on the bars
 - **Weekend Colors** — Colored backgrounds corresponding to the calendar view
 - **Sub-rows** — Tasks inside a group are displayed as individual sub-rows beneath the group bar; click the group bar to collapse or expand them
+- **Toggle Tasks** — Click a task bar to toggle completion (`- [ ]` / `- [x]`) directly in the `.tmd` file
 - Grouped schedules appear as a single connected bar, while standalone items with the same name appear as separate blocks on the same row
 
 ### 🏷️ Tags & Colors

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Visualize schedule durations and project spans as a Gantt chart.
 
 - **Pan** — Move smoothly in any direction by clicking and dragging
 - **Zoom** — Zoom in/out (from days to hours) with `Ctrl + Mouse Wheel`, or the zoom buttons in the view header
+- **Today Marker** — A red vertical line indicates the current date; click the `Today` button to scroll to it
 - **Progress Bars** — Group task completion rates are displayed visually on the bars
 - **Weekend Colors** — Colored backgrounds corresponding to the calendar view
 - **Sub-rows** — Tasks inside a group are displayed as individual sub-rows beneath the group bar; click the group bar to collapse or expand them

--- a/media/main.js
+++ b/media/main.js
@@ -850,6 +850,28 @@
     container.appendChild(axisRow);
   }
 
+  /** Render a vertical line marking the current date on the Gantt container */
+  function renderGanttTodayMarker(container, startDate, totalRenderDays, pxPerMs) {
+    const nowMs = Date.now();
+    const offsetMs = nowMs - startDate.getTime();
+    const endMs = totalRenderDays * MS_PER_DAY;
+    if (offsetMs < 0 || offsetMs > endMs) return;
+
+    const left = offsetMs * pxPerMs;
+
+    const line = document.createElement('div');
+    line.className = 'tm-gantt-today-line';
+    line.style.left = left + 'px';
+    line.style.height = '100%';
+    container.appendChild(line);
+
+    const label = document.createElement('div');
+    label.className = 'tm-gantt-today-label';
+    label.style.left = left + 'px';
+    label.textContent = 'Today';
+    container.appendChild(label);
+  }
+
   /** Render a single Gantt bar (group or standalone) */
   function renderGanttEntityBar(container, entity, startDate, pxPerMs, yOffset, totalWidth, skipRowBg) {
     if (!skipRowBg) {
@@ -1058,6 +1080,7 @@
 
     // Render axis and column backgrounds
     renderGanttAxis(ganttContainer, startDate, totalRenderDays, pxPerMs);
+    renderGanttTodayMarker(ganttContainer, startDate, totalRenderDays, pxPerMs);
 
     // Render entity bars grouped by lane (same lane = same row)
     let yOffset = GANTT_HEADER_HEIGHT;

--- a/media/main.js
+++ b/media/main.js
@@ -345,6 +345,17 @@
   btnZoomIn.addEventListener('click', () => applyZoom(GANTT_ZOOM_IN_FACTOR));
   btnZoomOut.addEventListener('click', () => applyZoom(GANTT_ZOOM_OUT_FACTOR));
 
+  // Delegated task-bar toggle: one listener handles every task bar in the gantt.
+  viewTimeline?.addEventListener('click', (e) => {
+    const bar = e.target.closest('.tm-gantt-task-bar[data-raw-line]');
+    if (!bar || hasDragged || !currentUri) return;
+    const rawLine = Number(bar.dataset.rawLine);
+    if (!Number.isInteger(rawLine) || rawLine < 0) return;
+    const sourceLine = bar.dataset.sourceLine;
+    if (typeof sourceLine !== 'string') return;
+    vscode.postMessage({ type: 'toggleTask', uri: currentUri, rawLine, sourceLine });
+  });
+
   // Date navigation
   function navigateDate(direction) {
     if (baseView === 'timeline' || activeView === 'monthly') {
@@ -1006,21 +1017,11 @@
     });
   }
 
-  /** Wire a gantt bar to toggle its backing task when clicked (ignored during panning). */
+  /** Tag a gantt bar as a toggleable task. Click handling is delegated on viewTimeline. */
   function attachTaskToggle(bar, child) {
     bar.classList.add('tm-gantt-task-bar');
     bar.dataset.rawLine = String(child.rawLine);
     bar.dataset.sourceLine = child.sourceLine;
-    bar.addEventListener('click', (e) => {
-      e.stopPropagation();
-      if (hasDragged || !currentUri) return;
-      vscode.postMessage({
-        type: 'toggleTask',
-        uri: currentUri,
-        rawLine: child.rawLine,
-        sourceLine: child.sourceLine
-      });
-    });
   }
 
   /** Create a positioned Gantt bar element */

--- a/media/main.js
+++ b/media/main.js
@@ -954,6 +954,9 @@
       }
       pBar.style.backgroundColor = bgColor;
       bar.appendChild(pBar);
+      if (child.isTask) {
+        attachTaskToggle(bar, child);
+      }
       container.appendChild(bar);
 
       // Label (outside bar, to the right)
@@ -993,10 +996,30 @@
       }
       pBar.style.backgroundColor = childColor;
       bar.appendChild(pBar);
+      if (child.isTask) {
+        attachTaskToggle(bar, child);
+      }
       container.appendChild(bar);
 
       // Label (outside bar, to the right)
       container.appendChild(createGanttLabel(child.text, left + width, childYOffset));
+    });
+  }
+
+  /** Wire a gantt bar to toggle its backing task when clicked (ignored during panning). */
+  function attachTaskToggle(bar, child) {
+    bar.classList.add('tm-gantt-task-bar');
+    bar.dataset.rawLine = String(child.rawLine);
+    bar.dataset.sourceLine = child.sourceLine;
+    bar.addEventListener('click', (e) => {
+      e.stopPropagation();
+      if (hasDragged || !currentUri) return;
+      vscode.postMessage({
+        type: 'toggleTask',
+        uri: currentUri,
+        rawLine: child.rawLine,
+        sourceLine: child.sourceLine
+      });
     });
   }
 

--- a/media/main.js
+++ b/media/main.js
@@ -22,6 +22,7 @@
   let currentGanttData = null;
   let rangeItemIndex = null; // Pre-built index: date string -> range items spanning that date
   let ganttZoom = GANTT_DEFAULT_ZOOM; // 1 = 100px per day
+  let ganttTodayLeft = null; // px offset of the today marker, or null if out of range
   let expandedGroups = new Set();
   let isPanning = false;
   let hasDragged = false;
@@ -275,6 +276,9 @@
   btnToday?.addEventListener('click', () => {
     currentDate = new Date();
     render();
+    if (baseView === 'timeline' && ganttTodayLeft !== null) {
+      viewTimeline.scrollLeft = Math.max(0, ganttTodayLeft - viewTimeline.clientWidth / 2);
+    }
   });
 
   viewCalendar?.addEventListener('click', (e) => {
@@ -855,9 +859,13 @@
     const nowMs = Date.now();
     const offsetMs = nowMs - startDate.getTime();
     const endMs = totalRenderDays * MS_PER_DAY;
-    if (offsetMs < 0 || offsetMs > endMs) return;
+    if (offsetMs < 0 || offsetMs > endMs) {
+      ganttTodayLeft = null;
+      return;
+    }
 
     const left = offsetMs * pxPerMs;
+    ganttTodayLeft = left;
 
     const line = document.createElement('div');
     line.className = 'tm-gantt-today-line';

--- a/media/main.js
+++ b/media/main.js
@@ -872,12 +872,6 @@
     line.style.left = left + 'px';
     line.style.height = '100%';
     container.appendChild(line);
-
-    const label = document.createElement('div');
-    label.className = 'tm-gantt-today-label';
-    label.style.left = left + 'px';
-    label.textContent = 'Today';
-    container.appendChild(label);
   }
 
   /** Render a single Gantt bar (group or standalone) */

--- a/media/style.css
+++ b/media/style.css
@@ -737,21 +737,6 @@ body {
   pointer-events: none;
 }
 
-.tm-gantt-today-label {
-  position: absolute;
-  top: 2px;
-  z-index: 9;
-  padding: 1px 4px;
-  font-size: max(9px, calc(var(--tm-font-size) - 4px));
-  font-weight: bold;
-  color: #fff;
-  background: #e53935;
-  border-radius: 2px;
-  transform: translateX(-50%);
-  pointer-events: none;
-  white-space: nowrap;
-}
-
 /* Child rows (group task members) */
 .tm-gantt-child-row-bg {
   border-left: 2px solid var(--tm-card-border);

--- a/media/style.css
+++ b/media/style.css
@@ -692,6 +692,10 @@ body {
   cursor: pointer;
 }
 
+.tm-gantt-task-bar {
+  cursor: pointer;
+}
+
 .tm-gantt-group-indicator {
   position: relative;
   z-index: 2;

--- a/media/style.css
+++ b/media/style.css
@@ -24,6 +24,7 @@
   --tm-sun-color: #e74c3c;
   --tm-sat-bg: rgba(52, 152, 219, 0.08);
   --tm-sun-bg: rgba(231, 76, 60, 0.08);
+  --tm-today-line-color: #e53935;
 }
 
 /* ─── Light Theme Overrides ─────────────────────────────────── */
@@ -736,7 +737,7 @@ body {
   position: absolute;
   top: 0;
   width: 2px;
-  background: #e53935;
+  background: var(--tm-today-line-color);
   z-index: 8;
   pointer-events: none;
 }

--- a/media/style.css
+++ b/media/style.css
@@ -733,7 +733,7 @@ body {
   top: 0;
   width: 2px;
   background: #e53935;
-  z-index: 8;
+  z-index: 0;
   pointer-events: none;
 }
 

--- a/media/style.css
+++ b/media/style.css
@@ -129,6 +129,12 @@ body {
   color: var(--tm-accent-fg);
 }
 
+.tm-nav-group {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
 .tm-month-nav {
   display: flex;
   align-items: center;

--- a/media/style.css
+++ b/media/style.css
@@ -129,7 +129,7 @@ body {
   color: var(--tm-accent-fg);
 }
 
-.tm-nav-group {
+.tm-header-right {
   display: flex;
   align-items: center;
   gap: 16px;

--- a/media/style.css
+++ b/media/style.css
@@ -733,7 +733,7 @@ body {
   top: 0;
   width: 2px;
   background: #e53935;
-  z-index: 0;
+  z-index: 8;
   pointer-events: none;
 }
 

--- a/media/style.css
+++ b/media/style.css
@@ -721,6 +721,31 @@ body {
   pointer-events: none;
 }
 
+/* Today marker */
+.tm-gantt-today-line {
+  position: absolute;
+  top: 0;
+  width: 2px;
+  background: #e53935;
+  z-index: 8;
+  pointer-events: none;
+}
+
+.tm-gantt-today-label {
+  position: absolute;
+  top: 2px;
+  z-index: 9;
+  padding: 1px 4px;
+  font-size: max(9px, calc(var(--tm-font-size) - 4px));
+  font-weight: bold;
+  color: #fff;
+  background: #e53935;
+  border-radius: 2px;
+  transform: translateX(-50%);
+  pointer-events: none;
+  white-space: nowrap;
+}
+
 /* Child rows (group task members) */
 .tm-gantt-child-row-bg {
   border-left: 2px solid var(--tm-card-border);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskmark",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskmark",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "25.x",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "taskmark",
   "displayName": "TaskMark",
   "description": "Schedule and Task Management with Markdown and Calendar/Timeline Views",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "icon": "media/icon.png",
   "publisher": "Yadecode",
   "repository": {

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -10,6 +10,8 @@ export interface GanttChildItem {
   endMs: number;
   isTask: boolean;
   isDone: boolean;
+  rawLine: number;
+  sourceLine: string;
 }
 
 export interface GanttEntity {
@@ -110,7 +112,9 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
         startMs,
         endMs,
         isTask: item.type === 'task',
-        isDone: item.status === 'done'
+        isDone: item.status === 'done',
+        rawLine: item.rawLine,
+        sourceLine: item.sourceLine
       });
 
       if (item.type === 'task') {

--- a/src/template.ts
+++ b/src/template.ts
@@ -23,16 +23,18 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
             <button class="tm-view-toggle active" id="btn-calendar">Calendar</button>
             <button class="tm-view-toggle" id="btn-timeline">Timeline</button>
           </div>
-          <button class="tm-view-toggle" id="btn-today">Today</button>
-          <div class="tm-month-nav">
-             <div class="tm-toggle-container" id="calendar-granularity-toggles">
-                <button class="tm-view-toggle active" id="btn-monthly">Monthly</button>
-                <button class="tm-view-toggle" id="btn-weekly">Weekly</button>
-                <button class="tm-view-toggle" id="btn-daily">Daily</button>
-             </div>
-             <button id="btn-prev-month">&lt;</button>
-             <h2 id="current-month-display"></h2>
-             <button id="btn-next-month">&gt;</button>
+          <div class="tm-nav-group">
+            <button class="tm-view-toggle" id="btn-today">Today</button>
+            <div class="tm-month-nav">
+               <div class="tm-toggle-container" id="calendar-granularity-toggles">
+                  <button class="tm-view-toggle active" id="btn-monthly">Monthly</button>
+                  <button class="tm-view-toggle" id="btn-weekly">Weekly</button>
+                  <button class="tm-view-toggle" id="btn-daily">Daily</button>
+               </div>
+               <button id="btn-prev-month">&lt;</button>
+               <h2 id="current-month-display"></h2>
+               <button id="btn-next-month">&gt;</button>
+            </div>
           </div>
           <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
             <button id="btn-zoom-out" title="Zoom Out">-</button>

--- a/src/template.ts
+++ b/src/template.ts
@@ -23,8 +23,8 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
             <button class="tm-view-toggle active" id="btn-calendar">Calendar</button>
             <button class="tm-view-toggle" id="btn-timeline">Timeline</button>
           </div>
+          <button class="tm-view-toggle" id="btn-today">Today</button>
           <div class="tm-month-nav">
-             <button class="tm-view-toggle" id="btn-today">Today</button>
              <div class="tm-toggle-container" id="calendar-granularity-toggles">
                 <button class="tm-view-toggle active" id="btn-monthly">Monthly</button>
                 <button class="tm-view-toggle" id="btn-weekly">Weekly</button>

--- a/src/template.ts
+++ b/src/template.ts
@@ -23,7 +23,7 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
             <button class="tm-view-toggle active" id="btn-calendar">Calendar</button>
             <button class="tm-view-toggle" id="btn-timeline">Timeline</button>
           </div>
-          <div class="tm-nav-group">
+          <div class="tm-header-right">
             <button class="tm-view-toggle" id="btn-today">Today</button>
             <div class="tm-month-nav">
                <div class="tm-toggle-container" id="calendar-granularity-toggles">
@@ -35,10 +35,10 @@ export function getWebviewHtml(scriptUri: vscode.Uri, stylesUri: vscode.Uri, csp
                <h2 id="current-month-display"></h2>
                <button id="btn-next-month">&gt;</button>
             </div>
-          </div>
-          <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
-            <button id="btn-zoom-out" title="Zoom Out">-</button>
-            <button id="btn-zoom-in" title="Zoom In">+</button>
+            <div class="tm-zoom-controls hidden" id="tm-zoom-controls">
+              <button id="btn-zoom-out" title="Zoom Out">-</button>
+              <button id="btn-zoom-in" title="Zoom In">+</button>
+            </div>
           </div>
         </div>
         <div class="tm-content" id="tm-content-area">

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -323,4 +323,41 @@ suite('Gantt Test Suite', () => {
     const { entities } = buildGanttEntities(data);
     assert.deepStrictEqual(entities[0].tags, ['urgent'], 'standalone entity should use its own tags');
   });
+
+  test('task children expose rawLine and sourceLine for toggling', () => {
+    const { data } = parseTmd(`# 2026-03-01
+- [ ] Standalone Task
+`);
+    const { entities } = buildGanttEntities(data);
+    const entity = entities[0];
+    const child = entity.children[0];
+    assert.strictEqual(child.isTask, true);
+    assert.strictEqual(child.rawLine, 1);
+    assert.strictEqual(child.sourceLine, '- [ ] Standalone Task');
+  });
+
+  test('grouped task children expose rawLine and sourceLine for toggling', () => {
+    const { data } = parseTmd(`# 2026-03-01
+> Sprint
+> - [ ] Task A
+> - [x] Task B
+`);
+    const { entities } = buildGanttEntities(data);
+    const group = entities[0];
+    assert.strictEqual(group.children[0].rawLine, 2);
+    assert.strictEqual(group.children[0].sourceLine, '> - [ ] Task A');
+    assert.strictEqual(group.children[1].rawLine, 3);
+    assert.strictEqual(group.children[1].sourceLine, '> - [x] Task B');
+  });
+
+  test('schedule children also carry rawLine and sourceLine from source item', () => {
+    const { data } = parseTmd(`# 2026-03-01
+- 9:00-10:00 Meeting
+`);
+    const { entities } = buildGanttEntities(data);
+    const child = entities[0].children[0];
+    assert.strictEqual(child.isTask, false);
+    assert.strictEqual(child.rawLine, 1);
+    assert.strictEqual(child.sourceLine, '- 9:00-10:00 Meeting');
+  });
 });


### PR DESCRIPTION
## 関連Issue
Closes #34, Closes #84

## 概要
v1.4.0 以降の develop を main に取り込み、v1.5.0 としてリリースするための PR です。
Gantt タイムラインへの Today ライン表示と、ガントチャートのタスクバークリックによる完了トグル機能を追加しています。

## 変更内容
### Added
- Gantt タイムラインビューに現在日時を示す Today ライン（赤色の縦線）を表示し、Timeline ビューでも Today ボタンを利用してその位置までスクロールできるよう対応 (#34)
- ガントチャートのタスクバーをクリックすることで、タスクの完了 / 未完了を切り替え可能に（`.tmd` ファイルへ反映） (#84)

### Docs / Chore
- README に Today ライン / Today ボタン、Gantt タスクトグルの説明を追記
- CHANGELOG に v1.5.0 セクションを追加
- `package.json` / `package-lock.json` を `1.5.0` にバンプ

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した
- [x] `npm run lint` / `npm run test:unit` が成功することを確認した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| Timeline に Today ラインなし / タスクバークリックで何も起きない | Today の位置に赤い縦線、タスクバークリックで完了トグル |

## 備考・次やること
- リリース後、`v1.5.0` タグを打ち、Marketplace への公開作業を実施する
- タグ付け完了後、`taskmark-1.5.0.vsix` を生成してアーティファクトとして残す

🤖 Generated with [Claude Code](https://claude.com/claude-code)