### PR TITLE
feat: .tmd 編集を補助するクイック追加コマンドとスニペット補完

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,37 @@ Use `# YYYY-MM-DD : YYYY-MM-DD` to define events or tasks that span multiple day
 
 ---
 
+### ✏️ Editing Helpers
+
+Reduce the typing cost of writing `.tmd` files with quick-add commands, snippets, and inline completion.
+
+**Quick-Add Commands** — Open the Command Palette (`Ctrl+Shift+P`) and run:
+
+- **`TaskMark: Add Task`** — Prompts for the task body and target date, then inserts `- [ ] <body>` into the matching date section. The section is created at the end of the file if it does not exist.
+- **`TaskMark: Add Schedule`** — Prompts for the body, start time, optional end time, and target date, then inserts `- HH:mm[-HH:mm] <body>` into the matching date section.
+
+The date prompt offers `Today` / `Tomorrow` / a custom `YYYY-MM-DD`.
+
+**Snippets** — Type the prefix and press `Tab` while editing a `.tmd` file:
+
+| Prefix | Expands to |
+|------|------|
+| `task` | `- [ ] ` |
+| `event` | `- HH:mm-HH:mm ` |
+| `date` | `# YYYY-MM-DD` |
+| `range` | `# YYYY-MM-DD : YYYY-MM-DD` |
+| `group` | `> Group Name #Tag` |
+| `repeat` | `@repeat(daily|weekly|monthly)` (choice) |
+| `tags` | `@tags` ... `@end` block |
+
+**Inline Completion**
+
+- After `#`, completes from tags defined in the current file's `@tags` block and from `taskmark.tagColors` settings.
+- After `@`, completes the keywords `repeat(`, `tags`, and `end`.
+- Inside `@repeat(...)`, completes the modifiers `daily`, `weekly`, `monthly`, `every:`, `until:`, `count:`, `except:`.
+
+---
+
 ## Usage
 
 1. Open a `.tmd` extension file.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,14 @@
         "command": "taskmark.openView",
         "title": "TaskMark: Open View",
         "icon": "$(open-preview)"
+      },
+      {
+        "command": "taskmark.addTask",
+        "title": "TaskMark: Add Task"
+      },
+      {
+        "command": "taskmark.addSchedule",
+        "title": "TaskMark: Add Schedule"
       }
     ],
     "keybindings": [
@@ -59,6 +67,12 @@
         "language": "tmd",
         "scopeName": "source.tmd",
         "path": "./syntaxes/tmd.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "tmd",
+        "path": "./snippets/tmd.code-snippets"
       }
     ],
     "configuration": {

--- a/snippets/tmd.code-snippets
+++ b/snippets/tmd.code-snippets
@@ -1,0 +1,41 @@
+{
+  "Task": {
+    "prefix": "task",
+    "body": "- [ ] $0",
+    "description": "Insert a new task line"
+  },
+  "Event": {
+    "prefix": "event",
+    "body": "- ${1:HH:mm}-${2:HH:mm} $0",
+    "description": "Insert a new timed schedule line"
+  },
+  "Date": {
+    "prefix": "date",
+    "body": "# ${1:YYYY-MM-DD}",
+    "description": "Insert a new date section header"
+  },
+  "Date range": {
+    "prefix": "range",
+    "body": "# ${1:YYYY-MM-DD} : ${2:YYYY-MM-DD}",
+    "description": "Insert a date-range section header"
+  },
+  "Group": {
+    "prefix": "group",
+    "body": "> ${1:Group Name} #${2:Tag}",
+    "description": "Insert a group header"
+  },
+  "Repeat": {
+    "prefix": "repeat",
+    "body": "@repeat(${1|daily,weekly,monthly|})",
+    "description": "Insert an @repeat() modifier"
+  },
+  "Tags block": {
+    "prefix": "tags",
+    "body": [
+      "@tags",
+      "#${1:Tag} : ${2:#color}",
+      "@end"
+    ],
+    "description": "Insert a @tags...@end block"
+  }
+}

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -1,0 +1,76 @@
+// Pure logic for the .tmd CompletionItemProvider.
+// VS Code wiring lives in extension.ts; this module only deals with strings
+// and plain data so it can be unit-tested.
+
+const TAG_DEFINITION_REGEX = /^#([^\s:]+)\s*:/;
+
+export const REPEAT_OPTION_KEYWORDS: string[] = [
+  'daily',
+  'weekly',
+  'monthly',
+  'every:',
+  'until:',
+  'count:',
+  'except:',
+];
+
+export const AT_KEYWORDS: string[] = [
+  'repeat(',
+  'tags',
+  'end',
+];
+
+/**
+ * Collect tag names known to the document.
+ * Sources: `#name : color` rows inside an `@tags ... @end` block, and the
+ * keys of the `taskmark.tagColors` setting if supplied.
+ */
+export function extractDefinedTags(
+  documentText: string,
+  tagColorsSetting?: Record<string, string>
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  const lines = documentText === '' ? [] : documentText.split(/\r?\n/);
+  let inTagsBlock = false;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (line === '@tags') {
+      inTagsBlock = true;
+      continue;
+    }
+    if (line === '@end') {
+      inTagsBlock = false;
+      continue;
+    }
+    if (!inTagsBlock) {
+      continue;
+    }
+    const m = line.match(TAG_DEFINITION_REGEX);
+    if (m && !seen.has(m[1])) {
+      seen.add(m[1]);
+      result.push(m[1]);
+    }
+  }
+
+  if (tagColorsSetting) {
+    for (const name of Object.keys(tagColorsSetting)) {
+      if (!seen.has(name)) {
+        seen.add(name);
+        result.push(name);
+      }
+    }
+  }
+
+  return result;
+}
+
+export interface TagCompletionItem {
+  label: string;
+  insertText: string;
+}
+
+export function buildTagCompletionItems(tags: string[]): TagCompletionItem[] {
+  return tags.map(t => ({ label: t, insertText: t }));
+}

