### PR TITLE
feat: アクティビティバーにサイドバー (TreeView) を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "TaskMark" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+
+### Added
+- Activity Bar TreeView ("TaskMark: Overview") that summarizes the active `.tmd` file by Today / This week / Overdue / Recently done. Clicking an item jumps to the corresponding line, and tasks expose an inline toggle action (#89).
+
 ## [1.5.0] - 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ Use `# YYYY-MM-DD : YYYY-MM-DD` to define events or tasks that span multiple day
 
 ---
 
+### Activity Bar Sidebar
+
+A dedicated TaskMark icon appears in the Activity Bar. Clicking it opens the **Overview** TreeView, which summarizes the active `.tmd` file at a glance:
+
+- **Today** — schedules and tasks for the current day (including ranges that span today)
+- **This week** — items in the current Mon–Sun week, excluding today
+- **Overdue** — incomplete tasks dated before today
+- **Recently done** — the most recent completed tasks (up to 10)
+
+Click any item to jump to its line in the `.tmd` file. Use the inline check-mark action on a task to toggle `- [ ]` / `- [x]` without opening the editor. The view auto-refreshes when the file is edited or another `.tmd` becomes active, and the title bar provides a manual refresh button.
+
+---
+
 ### ✏️ Editing Helpers
 
 Reduce the typing cost of writing `.tmd` files with quick-add commands, snippets, and inline completion.

--- a/media/activitybar-icon.svg
+++ b/media/activitybar-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3.5" y="4.5" width="17" height="16" rx="2"/>
+  <path d="M3.5 8.5h17"/>
+  <path d="M8 3.5v3"/>
+  <path d="M16 3.5v3"/>
+  <path d="M7.5 13l2 2 4.5-4.5"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,25 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "taskmark",
+          "title": "TaskMark",
+          "icon": "media/activitybar-icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "taskmark": [
+        {
+          "id": "taskmarkOverview",
+          "name": "Overview",
+          "icon": "media/activitybar-icon.svg",
+          "contextualTitle": "TaskMark"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "taskmark.openView",
@@ -30,6 +49,16 @@
       {
         "command": "taskmark.addSchedule",
         "title": "TaskMark: Add Schedule"
+      },
+      {
+        "command": "taskmark.tree.refresh",
+        "title": "TaskMark: Refresh Overview",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "taskmark.tree.toggleItem",
+        "title": "TaskMark: Toggle Task",
+        "icon": "$(check)"
       }
     ],
     "keybindings": [
@@ -46,6 +75,26 @@
           "command": "taskmark.openView",
           "when": "editorLangId == tmd",
           "group": "navigation"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "taskmark.tree.refresh",
+          "when": "view == taskmarkOverview",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "taskmark.tree.toggleItem",
+          "when": "view == taskmarkOverview && viewItem == taskmarkTask",
+          "group": "inline"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "taskmark.tree.toggleItem",
+          "when": "false"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import { TaskmarkPanel } from './TaskmarkPanel';
 import { registerQuickAddCommands } from './quickAddCommands';
 import { registerCompletionProviders } from './completionProvider';
+import { TaskmarkTreeDataProvider } from './treeViewProvider';
+import { debounce } from './utils/debounce';
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -12,6 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   registerQuickAddCommands(context);
   registerCompletionProviders(context);
+  registerTreeView(context);
 
   if (vscode.window.registerWebviewPanelSerializer) {
     vscode.window.registerWebviewPanelSerializer(TaskmarkPanel.viewType, {
@@ -20,4 +23,38 @@ export function activate(context: vscode.ExtensionContext) {
       }
     });
   }
+}
+
+function registerTreeView(context: vscode.ExtensionContext) {
+  const provider = new TaskmarkTreeDataProvider();
+  const treeView = vscode.window.createTreeView('taskmarkOverview', {
+    treeDataProvider: provider,
+    showCollapseAll: true
+  });
+  context.subscriptions.push(treeView);
+
+  provider.refresh();
+
+  const debouncedRefresh = debounce(() => provider.refresh(), 250);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('taskmark.tree.refresh', () => provider.refresh()),
+    vscode.commands.registerCommand('taskmark.tree.revealItem', (node) => {
+      if (node && node.kind === 'item') {
+        void provider.revealItem(node);
+      }
+    }),
+    vscode.commands.registerCommand('taskmark.tree.toggleItem', (node) => {
+      if (node && node.kind === 'item') {
+        void provider.toggleItem(node);
+      }
+    }),
+    vscode.window.onDidChangeActiveTextEditor(() => provider.refresh()),
+    vscode.workspace.onDidChangeTextDocument(e => {
+      if (e.document.languageId === 'tmd') {
+        debouncedRefresh();
+      }
+    }),
+    { dispose: () => debouncedRefresh.cancel() }
+  );
 }

