### PR TITLE
feat: タスクに進捗率を記述可能にする ([N] 記法)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Added
 - Activity Bar TreeView ("TaskMark: Overview") that summarizes the active `.tmd` file by Today / This week / Overdue / Recently done. Clicking an item jumps to the corresponding line, and tasks expose an inline toggle action (#89).
+- Task progress rate with the `[N]` checkbox notation (0-100). `[0]` is equivalent to `[ ]` and `[100]` is equivalent to `[x]`. Gantt task bars are filled by the progress rate, group bars use the average across child tasks, and the TreeView appends a `(N%)` suffix for intermediate values (#90).
 
 ## [1.5.0] - 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,9 @@ Options can be combined using commas. If a limit is not explicitly defined, recu
 | `# YYYY-MM-DD` | Date header | — |
 | `# YYYY-MM-DD : YYYY-MM-DD` | Date range header (start : end) | — |
 | `- Text` | Schedule (Event) | — |
-| `- [ ] Text` | Uncompleted task | — |
-| `- [x] Text` | Completed task | — |
+| `- [ ] Text` | Uncompleted task (= `- [0] Text`) | — |
+| `- [x] Text` | Completed task (= `- [100] Text`) | — |
+| `- [N] Text` | Task with progress rate (`N` = 0-100) | — |
 | `HH:mm-HH:mm` | Time range (Start-End) | Schedules |
 | `HH:mm` | Start time only | Schedules |
 | `#Tag` | Tags (Multiple allowed) | Both |

--- a/media/main.js
+++ b/media/main.js
@@ -911,11 +911,12 @@
     const bar = createGanttBar(left, yOffset, width, bgColor);
     bar.classList.add('tm-gantt-group-bar');
 
-    // Progress fill
+    // Progress fill — uses the average task progress across children
+    // (each task's progress is 0-100, [N] notation per Issue #90).
     const pBar = document.createElement('div');
     pBar.className = 'tm-gantt-progress';
     if (entity.tasksTotal > 0) {
-      const progress = (entity.tasksDone / entity.tasksTotal) * 100;
+      const progress = entity.tasksProgressSum / entity.tasksTotal;
       pBar.style.width = progress + '%';
       if (progress > 0 && progress < 100) {
         pBar.style.borderRight = '2px solid var(--tm-card-border)';
@@ -959,7 +960,7 @@
       const pBar = document.createElement('div');
       pBar.className = 'tm-gantt-progress';
       if (child.isTask) {
-        pBar.style.width = child.isDone ? '100%' : '0%';
+        pBar.style.width = child.progress + '%';
       } else {
         pBar.style.width = '100%';
       }
@@ -1001,7 +1002,7 @@
       const pBar = document.createElement('div');
       pBar.className = 'tm-gantt-progress';
       if (child.isTask) {
-        pBar.style.width = child.isDone ? '100%' : '0%';
+        pBar.style.width = child.progress + '%';
       } else {
         pBar.style.width = '100%';
       }

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -10,6 +10,8 @@ export interface GanttChildItem {
   endMs: number;
   isTask: boolean;
   isDone: boolean;
+  /** Progress rate (0-100) for tasks. 100 for schedule items. */
+  progress: number;
   rawLine: number;
   sourceLine: string;
 }
@@ -24,6 +26,9 @@ export interface GanttEntity {
   tags: string[];
   tasksTotal: number;
   tasksDone: number;
+  /** Sum of progress (0-100) across all task children. Average is
+   *  tasksProgressSum / tasksTotal; falls back to full bar when no tasks. */
+  tasksProgressSum: number;
   children: GanttChildItem[];
 }
 
@@ -99,12 +104,15 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
             : [...item.tags],
           tasksTotal: 0,
           tasksDone: 0,
+          tasksProgressSum: 0,
           children: []
         };
       } else {
         if (startMs < bucket[key].minTime) { bucket[key].minTime = startMs; }
         if (endMs > bucket[key].maxTime) { bucket[key].maxTime = endMs; }
       }
+
+      const childProgress = item.type === 'task' ? (item.progress ?? 0) : 100;
 
       bucket[key].children.push({
         text: item.text,
@@ -113,6 +121,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
         endMs,
         isTask: item.type === 'task',
         isDone: item.status === 'done',
+        progress: childProgress,
         rawLine: item.rawLine,
         sourceLine: item.sourceLine
       });
@@ -122,6 +131,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
         if (item.status === 'done') {
           bucket[key].tasksDone++;
         }
+        bucket[key].tasksProgressSum += childProgress;
       }
     });
   });

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -36,11 +36,13 @@ export interface ToggleTaskMessage {
 }
 
 // Leading line prefix matches parser ITEM_REGEX (TASK_LINE_PREFIX_NC + \s*).