--- a/src/completionProvider.ts
+++ b/src/completionProvider.ts
@@ -1,0 +1,105 @@
+import * as vscode from 'vscode';
+import {
+  AT_KEYWORDS,
+  REPEAT_OPTION_KEYWORDS,
+  extractDefinedTags,
+} from './completion';
+
+const TMD_SELECTOR: vscode.DocumentSelector = { language: 'tmd' };
+
+export function registerCompletionProviders(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      TMD_SELECTOR,
+      new TmdHashCompletionProvider(),
+      '#'
+    ),
+    vscode.languages.registerCompletionItemProvider(
+      TMD_SELECTOR,
+      new TmdAtCompletionProvider(),
+      '@'
+    ),
+    vscode.languages.registerCompletionItemProvider(
+      TMD_SELECTOR,
+      new TmdRepeatOptionProvider(),
+      '(',
+      ',',
+      ' '
+    ),
+  );
+}
+
+class TmdHashCompletionProvider implements vscode.CompletionItemProvider {
+  provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.CompletionItem[] {
+    const linePrefix = document.lineAt(position).text.slice(0, position.character);
+    if (!/(?:^|\s)#[^\s#]*$/.test(linePrefix)) {
+      return [];
+    }
+    const tagColors = vscode.workspace
+      .getConfiguration('taskmark')
+      .get<Record<string, string>>('tagColors', {});
+    const tags = extractDefinedTags(document.getText(), tagColors);
+    return tags.map(name => {
+      const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Value);
+      item.insertText = name;
+      item.detail = 'TaskMark tag';
+      return item;
+    });
+  }
+}
+
+class TmdAtCompletionProvider implements vscode.CompletionItemProvider {
+  provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.CompletionItem[] {
+    const linePrefix = document.lineAt(position).text.slice(0, position.character);
+    if (!/(?:^|\s)@[A-Za-z]*$/.test(linePrefix)) {
+      return [];
+    }
+    return AT_KEYWORDS.map(keyword => {
+      const label = keyword.endsWith('(') ? keyword.slice(0, -1) : keyword;
+      const item = new vscode.CompletionItem(label, vscode.CompletionItemKind.Keyword);
+      if (keyword === 'repeat(') {
+        const snippet = new vscode.SnippetString('repeat(${1|daily,weekly,monthly|})');
+        item.insertText = snippet;
+        item.detail = '@repeat(...) modifier';
+      } else if (keyword === 'tags') {
+        const snippet = new vscode.SnippetString('tags\n#${1:Tag} : ${2:#color}\n@end');
+        item.insertText = snippet;
+        item.detail = '@tags ... @end block';
+      } else {
+        item.insertText = keyword;
+        item.detail = `@${keyword}`;
+      }
+      return item;
+    });
+  }
+}
+
+class TmdRepeatOptionProvider implements vscode.CompletionItemProvider {
+  provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.CompletionItem[] {
+    const lineText = document.lineAt(position).text;
+    const before = lineText.slice(0, position.character);
+    const open = before.lastIndexOf('@repeat(');
+    if (open === -1) {
+      return [];
+    }
+    const close = before.indexOf(')', open);
+    if (close !== -1) {
+      return [];
+    }
+    return REPEAT_OPTION_KEYWORDS.map(keyword => {
+      const item = new vscode.CompletionItem(keyword, vscode.CompletionItemKind.EnumMember);
+      item.insertText = keyword;
+      item.detail = '@repeat option';
+      return item;
+    });
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import { TaskmarkPanel } from './TaskmarkPanel';
+import { registerQuickAddCommands } from './quickAddCommands';
+import { registerCompletionProviders } from './completionProvider';
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -7,6 +9,9 @@ export function activate(context: vscode.ExtensionContext) {
       TaskmarkPanel.createOrShow(context.extensionUri);
     })
   );
