### PR TITLE
feat: タスクを期間指定で複製するコマンドを追加 (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 - Activity Bar TreeView ("TaskMark: Overview") that summarizes the active `.tmd` file by Today / This week / Overdue / Recently done. Clicking an item jumps to the corresponding line, and tasks expose an inline toggle action (#89).
 - Task progress rate with the `[N]` checkbox notation (0-100). `[0]` is equivalent to `[ ]` and `[100]` is equivalent to `[x]`. Gantt task bars are filled by the progress rate, group bars use the average across child tasks, and the TreeView appends a `(N%)` suffix for intermediate values (#90).
+- `TaskMark: Duplicate Task` command (Command Palette / editor context menu) that copies the task on the current line into multiple date sections based on a repeat pattern (`daily` / `weekly` / `monthly` / `every:N{days|weeks|months}`) and an end condition (`count:N` or `until:YYYY-MM-DD`). Missing date sections are created automatically (#91).
 
 ## [1.5.0] - 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -230,8 +230,11 @@ Reduce the typing cost of writing `.tmd` files with quick-add commands, snippets
 
 - **`TaskMark: Add Task`** — Prompts for the task body and target date, then inserts `- [ ] <body>` into the matching date section. The section is created at the end of the file if it does not exist.
 - **`TaskMark: Add Schedule`** — Prompts for the body, start time, optional end time, and target date, then inserts `- HH:mm[-HH:mm] <body>` into the matching date section.
+- **`TaskMark: Duplicate Task`** — With the cursor on a task line, prompts for a repeat pattern (`daily` / `weekly` / `monthly` / `every:Ndays|Nweeks|Nmonths`) and an end condition (`count:N` or `until:YYYY-MM-DD`), then inserts copies of the task into the matching date sections. Missing date sections are created at the end of the file. Also available from the editor context menu on a `.tmd` file.
 
 The date prompt offers `Today` / `Tomorrow` / a custom `YYYY-MM-DD`.
+
+> **Note:** Unlike `@repeat`, which expands schedules in-place at parse time, `Duplicate Task` inserts independent `- [ ]` lines into the file. Each copy keeps its own completion state, so it works for recurring tasks (e.g. weekly reports).
 
 **Snippets** — Type the prefix and press `Tab` while editing a `.tmd` file:
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
         "title": "TaskMark: Add Schedule"
       },
       {
+        "command": "taskmark.duplicateTask",
+        "title": "TaskMark: Duplicate Task"
+      },
+      {
         "command": "taskmark.tree.refresh",
         "title": "TaskMark: Refresh Overview",
         "icon": "$(refresh)"
@@ -75,6 +79,13 @@
           "command": "taskmark.openView",
           "when": "editorLangId == tmd",
           "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "taskmark.duplicateTask",
+          "when": "editorLangId == tmd",
+          "group": "taskmark@1"
         }
       ],
       "view/title": [

--- a/src/duplicateTask.ts
+++ b/src/duplicateTask.ts
@@ -1,0 +1,152 @@
+// Pure helpers backing the TaskMark: Duplicate Task command.
+// Kept free of vscode imports so the logic can be unit-tested without
+// the VS Code test runner.
+
+import { insertItemForDate, isValidDate, formatLocalDate } from './quickAdd';
+
+export interface DuplicatePattern {
+  mode: 'days' | 'months';
+  interval: number;
+}
+
+export interface DuplicateEndCondition {
+  kind: 'count' | 'until';
+  count?: number;
+  until?: string;
+}
+
+export const MAX_DUPLICATE_OCCURRENCES = 3650;
+
+const EVERY_REGEX = /^([1-9]\d*)(days?|weeks?|months?)$/;
+const DATE_HEADER_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})/;
+
+export function parseDuplicatePattern(input: string): DuplicatePattern | null {
+  const s = input.trim();
+  if (s === 'daily') {
+    return { mode: 'days', interval: 1 };
+  }
+  if (s === 'weekly') {
+    return { mode: 'days', interval: 7 };
+  }
+  if (s === 'monthly') {
+    return { mode: 'months', interval: 1 };
+  }
+  if (s.startsWith('every:')) {
+    const m = s.substring(6).match(EVERY_REGEX);
+    if (!m) {
+      return null;
+    }
+    const num = parseInt(m[1], 10);
+    const unit = m[2].replace(/s$/, '');
+    if (unit === 'day') {
+      return { mode: 'days', interval: num };
+    }
+    if (unit === 'week') {
+      return { mode: 'days', interval: num * 7 };
+    }
+    if (unit === 'month') {
+      return { mode: 'months', interval: num };
+    }
+  }
+  return null;
+}
+
+export function parseDuplicateEndCondition(input: string): DuplicateEndCondition | null {
+  const s = input.trim();
+  if (s.startsWith('count:')) {
+    const raw = s.substring(6).trim();
+    if (!/^\d+$/.test(raw)) {
+      return null;
+    }
+    const n = parseInt(raw, 10);
+    if (!Number.isFinite(n) || n < 1) {
+      return null;
+    }
+    return { kind: 'count', count: Math.min(n, MAX_DUPLICATE_OCCURRENCES) };
+  }
+  if (s.startsWith('until:')) {
+    const d = s.substring(6).trim();
+    if (!isValidDate(d)) {
+      return null;
+    }
+    return { kind: 'until', until: d };
+  }
+  return null;
+}
+
+export function generateDuplicateDates(
+  sourceDate: string,
+  pattern: DuplicatePattern,
+  end: DuplicateEndCondition
+): string[] {
+  if (!isValidDate(sourceDate)) {
+    return [];
+  }
+  const origin = toLocalDate(sourceDate);
+  const dates: string[] = [];
+  const maxIterations = end.kind === 'count'
+    ? Math.min(end.count ?? 0, MAX_DUPLICATE_OCCURRENCES)
+    : MAX_DUPLICATE_OCCURRENCES;
+  const untilDate = end.kind === 'until' && end.until ? toLocalDate(end.until) : undefined;
+
+  for (let i = 1; i < maxIterations; i++) {
+    const next = new Date(origin.getFullYear(), origin.getMonth(), origin.getDate());
+    if (pattern.mode === 'months') {
+      const targetMonth = origin.getMonth() + pattern.interval * i;
+      next.setMonth(targetMonth);
+      const expectedMonth = ((targetMonth % 12) + 12) % 12;
+      if (next.getMonth() !== expectedMonth) {
+        next.setDate(0);
+      }
+    } else {
+      next.setDate(origin.getDate() + pattern.interval * i);
+    }
+    if (untilDate && next > untilDate) {
+      break;
+    }
+    dates.push(formatLocalDate(next));
+  }
+  return dates;
+}
+
+export interface DuplicateResult {
+  newText: string;
+  insertedDates: string[];
+}
+
+export function duplicateTaskAcrossDates(
+  documentText: string,
+  sourceDate: string,
+  taskLine: string,
+  pattern: DuplicatePattern,
+  end: DuplicateEndCondition,
+  eol: string = '\n'
+): DuplicateResult {
+  const dates = generateDuplicateDates(sourceDate, pattern, end);
+  let text = documentText;
+  for (const date of dates) {
+    text = insertItemForDate(text, date, taskLine, eol).newText;
+  }
+  return { newText: text, insertedDates: dates };
+}
+
+export function findSourceDateForLine(documentText: string, lineIndex: number): string | null {
+  const lines = documentText === '' ? [] : documentText.split(/\r?\n/);
+  for (let i = Math.min(lineIndex, lines.length - 1); i >= 0; i--) {
+    const m = lines[i].match(DATE_HEADER_REGEX);
+    if (m) {
+      return normalizeDate(m[1]);
+    }
+  }
+  return null;
+}
+
+function normalizeDate(raw: string): string {
+  const [y, m, d] = raw.split('-');
+  return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
+}
+
+function toLocalDate(s: string): Date {
+  const [y, m, d] = s.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}

--- a/src/duplicateTaskCommand.ts
+++ b/src/duplicateTaskCommand.ts
@@ -1,0 +1,145 @@
+import * as vscode from 'vscode';
+import {
+  DuplicateEndCondition,
+  DuplicatePattern,
+  duplicateTaskAcrossDates,
+  findSourceDateForLine,
+  parseDuplicateEndCondition,
+  parseDuplicatePattern,
+} from './duplicateTask';
+import { isValidDate } from './quickAdd';
+
+const TMD_LANGUAGE_ID = 'tmd';
+const TASK_LINE_REGEX = /^\s*(?:>\s*)?-\s*\[/;
+const EVERY_INPUT_REGEX = /^[1-9]\d*(?:days?|weeks?|months?)$/;
+
+export function registerDuplicateTaskCommand(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('taskmark.duplicateTask', () => runDuplicateTask()),
+  );
+}
+
+async function runDuplicateTask(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.languageId !== TMD_LANGUAGE_ID) {
+    vscode.window.showErrorMessage('TaskMark: Open a .tmd file before running Duplicate Task.');
+    return;
+  }
+
+  const document = editor.document;
+  const lineIndex = editor.selection.active.line;
+  const lineText = document.lineAt(lineIndex).text;
+  if (!TASK_LINE_REGEX.test(lineText)) {
+    vscode.window.showErrorMessage('TaskMark: Place the cursor on a task line (- [ ] ...) first.');
+    return;
+  }
+
+  const fullText = document.getText();
+  const sourceDate = findSourceDateForLine(fullText, lineIndex);
+  if (!sourceDate) {
+    vscode.window.showErrorMessage('TaskMark: No date header found above the current task.');
+    return;
+  }
+
+  const pattern = await pickPattern();
+  if (!pattern) {
+    return;
+  }
+
+  const endCondition = await pickEndCondition();
+  if (!endCondition) {
+    return;
+  }
+
+  const eol = document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n';
+  const { newText, insertedDates } = duplicateTaskAcrossDates(
+    fullText,
+    sourceDate,
+    lineText,
+    pattern,
+    endCondition,
+    eol,
+  );
+
+  if (insertedDates.length === 0) {
+    vscode.window.showInformationMessage('TaskMark: No dates matched — nothing to duplicate.');
+    return;
+  }
+
+  const fullRange = new vscode.Range(
+    document.positionAt(0),
+    document.positionAt(fullText.length),
+  );
+  const ok = await editor.edit(eb => eb.replace(fullRange, newText));
+  if (!ok) {
+    vscode.window.showErrorMessage('TaskMark: Failed to duplicate task.');
+    return;
+  }
+
+  vscode.window.showInformationMessage(
+    `TaskMark: Duplicated task into ${insertedDates.length} date${insertedDates.length === 1 ? '' : 's'}.`,
+  );
+}
+
+async function pickPattern(): Promise<DuplicatePattern | undefined> {
+  const choice = await vscode.window.showQuickPick(
+    [
+      { label: 'Daily', detail: 'Every day', value: 'daily' },
+      { label: 'Weekly', detail: 'Every week', value: 'weekly' },
+      { label: 'Monthly', detail: 'Every month', value: 'monthly' },
+      { label: 'Every N days/weeks/months…', detail: 'Enter a custom interval', value: '__custom__' },
+    ],
+    { placeHolder: 'Repeat pattern' },
+  );
+  if (!choice) {
+    return undefined;
+  }
+  if (choice.value !== '__custom__') {
+    return parseDuplicatePattern(choice.value) ?? undefined;
+  }
+  const raw = await vscode.window.showInputBox({
+    prompt: 'Custom interval',
+    placeHolder: 'e.g. 3days, 2weeks, 3months',
+    ignoreFocusOut: true,
+    validateInput: v => (EVERY_INPUT_REGEX.test(v.trim()) ? null : 'Enter <N><unit> where unit is days/weeks/months'),
+  });
+  if (raw === undefined) {
+    return undefined;
+  }
+  return parseDuplicatePattern(`every:${raw.trim()}`) ?? undefined;
+}
+
+async function pickEndCondition(): Promise<DuplicateEndCondition | undefined> {
+  const choice = await vscode.window.showQuickPick(
+    [
+      { label: 'Count', detail: 'Number of occurrences (including the source)', value: 'count' },
+      { label: 'Until', detail: 'End date (YYYY-MM-DD)', value: 'until' },
+    ],
+    { placeHolder: 'End condition' },
+  );
+  if (!choice) {
+    return undefined;
+  }
+  if (choice.value === 'count') {
+    const raw = await vscode.window.showInputBox({
+      prompt: 'Occurrence count (including the source)',
+      placeHolder: '4',
+      ignoreFocusOut: true,
+      validateInput: v => (/^[1-9]\d*$/.test(v.trim()) ? null : 'Enter a positive integer'),
+    });
+    if (raw === undefined) {
+      return undefined;
+    }
+    return parseDuplicateEndCondition(`count:${raw.trim()}`) ?? undefined;
+  }
+  const raw = await vscode.window.showInputBox({
+    prompt: 'End date (YYYY-MM-DD)',
+    placeHolder: '2026-12-31',
+    ignoreFocusOut: true,
+    validateInput: v => (isValidDate(v.trim()) ? null : 'Enter a date as YYYY-MM-DD'),
+  });
+  if (raw === undefined) {
+    return undefined;
+  }
+  return parseDuplicateEndCondition(`until:${raw.trim()}`) ?? undefined;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { TaskmarkPanel } from './TaskmarkPanel';
 import { registerQuickAddCommands } from './quickAddCommands';
+import { registerDuplicateTaskCommand } from './duplicateTaskCommand';
 import { registerCompletionProviders } from './completionProvider';
 import { TaskmarkTreeDataProvider } from './treeViewProvider';
 import { debounce } from './utils/debounce';
@@ -13,6 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   registerQuickAddCommands(context);
+  registerDuplicateTaskCommand(context);
   registerCompletionProviders(context);
   registerTreeView(context);
 

--- a/src/test/suite/duplicateTask.test.ts
+++ b/src/test/suite/duplicateTask.test.ts
@@ -1,0 +1,260 @@
+import * as assert from 'assert';
+import {
+  parseDuplicatePattern,
+  parseDuplicateEndCondition,
+  generateDuplicateDates,
+  duplicateTaskAcrossDates,
+  findSourceDateForLine,
+} from '../../duplicateTask';
+
+suite('Duplicate Task Test Suite', () => {
+  suite('parseDuplicatePattern', () => {
+    test('parses preset keywords', () => {
+      assert.deepStrictEqual(parseDuplicatePattern('daily'), { mode: 'days', interval: 1 });
+      assert.deepStrictEqual(parseDuplicatePattern('weekly'), { mode: 'days', interval: 7 });
+      assert.deepStrictEqual(parseDuplicatePattern('monthly'), { mode: 'months', interval: 1 });
+    });
+
+    test('parses every:Ndays / Nweeks / Nmonths', () => {
+      assert.deepStrictEqual(parseDuplicatePattern('every:3days'), { mode: 'days', interval: 3 });
+      assert.deepStrictEqual(parseDuplicatePattern('every:2weeks'), { mode: 'days', interval: 14 });
+      assert.deepStrictEqual(parseDuplicatePattern('every:3months'), { mode: 'months', interval: 3 });
+    });
+
+    test('trims surrounding whitespace', () => {
+      assert.deepStrictEqual(parseDuplicatePattern('  weekly  '), { mode: 'days', interval: 7 });
+    });
+
+    test('rejects invalid input', () => {
+      assert.strictEqual(parseDuplicatePattern(''), null);
+      assert.strictEqual(parseDuplicatePattern('yearly'), null);
+      assert.strictEqual(parseDuplicatePattern('every:0days'), null);
+      assert.strictEqual(parseDuplicatePattern('every:-1days'), null);
+      assert.strictEqual(parseDuplicatePattern('every:days'), null);
+      assert.strictEqual(parseDuplicatePattern('every:3'), null);
+    });
+  });
+
+  suite('parseDuplicateEndCondition', () => {
+    test('parses count:N', () => {
+      assert.deepStrictEqual(parseDuplicateEndCondition('count:5'), { kind: 'count', count: 5 });
+      assert.deepStrictEqual(parseDuplicateEndCondition('count:1'), { kind: 'count', count: 1 });
+    });
+
+    test('parses until:YYYY-MM-DD', () => {
+      assert.deepStrictEqual(
+        parseDuplicateEndCondition('until:2026-12-31'),
+        { kind: 'until', until: '2026-12-31' }
+      );
+    });
+
+    test('rejects invalid input', () => {
+      assert.strictEqual(parseDuplicateEndCondition(''), null);
+      assert.strictEqual(parseDuplicateEndCondition('count:0'), null);
+      assert.strictEqual(parseDuplicateEndCondition('count:-1'), null);
+      assert.strictEqual(parseDuplicateEndCondition('count:abc'), null);
+      assert.strictEqual(parseDuplicateEndCondition('until:2026-13-01'), null);
+      assert.strictEqual(parseDuplicateEndCondition('until:not-a-date'), null);
+      assert.strictEqual(parseDuplicateEndCondition('forever'), null);
+    });
+
+    test('caps count at maximum occurrences', () => {
+      const r = parseDuplicateEndCondition('count:99999');
+      assert.ok(r);
+      assert.strictEqual(r!.kind, 'count');
+      assert.strictEqual(r!.count, 3650);
+    });
+  });
+
+  suite('generateDuplicateDates', () => {
+    test('daily count:4 yields three additional dates', () => {
+      const dates = generateDuplicateDates(
+        '2026-04-27',
+        { mode: 'days', interval: 1 },
+        { kind: 'count', count: 4 }
+      );
+      assert.deepStrictEqual(dates, ['2026-04-28', '2026-04-29', '2026-04-30']);
+    });
+
+    test('weekly count:4 follows the issue example', () => {
+      const dates = generateDuplicateDates(
+        '2026-04-27',
+        { mode: 'days', interval: 7 },
+        { kind: 'count', count: 4 }
+      );
+      assert.deepStrictEqual(dates, ['2026-05-04', '2026-05-11', '2026-05-18']);
+    });
+
+    test('monthly clamps to last day for short months', () => {
+      const dates = generateDuplicateDates(
+        '2026-01-31',
+        { mode: 'months', interval: 1 },
+        { kind: 'count', count: 3 }
+      );
+      assert.deepStrictEqual(dates, ['2026-02-28', '2026-03-31']);
+    });
+
+    test('every:2days with count', () => {
+      const dates = generateDuplicateDates(
+        '2026-04-27',
+        { mode: 'days', interval: 2 },
+        { kind: 'count', count: 3 }
+      );
+      assert.deepStrictEqual(dates, ['2026-04-29', '2026-05-01']);
+    });
+
+    test('until stops at the given date inclusive', () => {
+      const dates = generateDuplicateDates(
+        '2026-04-27',
+        { mode: 'days', interval: 7 },
+        { kind: 'until', until: '2026-05-18' }
+      );
+      assert.deepStrictEqual(dates, ['2026-05-04', '2026-05-11', '2026-05-18']);
+    });
+
+    test('until on or before source date yields empty', () => {
+      assert.deepStrictEqual(
+        generateDuplicateDates(
+          '2026-04-27',
+          { mode: 'days', interval: 7 },
+          { kind: 'until', until: '2026-04-27' }
+        ),
+        []
+      );
+      assert.deepStrictEqual(
+        generateDuplicateDates(
+          '2026-04-27',
+          { mode: 'days', interval: 7 },
+          { kind: 'until', until: '2026-05-03' }
+        ),
+        []
+      );
+    });
+
+    test('count:1 yields no additional dates', () => {
+      assert.deepStrictEqual(
+        generateDuplicateDates(
+          '2026-04-27',
+          { mode: 'days', interval: 7 },
+          { kind: 'count', count: 1 }
+        ),
+        []
+      );
+    });
+  });
+
+  suite('duplicateTaskAcrossDates', () => {
+    test('inserts copies into new sections following the issue example', () => {
+      const text = ['# 2026-04-27', '- [ ] Weekly Report'].join('\n');
+      const { newText, insertedDates } = duplicateTaskAcrossDates(
+        text,
+        '2026-04-27',
+        '- [ ] Weekly Report',
+        { mode: 'days', interval: 7 },
+        { kind: 'count', count: 4 }
+      );
+
+      assert.deepStrictEqual(insertedDates, ['2026-05-04', '2026-05-11', '2026-05-18']);
+      assert.strictEqual(
+        newText,
+        [
+          '# 2026-04-27',
+          '- [ ] Weekly Report',
+          '',
+          '# 2026-05-04',
+          '- [ ] Weekly Report',
+          '',
+          '# 2026-05-11',
+          '- [ ] Weekly Report',
+          '',
+          '# 2026-05-18',
+          '- [ ] Weekly Report',
+        ].join('\n')
+      );
+    });
+
+    test('appends to an existing target section instead of creating a new one', () => {
+      const text = [
+        '# 2026-04-27',
+        '- [ ] Weekly Report',
+        '',
+        '# 2026-05-04',
+        '- 10:00 Other',
+      ].join('\n');
+      const { newText } = duplicateTaskAcrossDates(
+        text,
+        '2026-04-27',
+        '- [ ] Weekly Report',
+        { mode: 'days', interval: 7 },
+        { kind: 'count', count: 2 }
+      );
+
+      assert.strictEqual(
+        newText,
+        [
+          '# 2026-04-27',
+          '- [ ] Weekly Report',
+          '',
+          '# 2026-05-04',
+          '- 10:00 Other',
+          '- [ ] Weekly Report',
+        ].join('\n')
+      );
+    });
+
+    test('preserves CRLF line endings', () => {
+      const text = ['# 2026-04-27', '- [ ] Weekly Report'].join('\r\n');
+      const { newText } = duplicateTaskAcrossDates(
+        text,
+        '2026-04-27',
+        '- [ ] Weekly Report',
+        { mode: 'days', interval: 7 },
+        { kind: 'count', count: 2 },
+        '\r\n'
+      );
+
+      assert.ok(!/(?<!\r)\n/.test(newText), 'should not contain bare \\n');
+      assert.ok(newText.includes('\r\n# 2026-05-04\r\n- [ ] Weekly Report'));
+    });
+
+    test('returns the original text unchanged when count:1', () => {
+      const text = ['# 2026-04-27', '- [ ] Weekly Report'].join('\n');
+      const { newText, insertedDates } = duplicateTaskAcrossDates(
+        text,
+        '2026-04-27',
+        '- [ ] Weekly Report',
+        { mode: 'days', interval: 7 },
+        { kind: 'count', count: 1 }
+      );
+      assert.strictEqual(newText, text);
+      assert.deepStrictEqual(insertedDates, []);
+    });
+  });
+
+  suite('findSourceDateForLine', () => {
+    test('finds the nearest preceding date header', () => {
+      const text = [
+        '# 2026-04-27',
+        '- [ ] A',
+        '- [ ] B',
+        '',
+        '# 2026-05-04',
+        '- [ ] C',
+      ].join('\n');
+      assert.strictEqual(findSourceDateForLine(text, 1), '2026-04-27');
+      assert.strictEqual(findSourceDateForLine(text, 2), '2026-04-27');
+      assert.strictEqual(findSourceDateForLine(text, 5), '2026-05-04');
+    });
+
+    test('normalizes single-digit month/day', () => {
+      const text = ['# 2026-3-5', '- [ ] A'].join('\n');
+      assert.strictEqual(findSourceDateForLine(text, 1), '2026-03-05');
+    });
+
+    test('returns null when no date header precedes the line', () => {
+      const text = ['- [ ] A', '- [ ] B'].join('\n');
+      assert.strictEqual(findSourceDateForLine(text, 0), null);
+      assert.strictEqual(findSourceDateForLine(text, 1), null);
+    });
+  });
+});


### PR DESCRIPTION
## 関連Issue
Closes #91

## 概要
定例タスク (毎週月曜の週次報告など) を素早く登録できるよう、カーソル行のタスクを指定した繰り返しパターンと終了条件に従って複数の日付セクションへ複製する `TaskMark: Duplicate Task` コマンドを追加します。
`@repeat(...)` の構文拡張ではなく、独立した `- [ ]` 行をファイルに挿入するアプローチを採用しているため、各複製先のタスクは完了状態を独立して持ち、既存のクリックトグル等の機能をそのまま利用できます。

## 変更内容
- `src/duplicateTask.ts`: パターン/終了条件のパース、日付生成、複製挿入の純粋ロジックを追加 (vscode 非依存)
- `src/duplicateTaskCommand.ts`: QuickPick/InputBox による入力フローとコマンド登録を追加
- `package.json`: `taskmark.duplicateTask` コマンドと `.tmd` エディタ右クリックメニュー (`editor/context`) を追加
- `src/test/suite/duplicateTask.test.ts`: 上記ロジックの単体テストを追加 (TDD)
- README / CHANGELOG: 新コマンドの説明を追記

## 動作確認・テスト
- [x] 拡張機能をデバッグ実行し、意図した動作になることを確認した
- [x] 既存の機能に影響（デグレ）がないことを確認した
- [x] 必要に応じてドキュメントを更新した
- [x] `npm run lint` / `npm run test:unit` がすべてパスすることを確認

## 備考・次やること
- Issue 提案にあった「挿入ロジックの共通モジュール化」(#88 と共通の `src/editing/insertTask.ts`) は本 PR ではスコープ外。既存の `insertItemForDate` を `quickAdd.ts` から再利用する形で対応しており、#88 実装時に共通化を検討する想定。