-// Bracket interior mirrors ITEM: \[\s*([xX\s])\s*\] — one mark character
-// with flexible inner whitespace. Only that mark is swapped ('x' todo→done,
-// ASCII space done→todo) so surrounding spaces inside the brackets are kept.
+// Bracket interior mirrors ITEM: \[\s*([xX]|\d{1,3}|\s)\s*\] — one mark token
+// (x/X, a 1-3 digit progress number, or a single whitespace) with flexible
+// inner whitespace around it. Toggle treats `[ ]` and `[0]` as todo, `[x]`
+// and `[100]` as done; intermediate `[N]` is treated as todo (becomes `[x]`
+// on click) per Issue #90.
 const CHECKBOX_LINE_REGEX = new RegExp(
-  `^(${TASK_LINE_PREFIX_NC}\\s*)(\\[)(\\s*)([xX\\s])(\\s*)(\\])`
+  `^(${TASK_LINE_PREFIX_NC}\\s*)(\\[)(\\s*)([xX]|\\d{1,3}|\\s)(\\s*)(\\])`
 );
 
 export function toggleCheckboxInLine(line: string): string | null {
@@ -49,7 +51,8 @@ export function toggleCheckboxInLine(line: string): string | null {
     return null;
   }
   const mark = match[4];
-  const isDone = mark.trim().toLowerCase() === 'x';
+  const trimmed = mark.trim();
+  const isDone = trimmed.toLowerCase() === 'x' || trimmed === '100';
   const newMark = isDone ? ' ' : 'x';
   return (
     match[1] +

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -26,6 +26,9 @@ export interface MarkItem {
   time?: string;
   tags: string[];
   status?: TaskStatus;
+  /** Progress rate in 0-100 for task items. Undefined for schedule items.
+   *  `[ ]` is 0, `[x]` is 100, `[N]` carries the explicit value. */
+  progress?: number;
   repeat?: string;
   group?: string;
   rawLine: number;
@@ -45,7 +48,7 @@ const TASK_LINE_PREFIX_SRC = '(>\\s*)?(-)?';
  *  toggleCheckboxInLine. Keep the two regex shapes in sync. */
 export const TASK_LINE_PREFIX_NC = '(?:>\\s*)?(?:-)?';
 const ITEM_REGEX = new RegExp(
-  `^${TASK_LINE_PREFIX_SRC}\\s*(\\[\\s*([xX\\s])\\s*\\])?\\s*((\\d{1,2}:\\d{1,2})(?:-(\\d{1,2}:\\d{1,2}))?)?\\s*(.*)$`
+  `^${TASK_LINE_PREFIX_SRC}\\s*(\\[\\s*([xX]|\\d{1,3}|\\s)\\s*\\])?\\s*((\\d{1,2}:\\d{1,2})(?:-(\\d{1,2}:\\d{1,2}))?)?\\s*(.*)$`
 );
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
 const TAG_SPLIT_REGEX = /#([^\s#]+)/g;
@@ -314,9 +317,28 @@ function createMarkItem(
   let content = itemMatch[8] || '';
 
   const type: ItemType = hasCheckbox ? 'task' : 'schedule';
-  const status: TaskStatus | undefined = hasCheckbox
-    ? (checkMark.trim().toLowerCase() === 'x' ? 'done' : 'todo')
-    : undefined;
+  let status: TaskStatus | undefined;
+  let progress: number | undefined;
+  if (hasCheckbox) {
+    const trimmed = checkMark.trim();
+    if (trimmed === '') {
+      progress = 0;
+      status = 'todo';
+    } else if (trimmed.toLowerCase() === 'x') {
+      progress = 100;
+      status = 'done';
+    } else {
+      const n = parseInt(trimmed, 10);
+      if (n > 100) {
+        warnings.push(`Line ${lineIndex + 1}: invalid progress '${trimmed}' (must be 0-100), fallback to 0`);
+        progress = 0;
+        status = 'todo';
+      } else {
+        progress = n;
+        status = n === 100 ? 'done' : 'todo';
+      }
+    }
+  }
 
   // Extract repeat
   let repeatStr: string | undefined;
@@ -337,6 +359,7 @@ function createMarkItem(
     time: timeString,
     tags,
     status,
+    progress,
     repeat: repeatStr,
     group: newGroup || undefined,
     rawLine: lineIndex,

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -167,6 +167,20 @@ suite('toggleCheckboxInLine', () => {
   test('returns null when non-bullet text precedes the checkbox', () => {
     assert.strictEqual(toggleCheckboxInLine('foo - [ ] bar'), null);
   });
+
+  test('flips intermediate [N] task to [x] (treats N as not yet done)', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [30] foo'), '- [x] foo');
+    assert.strictEqual(toggleCheckboxInLine('- [60] foo'), '- [x] foo');
+    assert.strictEqual(toggleCheckboxInLine('- [99] foo'), '- [x] foo');
+  });
+
+  test('treats [0] as todo and flips to [x]', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [0] foo'), '- [x] foo');
+  });
+
+  test('treats [100] as done and flips to [ ]', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [100] foo'), '- [ ] foo');
+  });
 });
 
 suite('resolveFontSize', () => {

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -350,6 +350,32 @@ suite('Gantt Test Suite', () => {
     assert.strictEqual(group.children[1].sourceLine, '> - [x] Task B');
   });
 
+  test('group entity tasksProgressSum reflects intermediate [N] progress values', () => {
+    const { data } = parseTmd(`# 2026-03-01
+> Sprint
+> - [30] Task A
+> - [50] Task B
+> - [x] Task C
+`);
+    const { entities } = buildGanttEntities(data);
+    const group = entities[0];
+    assert.strictEqual(group.tasksTotal, 3);
+    assert.strictEqual(group.tasksProgressSum, 30 + 50 + 100);
+    // Average = 60
+  });
+
+  test('standalone task child exposes progress 0-100', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [40] Task\n`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities[0].children[0].progress, 40);
+  });
+
+  test('schedule child progress is 100 (rendered as a full bar)', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- Plain schedule\n`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities[0].children[0].progress, 100);
+  });
+
   test('schedule children also carry rawLine and sourceLine from source item', () => {
     const { data } = parseTmd(`# 2026-03-01
 - 9:00-10:00 Meeting

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -636,6 +636,75 @@ not a valid tag line
     assert.strictEqual(data.days['2026-04-23'].items.length, 0, 'Indented items are not included');
   });
 
+  // ─── Progress Rate ([N] notation) Tests ──────────────────────
+
+  test('parseTmd [ ] task has progress=0 and status=todo', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [ ] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.status, 'todo');
+    assert.strictEqual(item.progress, 0);
+  });
+
+  test('parseTmd [x] task has progress=100 and status=done', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [x] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.status, 'done');
+    assert.strictEqual(item.progress, 100);
+  });
+
+  test('parseTmd [N] task carries the explicit progress value', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [30] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.progress, 30);
+    assert.strictEqual(item.status, 'todo', 'Intermediate values are not "done"');
+  });
+
+  test('parseTmd [0] is treated as todo with progress=0 (synonym of [ ])', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [0] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.status, 'todo');
+    assert.strictEqual(item.progress, 0);
+  });
+
+  test('parseTmd [100] is treated as done (synonym of [x])', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [100] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.status, 'done');
+    assert.strictEqual(item.progress, 100);
+  });
+
+  test('parseTmd [N] out of range warns and falls back to 0', () => {
+    const { data, warnings } = parseTmd(`# 2026-03-01\n- [150] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.progress, 0);
+    assert.strictEqual(item.status, 'todo');
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /invalid progress '150'/);
+  });
+
+  test('parseTmd schedule items have no progress field', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- Plain schedule\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.progress, undefined);
+    assert.strictEqual(item.status, undefined);
+  });
+
+  test('parseTmd [N] with inner whitespace is accepted', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [ 60 ] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.progress, 60);
+    assert.strictEqual(item.status, 'todo');
+  });
+
+  test('parseTmd [N] preserves time and content parsing', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [45] 09:00-10:00 Meeting #work\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.progress, 45);
+    assert.strictEqual(item.time, '09:00-10:00');
+    assert.strictEqual(item.text, 'Meeting');
+    assert.deepStrictEqual(item.tags, ['work']);
+  });
+
   test('parseTmd range item has startDate matching the range start date', () => {
     const text = `
 # 2026-03-01 : 2026-03-10

--- a/src/test/suite/treeView.test.ts
+++ b/src/test/suite/treeView.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { parseTmd } from '../../parser';
-import { categorizeForTreeView, RECENTLY_DONE_LIMIT } from '../../treeView';
+import { categorizeForTreeView, formatItemLabel, RECENTLY_DONE_LIMIT } from '../../treeView';
 
 function getCategorized(text: string, today: string) {
   const { data } = parseTmd(text);
@@ -171,5 +171,33 @@ suite('categorizeForTreeView', () => {
     assert.deepStrictEqual(result.thisWeek, []);
     assert.deepStrictEqual(result.overdue, []);
     assert.deepStrictEqual(result.recentlyDone, []);
+  });
+});
+
+suite('formatItemLabel', () => {
+  function firstItem(text: string) {
+    const { data } = parseTmd(text);
+    const dateKey = Object.keys(data.days)[0];
+    return data.days[dateKey].items[0];
+  }
+
+  test('appends (N%) suffix for an intermediate-progress task', () => {
+    const item = firstItem(`# 2026-05-02\n- [60] Implement\n`);
+    assert.strictEqual(formatItemLabel(item), '[ ] Implement (60%)');
+  });
+
+  test('does not append a suffix for [ ] (0%)', () => {
+    const item = firstItem(`# 2026-05-02\n- [ ] Implement\n`);
+    assert.strictEqual(formatItemLabel(item), '[ ] Implement');
+  });
+
+  test('does not append a suffix for [x] (100%)', () => {
+    const item = firstItem(`# 2026-05-02\n- [x] Implement\n`);
+    assert.strictEqual(formatItemLabel(item), '[x] Implement');
+  });
+
+  test('keeps time prefix together with the (N%) suffix', () => {
+    const item = firstItem(`# 2026-05-02\n- [45] 09:00 Standup\n`);
+    assert.strictEqual(formatItemLabel(item), '[ ] 09:00 Standup (45%)');
   });
 });

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -125,5 +125,9 @@ export function categoryLabel(id: CategoryId, todayStr: string): string {
 export function formatItemLabel(item: MarkItem): string {
   const checkbox = item.type === 'task' ? (item.status === 'done' ? '[x] ' : '[ ] ') : '';
   const time = item.time ? `${item.time} ` : '';
-  return `${checkbox}${time}${item.text}`.trim();
+  const progress =
+    item.type === 'task' && item.progress !== undefined && item.progress > 0 && item.progress < 100
+      ? ` (${item.progress}%)`
+      : '';
+  return `${checkbox}${time}${item.text}${progress}`.trim();
 }


### PR DESCRIPTION
## 関連Issue
Closes #90

## 概要
タスクの状態を `[ ]` / `[x]` の二値だけでなく、`[N]` (0-100 の整数) で進捗率として記述できるようにする。`[0]` は `[ ]` と、`[100]` は `[x]` と等価。Gantt の塗りつぶし率とサイドバーの (N%) 表記に反映される。

## 変更内容
- パーサが `[N]` (0-100) を進捗率として読み取り、`MarkItem.progress` に格納する。範囲外 (例: `[150]`) は警告を出して 0% にフォールバック
- トグル動作を維持: `[ ]` / `[0]` / `[N]` (中間) → `[x]`、`[x]` / `[100]` → `[ ]`
- Gantt のタスクバー塗り潰しを進捗率で描画。グループバーは子タスク進捗の平均で計算する
- TreeView のラベルは中間値 (`0 < N < 100`) のとき `[ ] 実装 (60%)` のように `(N%)` を末尾に併記する
- README の Syntax Reference と CHANGELOG に追記
- パーサ / トグル / Gantt / TreeView それぞれにテストを追加

## 動作確認・テスト
- [x] `npm run lint` がパスする (既存の 1 warning のみ、本 PR では変更なし)
- [x] `npm run test:unit` が 170 件すべてパス
- [x] 既存の `[ ]` / `[x]` の挙動に変化がないことをテストで確認

## 備考・次やること
- `tasksDone` / `tasksTotal` は後方互換のため残してあるが、Gantt 表示計算では `tasksProgressSum` の平均を使用している。今後使い道がなくなれば整理候補