+
+  registerQuickAddCommands(context);
+  registerCompletionProviders(context);
 
   if (vscode.window.registerWebviewPanelSerializer) {
     vscode.window.registerWebviewPanelSerializer(TaskmarkPanel.viewType, {

--- a/src/quickAdd.ts
+++ b/src/quickAdd.ts
@@ -1,0 +1,133 @@
+// Pure helpers backing the TaskMark: Add Task / Add Schedule commands.
+// Kept free of vscode imports so the logic can be unit-tested without
+// the VS Code test runner.
+
+const DATE_HEADER_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})/;
+const FULL_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_REGEX = /^([01]?\d|2[0-3]):[0-5]\d$/;
+
+export function formatTaskLine(text: string): string {
+  return `- [ ] ${text.trim()}`;
+}
+
+export function formatScheduleLine(text: string, startTime: string, endTime?: string): string {
+  const trimmed = text.trim();
+  const time = endTime ? `${startTime}-${endTime}` : startTime;
+  return trimmed ? `- ${time} ${trimmed}` : `- ${time}`;
+}
+
+export interface InsertResult {
+  newText: string;
+  /** Zero-based line index of the inserted item line in `newText`. */
+  insertedLineIndex: number;
+}
+
+/**
+ * Insert `itemLine` into the section for `dateStr`.
+ * - If a section header for the date exists, append the line after the
+ *   last non-empty line within that section.
+ * - If no section exists, append a new `# YYYY-MM-DD` section followed
+ *   by the item to the end of the document, keeping any trailing blank
+ *   lines intact.
+ *
+ * `dateStr` is matched against the section header in normalized form so
+ * a header like `# 2026-3-5` still matches `dateStr = '2026-03-05'`.
+ */
+export function insertItemForDate(
+  documentText: string,
+  dateStr: string,
+  itemLine: string
+): InsertResult {
+  const lines = documentText === '' ? [] : documentText.split(/\r?\n/);
+  const sectionStart = findSectionStart(lines, dateStr);
+
+  if (sectionStart === -1) {
+    return appendNewSection(lines, dateStr, itemLine);
+  }
+  return appendToExistingSection(lines, sectionStart, itemLine);
+}
+
+function findSectionStart(lines: string[], dateStr: string): number {
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(DATE_HEADER_REGEX);
+    if (m && normalizeDate(m[1]) === dateStr) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function appendNewSection(lines: string[], dateStr: string, itemLine: string): InsertResult {
+  let trimEnd = lines.length;
+  while (trimEnd > 0 && lines[trimEnd - 1].trim() === '') {
+    trimEnd--;
+  }
+  const head = lines.slice(0, trimEnd);
+  const tail = lines.slice(trimEnd);
+
+  const inserted: string[] = [];
+  if (head.length > 0) {
+    inserted.push('');
+  }
+  inserted.push(`# ${dateStr}`);
+  inserted.push(itemLine);
+
+  const newLines = [...head, ...inserted, ...tail];
+  const insertedLineIndex = head.length + inserted.length - 1;
+  return { newText: newLines.join('\n'), insertedLineIndex };
+}
+
+function appendToExistingSection(lines: string[], sectionStart: number, itemLine: string): InsertResult {
+  let nextSection = lines.length;
+  for (let i = sectionStart + 1; i < lines.length; i++) {
+    if (DATE_HEADER_REGEX.test(lines[i])) {
+      nextSection = i;
+      break;
+    }
+  }
+
+  let insertAfter = sectionStart;
+  for (let i = sectionStart + 1; i < nextSection; i++) {
+    if (lines[i].trim() !== '') {
+      insertAfter = i;
+    }
+  }
+
+  const newLines = [
+    ...lines.slice(0, insertAfter + 1),
+    itemLine,
+    ...lines.slice(insertAfter + 1),
+  ];
+  return { newText: newLines.join('\n'), insertedLineIndex: insertAfter + 1 };
+}
+
+function normalizeDate(raw: string): string {
+  const [y, m, d] = raw.split('-');
+  return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
+}
+
+export function isValidDate(s: string): boolean {
+  if (!FULL_DATE_REGEX.test(s)) {
+    return false;
+  }
+  const [y, m, d] = s.split('-').map(Number);
+  const date = new Date(y, m - 1, d);
+  return date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d;
+}
+
+export function isValidTime(s: string): boolean {
+  return TIME_REGEX.test(s);
+}
+
+export function formatLocalDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export function offsetDate(base: Date, days: number): Date {
+  const next = new Date(base.getFullYear(), base.getMonth(), base.getDate());
+  next.setDate(next.getDate() + days);
+  return next;
+}

--- a/src/quickAdd.ts
+++ b/src/quickAdd.ts
@@ -32,19 +32,33 @@ export interface InsertResult {
  *
  * `dateStr` is matched against the section header in normalized form so
  * a header like `# 2026-3-5` still matches `dateStr = '2026-03-05'`.
+ *
+ * `eol` controls the line separator used when joining the result. Pass
+ * the document's existing EOL (`\n` or `\r\n`) so line endings are not
+ * silently converted on Windows-style files.
  */
 export function insertItemForDate(
   documentText: string,
   dateStr: string,
-  itemLine: string
+  itemLine: string,
+  eol: string = '\n'
 ): InsertResult {
   const lines = documentText === '' ? [] : documentText.split(/\r?\n/);
   const sectionStart = findSectionStart(lines, dateStr);
 
-  if (sectionStart === -1) {
-    return appendNewSection(lines, dateStr, itemLine);
-  }
-  return appendToExistingSection(lines, sectionStart, itemLine);
+  const planned = sectionStart === -1
+    ? planNewSection(lines, dateStr, itemLine)
+    : planExistingSection(lines, sectionStart, itemLine);
+
+  return {
+    newText: planned.lines.join(eol),
+    insertedLineIndex: planned.insertedLineIndex,
+  };
+}
+
+interface InsertPlan {
+  lines: string[];
+  insertedLineIndex: number;
 }
 
 function findSectionStart(lines: string[], dateStr: string): number {
@@ -57,7 +71,7 @@ function findSectionStart(lines: string[], dateStr: string): number {
   return -1;
 }
 
-function appendNewSection(lines: string[], dateStr: string, itemLine: string): InsertResult {
+function planNewSection(lines: string[], dateStr: string, itemLine: string): InsertPlan {
   let trimEnd = lines.length;
   while (trimEnd > 0 && lines[trimEnd - 1].trim() === '') {
     trimEnd--;
@@ -72,12 +86,13 @@ function appendNewSection(lines: string[], dateStr: string, itemLine: string): I
   inserted.push(`# ${dateStr}`);
   inserted.push(itemLine);
 
-  const newLines = [...head, ...inserted, ...tail];
-  const insertedLineIndex = head.length + inserted.length - 1;
-  return { newText: newLines.join('\n'), insertedLineIndex };
+  return {
+    lines: [...head, ...inserted, ...tail],
+    insertedLineIndex: head.length + inserted.length - 1,
+  };
 }
 
-function appendToExistingSection(lines: string[], sectionStart: number, itemLine: string): InsertResult {
+function planExistingSection(lines: string[], sectionStart: number, itemLine: string): InsertPlan {
   let nextSection = lines.length;
   for (let i = sectionStart + 1; i < lines.length; i++) {
     if (DATE_HEADER_REGEX.test(lines[i])) {
@@ -93,12 +108,14 @@ function appendToExistingSection(lines: string[], sectionStart: number, itemLine
     }
   }
 
-  const newLines = [
-    ...lines.slice(0, insertAfter + 1),
-    itemLine,
-    ...lines.slice(insertAfter + 1),
-  ];
-  return { newText: newLines.join('\n'), insertedLineIndex: insertAfter + 1 };
+  return {
+    lines: [
+      ...lines.slice(0, insertAfter + 1),
+      itemLine,
+      ...lines.slice(insertAfter + 1),
+    ],
+    insertedLineIndex: insertAfter + 1,
+  };
 }
 
 function normalizeDate(raw: string): string {

--- a/src/quickAddCommands.ts
+++ b/src/quickAddCommands.ts
@@ -154,7 +154,8 @@ async function pickDate(): Promise<string | undefined> {
 async function applyInsertion(editor: vscode.TextEditor, dateStr: string, itemLine: string): Promise<void> {
   const document = editor.document;
   const original = document.getText();
-  const { newText, insertedLineIndex } = insertItemForDate(original, dateStr, itemLine);
+  const eol = document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n';
+  const { newText, insertedLineIndex } = insertItemForDate(original, dateStr, itemLine, eol);
 
   const fullRange = new vscode.Range(
     document.positionAt(0),

--- a/src/quickAddCommands.ts
+++ b/src/quickAddCommands.ts
@@ -1,0 +1,173 @@
+import * as vscode from 'vscode';
+import {
+  formatLocalDate,
+  formatScheduleLine,
+  formatTaskLine,
+  insertItemForDate,
+  isValidDate,
+  isValidTime,
+  offsetDate,
+} from './quickAdd';
+
+const TMD_LANGUAGE_ID = 'tmd';
+
+export function registerQuickAddCommands(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('taskmark.addTask', () => runAddTask()),
+    vscode.commands.registerCommand('taskmark.addSchedule', () => runAddSchedule()),
+  );
+}
+
+async function runAddTask(): Promise<void> {
+  const editor = await resolveTmdEditor();
+  if (!editor) {
+    return;
+  }
+
+  const body = await vscode.window.showInputBox({
+    prompt: 'Task text',
+    placeHolder: 'e.g. Review pull request',
+    ignoreFocusOut: true,
+    validateInput: v => (v.trim() === '' ? 'Task text cannot be empty' : null),
+  });
+  if (body === undefined) {
+    return;
+  }
+
+  const dateStr = await pickDate();
+  if (!dateStr) {
+    return;
+  }
+
+  await applyInsertion(editor, dateStr, formatTaskLine(body));
+}
+
+async function runAddSchedule(): Promise<void> {
+  const editor = await resolveTmdEditor();
+  if (!editor) {
+    return;
+  }
+
+  const body = await vscode.window.showInputBox({
+    prompt: 'Schedule text',
+    placeHolder: 'e.g. Team meeting',
+    ignoreFocusOut: true,
+    validateInput: v => (v.trim() === '' ? 'Schedule text cannot be empty' : null),
+  });
+  if (body === undefined) {
+    return;
+  }
+
+  const startTime = await vscode.window.showInputBox({
+    prompt: 'Start time (HH:mm)',
+    placeHolder: '09:00',
+    ignoreFocusOut: true,
+    validateInput: v => (isValidTime(v) ? null : 'Enter time as HH:mm (24-hour)'),
+  });
+  if (startTime === undefined) {
+    return;
+  }
+
+  const endTime = await vscode.window.showInputBox({
+    prompt: 'End time (HH:mm) — leave blank for no end time',
+    placeHolder: '10:00',
+    ignoreFocusOut: true,
+    validateInput: v => (v === '' || isValidTime(v) ? null : 'Enter time as HH:mm (24-hour)'),
+  });
+  if (endTime === undefined) {
+    return;
+  }
+
+  const dateStr = await pickDate();
+  if (!dateStr) {
+    return;
+  }
+
+  const line = formatScheduleLine(body, startTime, endTime === '' ? undefined : endTime);
+  await applyInsertion(editor, dateStr, line);
+}
+
+async function resolveTmdEditor(): Promise<vscode.TextEditor | undefined> {
+  const active = vscode.window.activeTextEditor;
+  if (active && active.document.languageId === TMD_LANGUAGE_ID) {
+    return active;
+  }
+
+  const tmdDocs = vscode.workspace.textDocuments.filter(d => d.languageId === TMD_LANGUAGE_ID);
+  if (tmdDocs.length === 0) {
+    const tmdFiles = await vscode.workspace.findFiles('**/*.tmd', '**/node_modules/**', 20);
+    if (tmdFiles.length === 0) {
+      vscode.window.showErrorMessage('TaskMark: No .tmd file found in the workspace.');
+      return undefined;
+    }
+    const picked = tmdFiles.length === 1
+      ? tmdFiles[0]
+      : await vscode.window.showQuickPick(
+          tmdFiles.map(uri => ({ label: vscode.workspace.asRelativePath(uri), uri })),
+          { placeHolder: 'Select a .tmd file' }
+        ).then(p => p?.uri);
+    if (!picked) {
+      return undefined;
+    }
+    const doc = await vscode.workspace.openTextDocument(picked);
+    return vscode.window.showTextDocument(doc);
+  }
+
+  if (tmdDocs.length === 1) {
+    return vscode.window.showTextDocument(tmdDocs[0]);
+  }
+
+  const pick = await vscode.window.showQuickPick(
+    tmdDocs.map(d => ({ label: vscode.workspace.asRelativePath(d.uri), document: d })),
+    { placeHolder: 'Select a .tmd file' }
+  );
+  return pick ? vscode.window.showTextDocument(pick.document) : undefined;
+}
+
+async function pickDate(): Promise<string | undefined> {
+  const now = new Date();
+  const today = formatLocalDate(now);
+  const tomorrow = formatLocalDate(offsetDate(now, 1));
+
+  const choice = await vscode.window.showQuickPick(
+    [
+      { label: 'Today', detail: today, value: today },
+      { label: 'Tomorrow', detail: tomorrow, value: tomorrow },
+      { label: 'Pick a date…', detail: 'Enter YYYY-MM-DD', value: '__custom__' },
+    ],
+    { placeHolder: 'Target date' }
+  );
+  if (!choice) {
+    return undefined;
+  }
+  if (choice.value !== '__custom__') {
+    return choice.value;
+  }
+  return vscode.window.showInputBox({
+    prompt: 'Date (YYYY-MM-DD)',
+    placeHolder: today,
+    ignoreFocusOut: true,
+    validateInput: v => (isValidDate(v) ? null : 'Enter a date as YYYY-MM-DD'),
+  });
+}
+
+async function applyInsertion(editor: vscode.TextEditor, dateStr: string, itemLine: string): Promise<void> {
+  const document = editor.document;
+  const original = document.getText();
+  const { newText, insertedLineIndex } = insertItemForDate(original, dateStr, itemLine);
+
+  const fullRange = new vscode.Range(
+    document.positionAt(0),
+    document.positionAt(original.length)
+  );
+
+  const ok = await editor.edit(eb => eb.replace(fullRange, newText));
+  if (!ok) {
+    vscode.window.showErrorMessage('TaskMark: Failed to insert item.');
+    return;
+  }
+
+  const target = new vscode.Position(insertedLineIndex, document.lineAt(insertedLineIndex).text.length);
+  editor.selection = new vscode.Selection(target, target);
+  editor.revealRange(new vscode.Range(target, target), vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+}

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -1,0 +1,83 @@
+import * as assert from 'assert';
+import {
+  extractDefinedTags,
+  REPEAT_OPTION_KEYWORDS,
+  AT_KEYWORDS,
+  buildTagCompletionItems,
+} from '../../completion';
+
+suite('Completion Test Suite', () => {
+  test('extractDefinedTags returns tags listed inside the @tags block', () => {
+    const text = [
+      '@tags',
+      '#meeting : #ff0000',
+      '#work : #0088ff',
+      '@end',
+      '',
+      '# 2026-03-26',
+      '- A #meeting',
+    ].join('\n');
+
+    assert.deepStrictEqual(extractDefinedTags(text), ['meeting', 'work']);
+  });
+
+  test('extractDefinedTags ignores tags written outside the block', () => {
+    const text = [
+      '# 2026-03-26',
+      '- A #stray',
+    ].join('\n');
+
+    assert.deepStrictEqual(extractDefinedTags(text), []);
+  });
+
+  test('extractDefinedTags skips lines that are not tag definitions', () => {
+    const text = [
+      '@tags',
+      '#good : #ff0000',
+      'invalid line',
+      '#also-good : red',
+      '@end',
+    ].join('\n');
+
+    assert.deepStrictEqual(extractDefinedTags(text), ['good', 'also-good']);
+  });
+
+  test('extractDefinedTags merges tag names from taskmark.tagColors when provided', () => {
+    const text = '';
+    const tagColors: Record<string, string> = { important: '#ff0000', mtg: '#3498db' };
+    const tags = extractDefinedTags(text, tagColors);
+    assert.deepStrictEqual([...tags].sort(), ['important', 'mtg']);
+  });
+
+  test('extractDefinedTags deduplicates tags coming from both sources', () => {
+    const text = [
+      '@tags',
+      '#mtg : #3498db',
+      '@end',
+    ].join('\n');
+    const tagColors: Record<string, string> = { mtg: '#000000', other: '#fff' };
+    const tags = extractDefinedTags(text, tagColors);
+    assert.strictEqual(tags.length, 2);
+    assert.ok(tags.includes('mtg'));
+    assert.ok(tags.includes('other'));
+  });
+
+  test('REPEAT_OPTION_KEYWORDS includes the documented modifiers', () => {
+    for (const k of ['daily', 'weekly', 'monthly', 'every:', 'until:', 'count:', 'except:']) {
+      assert.ok(REPEAT_OPTION_KEYWORDS.includes(k), `expected ${k} in REPEAT_OPTION_KEYWORDS`);
+    }
+  });
+
+  test('AT_KEYWORDS includes repeat / tags / end', () => {
+    assert.ok(AT_KEYWORDS.some(k => k.startsWith('repeat')));
+    assert.ok(AT_KEYWORDS.includes('tags'));
+    assert.ok(AT_KEYWORDS.includes('end'));
+  });
+
+  test('buildTagCompletionItems returns one entry per tag with the bare name as label', () => {
+    const items = buildTagCompletionItems(['meeting', 'work']);
+    assert.strictEqual(items.length, 2);
+    assert.deepStrictEqual(items.map(i => i.label), ['meeting', 'work']);
+    assert.deepStrictEqual(items.map(i => i.insertText), ['meeting', 'work']);
+  });
+});

--- a/src/test/suite/quickAdd.test.ts
+++ b/src/test/suite/quickAdd.test.ts
@@ -1,0 +1,143 @@
+import * as assert from 'assert';
+import {
+  formatTaskLine,
+  formatScheduleLine,
+  insertItemForDate,
+  isValidDate,
+  isValidTime,
+  formatLocalDate,
+  offsetDate,
+} from '../../quickAdd';
+
+suite('Quick Add Test Suite', () => {
+  test('formatTaskLine wraps text in checkbox syntax', () => {
+    assert.strictEqual(formatTaskLine('Buy milk'), '- [ ] Buy milk');
+  });
+
+  test('formatScheduleLine produces start-end form when endTime is set', () => {
+    assert.strictEqual(
+      formatScheduleLine('Meeting', '09:00', '10:00'),
+      '- 09:00-10:00 Meeting'
+    );
+  });
+
+  test('formatScheduleLine produces start-only form when endTime is omitted', () => {
+    assert.strictEqual(
+      formatScheduleLine('Lunch', '12:00'),
+      '- 12:00 Lunch'
+    );
+  });
+
+  test('formatScheduleLine trims whitespace around the body', () => {
+    assert.strictEqual(
+      formatScheduleLine('  Meeting  ', '09:00', '10:00'),
+      '- 09:00-10:00 Meeting'
+    );
+  });
+
+  test('insertItemForDate inserts a line into the existing date section', () => {
+    const text = [
+      '# 2026-03-26',
+      '- 09:00 Existing',
+      '',
+      '# 2026-03-27',
+      '- 10:00 Other',
+    ].join('\n');
+
+    const { newText, insertedLineIndex } = insertItemForDate(text, '2026-03-26', '- [ ] New');
+
+    assert.strictEqual(insertedLineIndex, 2);
+    assert.strictEqual(
+      newText,
+      [
+        '# 2026-03-26',
+        '- 09:00 Existing',
+        '- [ ] New',
+        '',
+        '# 2026-03-27',
+        '- 10:00 Other',
+      ].join('\n')
+    );
+  });
+
+  test('insertItemForDate creates a new section when the date is missing', () => {
+    const text = [
+      '# 2026-03-26',
+      '- 09:00 Existing',
+    ].join('\n');
+
+    const { newText, insertedLineIndex } = insertItemForDate(text, '2026-03-30', '- [ ] New');
+
+    assert.strictEqual(
+      newText,
+      [
+        '# 2026-03-26',
+        '- 09:00 Existing',
+        '',
+        '# 2026-03-30',
+        '- [ ] New',
+      ].join('\n')
+    );
+    assert.strictEqual(insertedLineIndex, 4);
+  });
+
+  test('insertItemForDate handles empty documents', () => {
+    const { newText, insertedLineIndex } = insertItemForDate('', '2026-03-30', '- [ ] New');
+
+    assert.strictEqual(newText, ['# 2026-03-30', '- [ ] New'].join('\n'));
+    assert.strictEqual(insertedLineIndex, 1);
+  });
+
+  test('insertItemForDate keeps trailing empty lines after the new section', () => {
+    const text = '# 2026-03-26\n- A\n\n\n';
+    const { newText } = insertItemForDate(text, '2026-03-30', '- [ ] B');
+    assert.ok(newText.endsWith('\n\n\n'));
+    assert.ok(newText.includes('# 2026-03-30\n- [ ] B'));
+  });
+
+  test('insertItemForDate matches sections written with single-digit month/day', () => {
+    const text = '# 2026-3-5\n- A';
+    const { newText } = insertItemForDate(text, '2026-03-05', '- [ ] B');
+    assert.strictEqual(newText, '# 2026-3-5\n- A\n- [ ] B');
+  });
+
+  test('isValidDate accepts well-formed YYYY-MM-DD', () => {
+    assert.strictEqual(isValidDate('2026-03-26'), true);
+    assert.strictEqual(isValidDate('2026-12-31'), true);
+  });
+
+  test('isValidDate rejects malformed and impossible dates', () => {
+    assert.strictEqual(isValidDate('2026-13-01'), false);
+    assert.strictEqual(isValidDate('2026-02-30'), false);
+    assert.strictEqual(isValidDate('2026/03/26'), false);
+    assert.strictEqual(isValidDate(''), false);
+    assert.strictEqual(isValidDate('not-a-date'), false);
+  });
+
+  test('isValidTime accepts HH:mm in 24-hour range', () => {
+    assert.strictEqual(isValidTime('00:00'), true);
+    assert.strictEqual(isValidTime('09:30'), true);
+    assert.strictEqual(isValidTime('23:59'), true);
+    assert.strictEqual(isValidTime('9:30'), true);
+  });
+
+  test('isValidTime rejects out-of-range values', () => {
+    assert.strictEqual(isValidTime('24:00'), false);
+    assert.strictEqual(isValidTime('12:60'), false);
+    assert.strictEqual(isValidTime('9-30'), false);
+    assert.strictEqual(isValidTime(''), false);
+  });
+
+  test('formatLocalDate emits zero-padded YYYY-MM-DD from a Date', () => {
+    assert.strictEqual(formatLocalDate(new Date(2026, 2, 5)), '2026-03-05');
+    assert.strictEqual(formatLocalDate(new Date(2026, 11, 31)), '2026-12-31');
+  });
+
+  test('offsetDate adds days without mutating the input', () => {
+    const base = new Date(2026, 2, 30);
+    const next = offsetDate(base, 1);
+    assert.strictEqual(formatLocalDate(next), '2026-03-31');
+    assert.strictEqual(formatLocalDate(offsetDate(base, 2)), '2026-04-01');
+    assert.strictEqual(formatLocalDate(base), '2026-03-30');
+  });
+});

--- a/src/test/suite/quickAdd.test.ts
+++ b/src/test/suite/quickAdd.test.ts
@@ -101,6 +101,27 @@ suite('Quick Add Test Suite', () => {
     assert.strictEqual(newText, '# 2026-3-5\n- A\n- [ ] B');
   });
 
+  test('insertItemForDate preserves CRLF line endings when eol="\\r\\n"', () => {
+    const text = ['# 2026-03-26', '- A', '', '# 2026-03-27', '- B'].join('\r\n');
+    const { newText, insertedLineIndex } = insertItemForDate(text, '2026-03-26', '- [ ] New', '\r\n');
+
+    assert.strictEqual(insertedLineIndex, 2);
+    assert.strictEqual(
+      newText,
+      ['# 2026-03-26', '- A', '- [ ] New', '', '# 2026-03-27', '- B'].join('\r\n')
+    );
+    assert.ok(!/(?<!\r)\n/.test(newText), 'should not contain bare \\n');
+  });
+
+  test('insertItemForDate appends a new section using the given eol', () => {
+    const text = ['# 2026-03-26', '- A'].join('\r\n');
+    const { newText } = insertItemForDate(text, '2026-03-30', '- [ ] B', '\r\n');
+    assert.strictEqual(
+      newText,
+      ['# 2026-03-26', '- A', '', '# 2026-03-30', '- [ ] B'].join('\r\n')
+    );
+  });
+
   test('isValidDate accepts well-formed YYYY-MM-DD', () => {
     assert.strictEqual(isValidDate('2026-03-26'), true);
     assert.strictEqual(isValidDate('2026-12-31'), true);


### PR DESCRIPTION
## 関連Issue
Closes #88

## 概要
`.tmd` への入力コストを下げるため、コマンドパレットからのクイック追加と、スニペット / 補完による編集補助を追加した。書き始めの定型タイプ量と、リピート修飾子・タグ名を思い出すコストを削減することが目的。

## 変更内容
- `TaskMark: Add Task` / `TaskMark: Add Schedule` をコマンドとして追加（本文・時刻・日付を QuickPick / InputBox で受け取り、対象セクションが無ければ末尾に新規作成）
- `.tmd` 編集時のスニペットを追加 (`task` / `event` / `date` / `range` / `group` / `repeat` / `tags`)
- CompletionItemProvider を追加
  - `#` 入力でタグブロックおよび `taskmark.tagColors` 設定で定義済みのタグ名を補完
  - `` ` `` 文字入力で `repeat(` / `tags` / `end` を補完
  - `repeat(` 内で `daily` / `weekly` / `monthly` / `every:` / `until:` / `count:` / `except:` を補完
- 上記に対応するロジックは VS Code API に依存しない純粋関数に切り出し、ユニットテストを追加

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] `npm run lint` がエラーなく完了する（既存の警告 1 件のみ）
- [x] `npm run test:unit` が全 137 件パスする

## 備考・次やること
- スニペット / 補完は `language: tmd` セレクタで限定しているため他言語には影響しない。
- Add Task / Add Schedule の挿入位置は「対象セクション内の最後の非空行の直後」としている。グループブロック直後に挿入される場合があるが、`-` 始まりの新規行はパーサ上でグループに属さないため意味的な不整合は発生しない。