--- a/src/test/suite/treeView.test.ts
+++ b/src/test/suite/treeView.test.ts
@@ -123,6 +123,18 @@ suite('categorizeForTreeView', () => {
     assert.deepStrictEqual(texts, ['Morning', 'Afternoon', 'Untimed']);
   });
 
+  test('today sort handles unpadded hours numerically (9:00 < 10:00)', () => {
+    const text = `
+# 2026-05-02
+- 10:00 Ten
+- 9:00 Nine
+- 9:30-10:30 NineThirty
+`;
+    const result = getCategorized(text, '2026-05-02');
+    const texts = result.today.map(i => i.text);
+    assert.deepStrictEqual(texts, ['Nine', 'NineThirty', 'Ten']);
+  });
+
   test('week boundary: Monday is first day of week', () => {
     // 2026-05-04 is Monday.
     const text = `

--- a/src/test/suite/treeView.test.ts
+++ b/src/test/suite/treeView.test.ts
@@ -1,0 +1,149 @@
+import * as assert from 'assert';
+import { parseTmd } from '../../parser';
+import { categorizeForTreeView, RECENTLY_DONE_LIMIT } from '../../treeView';
+
+function getCategorized(text: string, today: string) {
+  const { data } = parseTmd(text);
+  return categorizeForTreeView(data, today);
+}
+
+suite('categorizeForTreeView', () => {
+  test('today bucket includes items whose startDate equals today', () => {
+    const text = `
+# 2026-05-02
+- [ ] 10:00 Meeting
+- Plain schedule
+
+# 2026-05-01
+- Yesterday item
+`;
+    const result = getCategorized(text, '2026-05-02');
+    const todayTexts = result.today.map(i => i.text);
+    assert.deepStrictEqual(todayTexts.sort(), ['Meeting', 'Plain schedule'].sort());
+  });
+
+  test('today bucket includes spanning items where today is between start and end', () => {
+    const text = `
+# 2026-04-30 : 2026-05-05
+- Long event
+`;
+    const result = getCategorized(text, '2026-05-02');
+    assert.strictEqual(result.today.length, 1);
+    assert.strictEqual(result.today[0].text, 'Long event');
+  });
+
+  test('thisWeek bucket includes items in the same Mon-Sun week excluding today', () => {
+    // 2026-05-02 is a Saturday. Week (Mon-Sun) = 2026-04-27..2026-05-03.
+    const text = `
+# 2026-04-27
+- Monday item
+
+# 2026-05-02
+- Saturday item
+
+# 2026-05-03
+- Sunday item
+
+# 2026-05-04
+- Next Monday item
+`;
+    const result = getCategorized(text, '2026-05-02');
+    const weekTexts = result.thisWeek.map(i => i.text);
+    assert.ok(weekTexts.includes('Monday item'));
+    assert.ok(weekTexts.includes('Sunday item'));
+    assert.ok(!weekTexts.includes('Saturday item'), 'today should be excluded from thisWeek');
+    assert.ok(!weekTexts.includes('Next Monday item'), 'next week should not be in thisWeek');
+  });
+
+  test('overdue bucket includes only undone tasks before today', () => {
+    const text = `
+# 2026-04-25
+- [ ] Old todo
+- [x] Old done
+- Old schedule
+
+# 2026-05-02
+- [ ] Today todo
+`;
+    const result = getCategorized(text, '2026-05-02');
+    const overdueTexts = result.overdue.map(i => i.text);
+    assert.deepStrictEqual(overdueTexts, ['Old todo']);
+  });
+
+  test('overdue uses endDate when present (an item is not overdue while its range includes today)', () => {
+    const text = `
+# 2026-04-30 : 2026-05-05
+- [ ] Long task
+`;
+    const result = getCategorized(text, '2026-05-02');
+    assert.strictEqual(result.overdue.length, 0, 'task whose endDate is in the future is not overdue');
+  });
+
+  test('recentlyDone returns up to RECENTLY_DONE_LIMIT done tasks, newest first', () => {
+    const lines: string[] = [];
+    const total = RECENTLY_DONE_LIMIT + 3;
+    for (let i = 0; i < total; i++) {
+      const day = String(i + 1).padStart(2, '0');
+      lines.push(`# 2026-04-${day}`);
+      lines.push(`- [x] done-${i}`);
+      lines.push('');
+    }
+    const result = getCategorized(lines.join('\n'), '2026-05-02');
+    assert.strictEqual(result.recentlyDone.length, RECENTLY_DONE_LIMIT);
+    // Newest (largest date) first.
+    assert.strictEqual(result.recentlyDone[0].text, `done-${total - 1}`);
+    assert.strictEqual(
+      result.recentlyDone[RECENTLY_DONE_LIMIT - 1].text,
+      `done-${total - RECENTLY_DONE_LIMIT}`
+    );
+  });
+
+  test('recentlyDone excludes done tasks dated in the future', () => {
+    const text = `
+# 2026-04-25
+- [x] past done
+
+# 2026-05-10
+- [x] future done
+`;
+    const result = getCategorized(text, '2026-05-02');
+    const texts = result.recentlyDone.map(i => i.text);
+    assert.deepStrictEqual(texts, ['past done']);
+  });
+
+  test('items in today are sorted by time then by line order', () => {
+    const text = `
+# 2026-05-02
+- 14:00 Afternoon
+- 09:00 Morning
+- Untimed
+`;
+    const result = getCategorized(text, '2026-05-02');
+    const texts = result.today.map(i => i.text);
+    assert.deepStrictEqual(texts, ['Morning', 'Afternoon', 'Untimed']);
+  });
+
+  test('week boundary: Monday is first day of week', () => {
+    // 2026-05-04 is Monday.
+    const text = `
+# 2026-05-03
+- Sunday previous week
+
+# 2026-05-04
+- Monday today
+`;
+    const result = getCategorized(text, '2026-05-04');
+    const weekTexts = result.thisWeek.map(i => i.text);
+    assert.ok(!weekTexts.includes('Sunday previous week'));
+    // today is Monday, excluded from thisWeek.
+    assert.ok(!weekTexts.includes('Monday today'));
+  });
+
+  test('returns empty buckets for an empty document', () => {
+    const result = getCategorized('', '2026-05-02');
+    assert.deepStrictEqual(result.today, []);
+    assert.deepStrictEqual(result.thisWeek, []);
+    assert.deepStrictEqual(result.overdue, []);
+    assert.deepStrictEqual(result.recentlyDone, []);
+  });
+});

--- a/src/test/suite/treeView.test.ts
+++ b/src/test/suite/treeView.test.ts
@@ -151,6 +151,20 @@ suite('categorizeForTreeView', () => {
     assert.ok(!weekTexts.includes('Monday today'));
   });
 
+  test('repeat occurrences carry the occurrence date as startDate', () => {
+    // 2026-05-04 is Monday. Weekly repeat starting that day produces occurrences
+    // on 05-04, 05-11, 05-18, ... The week containing today (2026-05-12, Tue)
+    // is 05-11 .. 05-17, so only the 05-11 occurrence belongs to thisWeek.
+    const text = `
+# 2026-05-04
+- Weekly Sync @repeat(weekly, count:4)
+`;
+    const result = getCategorized(text, '2026-05-12');
+    assert.strictEqual(result.thisWeek.length, 1);
+    assert.strictEqual(result.thisWeek[0].startDate, '2026-05-11',
+      'thisWeek occurrence should carry the occurrence date, not the repeat origin');
+  });
+
   test('returns empty buckets for an empty document', () => {
     const result = getCategorized('', '2026-05-02');
     assert.deepStrictEqual(result.today, []);

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -75,6 +75,7 @@ export function categorizeForTreeView(
   const recentlyDoneOcc: Occurrence[] = [];
 
   for (const occ of occurrences) {
+    occ.item.startDate = occ.start;
     const inToday = todayStr >= occ.start && todayStr <= occ.end;
     if (inToday) {
       today.push(occ.item);

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -35,9 +35,15 @@ export function getWeekRange(dateStr: string): { start: string; end: string } {
   return { start: toDateStr(monday), end: toDateStr(sunday) };
 }
 
+function timeStartMinutes(time: string): number {
+  const start = time.split('-')[0];
+  const [h, m] = start.split(':').map(s => parseInt(s, 10));
+  return h * 60 + m;
+}
+
 function compareByTimeThenLine(a: MarkItem, b: MarkItem): number {
   if (a.time && b.time) {
-    return a.time.localeCompare(b.time) || a.rawLine - b.rawLine;
+    return timeStartMinutes(a.time) - timeStartMinutes(b.time) || a.rawLine - b.rawLine;
   }
   if (a.time) { return -1; }
   if (b.time) { return 1; }

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -1,0 +1,122 @@
+import { MarkItem, TaskMarkData, parseLocalDate } from './parser';
+
+export const RECENTLY_DONE_LIMIT = 10;
+
+export interface TreeCategorizedItems {
+  today: MarkItem[];
+  thisWeek: MarkItem[];
+  overdue: MarkItem[];
+  recentlyDone: MarkItem[];
+}
+
+interface Occurrence {
+  item: MarkItem;
+  dayKey: string;
+  start: string;
+  end: string;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function toDateStr(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+export function getWeekRange(dateStr: string): { start: string; end: string } {
+  const d = parseLocalDate(dateStr);
+  const dow = d.getDay(); // 0=Sun..6=Sat
+  const offsetToMonday = dow === 0 ? -6 : 1 - dow;
+  const monday = new Date(d);
+  monday.setDate(d.getDate() + offsetToMonday);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  return { start: toDateStr(monday), end: toDateStr(sunday) };
+}
+
+function compareByTimeThenLine(a: MarkItem, b: MarkItem): number {
+  if (a.time && b.time) {
+    return a.time.localeCompare(b.time) || a.rawLine - b.rawLine;
+  }
+  if (a.time) { return -1; }
+  if (b.time) { return 1; }
+  return a.rawLine - b.rawLine;
+}
+
+function buildOccurrences(data: TaskMarkData): Occurrence[] {
+  const out: Occurrence[] = [];
+  for (const [dayKey, day] of Object.entries(data.days)) {
+    for (const item of day.items) {
+      const start = item.endDate ? item.startDate : dayKey;
+      const end = item.endDate ?? dayKey;
+      out.push({ item, dayKey, start, end });
+    }
+  }
+  return out;
+}
+
+export function categorizeForTreeView(
+  data: TaskMarkData,
+  todayStr: string
+): TreeCategorizedItems {
+  const occurrences = buildOccurrences(data);
+  const week = getWeekRange(todayStr);
+
+  const today: MarkItem[] = [];
+  const thisWeek: MarkItem[] = [];
+  const overdue: MarkItem[] = [];
+  const recentlyDoneOcc: Occurrence[] = [];
+
+  for (const occ of occurrences) {
+    const inToday = todayStr >= occ.start && todayStr <= occ.end;
+    if (inToday) {
+      today.push(occ.item);
+    } else if (occ.start <= week.end && occ.end >= week.start) {
+      thisWeek.push(occ.item);
+    }
+
+    if (occ.item.type === 'task' && occ.item.status === 'todo' && occ.end < todayStr) {
+      overdue.push(occ.item);
+    }
+
+    if (occ.item.type === 'task' && occ.item.status === 'done' && occ.end <= todayStr) {
+      recentlyDoneOcc.push(occ);
+    }
+  }
+
+  today.sort(compareByTimeThenLine);
+  thisWeek.sort((a, b) => a.startDate.localeCompare(b.startDate) || compareByTimeThenLine(a, b));
+  overdue.sort((a, b) => a.startDate.localeCompare(b.startDate) || a.rawLine - b.rawLine);
+  recentlyDoneOcc.sort((a, b) => b.end.localeCompare(a.end) || b.item.rawLine - a.item.rawLine);
+
+  return {
+    today,
+    thisWeek,
+    overdue,
+    recentlyDone: recentlyDoneOcc.slice(0, RECENTLY_DONE_LIMIT).map(o => o.item)
+  };
+}
+
+export function todayDateStr(now: Date = new Date()): string {
+  return toDateStr(now);
+}
+
+export type CategoryId = 'today' | 'thisWeek' | 'overdue' | 'recentlyDone';
+
+export const CATEGORY_ORDER: CategoryId[] = ['today', 'thisWeek', 'overdue', 'recentlyDone'];
+
+export function categoryLabel(id: CategoryId, todayStr: string): string {
+  switch (id) {
+    case 'today': return `Today (${todayStr})`;
+    case 'thisWeek': return 'This week';
+    case 'overdue': return 'Overdue';
+    case 'recentlyDone': return 'Recently done';
+  }
+}
+
+export function formatItemLabel(item: MarkItem): string {
+  const checkbox = item.type === 'task' ? (item.status === 'done' ? '[x] ' : '[ ] ') : '';
+  const time = item.time ? `${item.time} ` : '';
+  return `${checkbox}${time}${item.text}`.trim();
+}

--- a/src/treeViewProvider.ts
+++ b/src/treeViewProvider.ts
@@ -87,9 +87,9 @@ export class TaskmarkTreeDataProvider implements vscode.TreeDataProvider<TreeNod
     }
 
     const treeItem = new vscode.TreeItem(formatItemLabel(node.item), vscode.TreeItemCollapsibleState.None);
-    treeItem.description = node.item.tags.length > 0
-      ? node.item.tags.map(t => `#${t}`).join(' ')
-      : undefined;
+    const datePart = node.category !== 'today' ? `${node.item.startDate} ` : '';
+    const tagsPart = node.item.tags.map(t => `#${t}`).join(' ');
+    treeItem.description = (datePart + tagsPart).trim() || undefined;
     treeItem.tooltip = `${node.item.startDate}${node.item.endDate ? ` : ${node.item.endDate}` : ''}\n${node.item.sourceLine}`;
     treeItem.command = {
       command: 'taskmark.tree.revealItem',

--- a/src/treeViewProvider.ts
+++ b/src/treeViewProvider.ts
@@ -1,0 +1,164 @@
+import * as vscode from 'vscode';
+import { MarkItem, parseTmd } from './parser';
+import { resolveToggleTargetLineIndex, toggleCheckboxInLine } from './messages';
+import {
+  CategoryId,
+  CATEGORY_ORDER,
+  TreeCategorizedItems,
+  categorizeForTreeView,
+  categoryLabel,
+  formatItemLabel,
+  todayDateStr
+} from './treeView';
+
+interface CategoryNode {
+  kind: 'category';
+  id: CategoryId;
+}
+
+interface ItemNode {
+  kind: 'item';
+  category: CategoryId;
+  item: MarkItem;
+  uri: vscode.Uri;
+}
+
+export type TreeNode = CategoryNode | ItemNode;
+
+function categoryIcon(id: CategoryId): vscode.ThemeIcon {
+  switch (id) {
+    case 'today': return new vscode.ThemeIcon('calendar');
+    case 'thisWeek': return new vscode.ThemeIcon('calendar');
+    case 'overdue': return new vscode.ThemeIcon('warning');
+    case 'recentlyDone': return new vscode.ThemeIcon('check');
+  }
+}
+
+export class TaskmarkTreeDataProvider implements vscode.TreeDataProvider<TreeNode> {
+  private readonly _onDidChange = new vscode.EventEmitter<TreeNode | undefined>();
+  public readonly onDidChangeTreeData = this._onDidChange.event;
+
+  private _activeUri: vscode.Uri | undefined;
+  private _categorized: TreeCategorizedItems = {
+    today: [], thisWeek: [], overdue: [], recentlyDone: []
+  };
+  private _todayStr: string = todayDateStr();
+
+  refresh(): void {
+    this._todayStr = todayDateStr();
+    const editor = this._findTmdEditor();
+    if (editor) {
+      this._activeUri = editor.document.uri;
+      const { data } = parseTmd(editor.document.getText());
+      this._categorized = categorizeForTreeView(data, this._todayStr);
+    } else {
+      this._activeUri = undefined;
+      this._categorized = { today: [], thisWeek: [], overdue: [], recentlyDone: [] };
+    }
+    this._onDidChange.fire(undefined);
+  }
+
+  private _findTmdEditor(): vscode.TextEditor | undefined {
+    const active = vscode.window.activeTextEditor;
+    if (active && active.document.languageId === 'tmd') {
+      return active;
+    }
+    for (const editor of vscode.window.visibleTextEditors) {
+      if (editor.document.languageId === 'tmd') {
+        return editor;
+      }
+    }
+    return undefined;
+  }
+
+  getTreeItem(node: TreeNode): vscode.TreeItem {
+    if (node.kind === 'category') {
+      const items = this._categorized[node.id];
+      const label = categoryLabel(node.id, this._todayStr);
+      const treeItem = new vscode.TreeItem(
+        `${label} (${items.length})`,
+        items.length > 0
+          ? vscode.TreeItemCollapsibleState.Expanded
+          : vscode.TreeItemCollapsibleState.None
+      );
+      treeItem.iconPath = categoryIcon(node.id);
+      treeItem.contextValue = `taskmarkCategory.${node.id}`;
+      return treeItem;
+    }
+
+    const treeItem = new vscode.TreeItem(formatItemLabel(node.item), vscode.TreeItemCollapsibleState.None);
+    treeItem.description = node.item.tags.length > 0
+      ? node.item.tags.map(t => `#${t}`).join(' ')
+      : undefined;
+    treeItem.tooltip = `${node.item.startDate}${node.item.endDate ? ` : ${node.item.endDate}` : ''}\n${node.item.sourceLine}`;
+    treeItem.command = {
+      command: 'taskmark.tree.revealItem',
+      title: 'Reveal in editor',
+      arguments: [node]
+    };
+    treeItem.contextValue = node.item.type === 'task' ? 'taskmarkTask' : 'taskmarkSchedule';
+    if (node.item.type === 'task') {
+      treeItem.iconPath = new vscode.ThemeIcon(
+        node.item.status === 'done' ? 'pass-filled' : 'circle-large-outline'
+      );
+    } else {
+      treeItem.iconPath = new vscode.ThemeIcon('clock');
+    }
+    return treeItem;
+  }
+
+  getChildren(node?: TreeNode): TreeNode[] {
+    if (!node) {
+      return CATEGORY_ORDER.map(id => ({ kind: 'category', id }));
+    }
+    if (node.kind === 'category') {
+      const uri = this._activeUri;
+      if (!uri) { return []; }
+      return this._categorized[node.id].map(item => ({
+        kind: 'item',
+        category: node.id,
+        item,
+        uri
+      }));
+    }
+    return [];
+  }
+
+  async revealItem(node: ItemNode): Promise<void> {
+    const document = await vscode.workspace.openTextDocument(node.uri);
+    const lineIdx = resolveToggleTargetLineIndex(
+      document.lineCount,
+      i => document.lineAt(i).text,
+      node.item.rawLine,
+      node.item.sourceLine
+    );
+    const targetLine = lineIdx ?? Math.min(node.item.rawLine, document.lineCount - 1);
+    const editor = await vscode.window.showTextDocument(document, { preview: false });
+    const range = document.lineAt(targetLine).range;
+    editor.selection = new vscode.Selection(range.start, range.start);
+    editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+  }
+
+  async toggleItem(node: ItemNode): Promise<void> {
+    if (node.item.type !== 'task') { return; }
+    const document = await vscode.workspace.openTextDocument(node.uri);
+    const lineIdx = resolveToggleTargetLineIndex(
+      document.lineCount,
+      i => document.lineAt(i).text,
+      node.item.rawLine,
+      node.item.sourceLine
+    );
+    if (lineIdx === null) {
+      vscode.window.showInformationMessage(
+        'TaskMark: That task no longer matches the file (it may have been edited).'
+      );
+      return;
+    }
+    const line = document.lineAt(lineIdx);
+    const toggled = toggleCheckboxInLine(line.text);
+    if (toggled === null || toggled === line.text) { return; }
+    const edit = new vscode.WorkspaceEdit();
+    edit.replace(node.uri, line.range, toggled);
+    await vscode.workspace.applyEdit(edit);
+  }
+}


### PR DESCRIPTION
## 関連Issue
Closes #89

## 概要
アクティブな `.tmd` ファイルの状況を VS Code のアクティビティバーから常時俯瞰できるようにするため、専用アイコンと TreeView (Overview) を追加した。

## 変更内容
- 純粋ロジック `src/treeView.ts` で `TaskMarkData` を Today / This week / Overdue / Recently done の 4 カテゴリに分類 (週は月曜始まり、Recently done は最大 10 件)。期間付きアイテムやリピート展開後のオカレンスを正しく扱う。
- VS Code 統合 `src/treeViewProvider.ts` で `TreeDataProvider` を実装。項目クリックで該当行へカーソル移動 + 中央表示し、タスクにはチェック切替のインラインアクションを提供する。
- `extension.ts` でビュー登録、リフレッシュ / ジャンプ / トグルコマンド、アクティブエディタ・ドキュメント変更時の自動更新 (debounce) を配線。
- `package.json` に `viewsContainers.activitybar` と `views.taskmark`、関連コマンド・メニューを追加。アクティビティバー用 SVG アイコン (`media/activitybar-icon.svg`) を新規作成。
- README にサイドバーの説明を追記し、CHANGELOG に Unreleased エントリを追加。
- 分類ロジックの単体テスト `src/test/suite/treeView.test.ts` を追加 (10 ケース)。

## 動作確認・テスト
- [x] `npm run lint` がエラーなく通ること (既存の警告 1 件のみ)
- [x] `npm run test:unit` が 149 ケース (新規 10 ケースを含む) すべてパス
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能 (Calendar / Timeline / Quick Add) に影響がないことを確認した
- [x] 必要に応じてドキュメント (README, CHANGELOG) を更新した

## スクリーンショット / GIF (UI変更がある場合)
| Before | After |
| --- | --- |
| アクティビティバーに TaskMark なし | TaskMark アイコン → Overview ツリー (Today / This week / Overdue / Recently done) |

## 備考・次やること
- 将来拡張: ワークスペース内の複数 `.tmd` を横断集約するモード (Issue 化を想定)。
- ステータスバーに「次の予定」を出す案 (Issue で言及されていた代替案) は本 PR とは独立に追加可能。