### PR TITLE
release: 1.6.0 を main にリリース (#88, #89, #90, #91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Added
 - Activity Bar TreeView ("TaskMark: Overview") that summarizes the active `.tmd` file by Today / This week / Overdue / Recently done. Clicking an item jumps to the corresponding line, and tasks expose an inline toggle action (#89).
 - Task progress rate with the `[N]` checkbox notation (0-100). `[0]` is equivalent to `[ ]` and `[100]` is equivalent to `[x]`. Gantt task bars are filled by the progress rate, group bars use the average across child tasks, and the TreeView appends a `(N%)` suffix for intermediate values (#90).
+- `TaskMark: Duplicate Task` command (Command Palette / editor context menu) that copies the task on the current line into multiple date sections based on a repeat pattern (`daily` / `weekly` / `monthly` / `every:N{days|weeks|months}`) and an end condition (`count:N` or `until:YYYY-MM-DD`). Missing date sections are created automatically (#91).
 
 ## [1.5.0] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "TaskMark" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [Unreleased]
+
+### Added
+- Activity Bar TreeView ("TaskMark: Overview") that summarizes the active `.tmd` file by Today / This week / Overdue / Recently done. Clicking an item jumps to the corresponding line, and tasks expose an inline toggle action (#89).
+
 ## [1.5.0] - 2026-04-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ### Added
 - Activity Bar TreeView ("TaskMark: Overview") that summarizes the active `.tmd` file by Today / This week / Overdue / Recently done. Clicking an item jumps to the corresponding line, and tasks expose an inline toggle action (#89).
+- Task progress rate with the `[N]` checkbox notation (0-100). `[0]` is equivalent to `[ ]` and `[100]` is equivalent to `[x]`. Gantt task bars are filled by the progress rate, group bars use the average across child tasks, and the TreeView appends a `(N%)` suffix for intermediate values (#90).
 
 ## [1.5.0] - 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ Options can be combined using commas. If a limit is not explicitly defined, recu
 | `> Group Name` | Group header (tags optional) | — |
 | `> - Item` | Items inside group | Both |
 
+> **Note:** Month, day, hour, and minute parts accept both zero-padded and unpadded forms — `2026-3-1` and `9:0` are parsed the same as `2026-03-01` and `09:00`. The zero-padded form is recommended for consistency.
+
 ### 🗂️ Group Colors
 
 Attach a tag directly to a group header to control its display color in both the Calendar and Timeline views.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ Use `# YYYY-MM-DD : YYYY-MM-DD` to define events or tasks that span multiple day
 
 ---
 
+### Activity Bar Sidebar
+
+A dedicated TaskMark icon appears in the Activity Bar. Clicking it opens the **Overview** TreeView, which summarizes the active `.tmd` file at a glance:
+
+- **Today** — schedules and tasks for the current day (including ranges that span today)
+- **This week** — items in the current Mon–Sun week, excluding today
+- **Overdue** — incomplete tasks dated before today
+- **Recently done** — the most recent completed tasks (up to 10)
+
+Click any item to jump to its line in the `.tmd` file. Use the inline check-mark action on a task to toggle `- [ ]` / `- [x]` without opening the editor. The view auto-refreshes when the file is edited or another `.tmd` becomes active, and the title bar provides a manual refresh button.
+
+---
+
 ### ✏️ Editing Helpers
 
 Reduce the typing cost of writing `.tmd` files with quick-add commands, snippets, and inline completion.

--- a/README.md
+++ b/README.md
@@ -230,8 +230,11 @@ Reduce the typing cost of writing `.tmd` files with quick-add commands, snippets
 
 - **`TaskMark: Add Task`** — Prompts for the task body and target date, then inserts `- [ ] <body>` into the matching date section. The section is created at the end of the file if it does not exist.
 - **`TaskMark: Add Schedule`** — Prompts for the body, start time, optional end time, and target date, then inserts `- HH:mm[-HH:mm] <body>` into the matching date section.
+- **`TaskMark: Duplicate Task`** — With the cursor on a task line, prompts for a repeat pattern (`daily` / `weekly` / `monthly` / `every:Ndays|Nweeks|Nmonths`) and an end condition (`count:N` or `until:YYYY-MM-DD`), then inserts copies of the task into the matching date sections. Missing date sections are created at the end of the file. Also available from the editor context menu on a `.tmd` file.
 
 The date prompt offers `Today` / `Tomorrow` / a custom `YYYY-MM-DD`.
+
+> **Note:** Unlike `@repeat`, which expands schedules in-place at parse time, `Duplicate Task` inserts independent `- [ ]` lines into the file. Each copy keeps its own completion state, so it works for recurring tasks (e.g. weekly reports).
 
 **Snippets** — Type the prefix and press `Tab` while editing a `.tmd` file:
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,9 @@ Options can be combined using commas. If a limit is not explicitly defined, recu
 | `# YYYY-MM-DD` | Date header | — |
 | `# YYYY-MM-DD : YYYY-MM-DD` | Date range header (start : end) | — |
 | `- Text` | Schedule (Event) | — |
-| `- [ ] Text` | Uncompleted task | — |
-| `- [x] Text` | Completed task | — |
+| `- [ ] Text` | Uncompleted task (= `- [0] Text`) | — |
+| `- [x] Text` | Completed task (= `- [100] Text`) | — |
+| `- [N] Text` | Task with progress rate (`N` = 0-100) | — |
 | `HH:mm-HH:mm` | Time range (Start-End) | Schedules |
 | `HH:mm` | Start time only | Schedules |
 | `#Tag` | Tags (Multiple allowed) | Both |

--- a/README.md
+++ b/README.md
@@ -208,6 +208,37 @@ Use `# YYYY-MM-DD : YYYY-MM-DD` to define events or tasks that span multiple day
 
 ---
 
+### ✏️ Editing Helpers
+
+Reduce the typing cost of writing `.tmd` files with quick-add commands, snippets, and inline completion.
+
+**Quick-Add Commands** — Open the Command Palette (`Ctrl+Shift+P`) and run:
+
+- **`TaskMark: Add Task`** — Prompts for the task body and target date, then inserts `- [ ] <body>` into the matching date section. The section is created at the end of the file if it does not exist.
+- **`TaskMark: Add Schedule`** — Prompts for the body, start time, optional end time, and target date, then inserts `- HH:mm[-HH:mm] <body>` into the matching date section.
+
+The date prompt offers `Today` / `Tomorrow` / a custom `YYYY-MM-DD`.
+
+**Snippets** — Type the prefix and press `Tab` while editing a `.tmd` file:
+
+| Prefix | Expands to |
+|------|------|
+| `task` | `- [ ] ` |
+| `event` | `- HH:mm-HH:mm ` |
+| `date` | `# YYYY-MM-DD` |
+| `range` | `# YYYY-MM-DD : YYYY-MM-DD` |
+| `group` | `> Group Name #Tag` |
+| `repeat` | `@repeat(daily|weekly|monthly)` (choice) |
+| `tags` | `@tags` ... `@end` block |
+
+**Inline Completion**
+
+- After `#`, completes from tags defined in the current file's `@tags` block and from `taskmark.tagColors` settings.
+- After `@`, completes the keywords `repeat(`, `tags`, and `end`.
+- Inside `@repeat(...)`, completes the modifiers `daily`, `weekly`, `monthly`, `every:`, `until:`, `count:`, `except:`.
+
+---
+
 ## Usage
 
 1. Open a `.tmd` extension file.

--- a/media/activitybar-icon.svg
+++ b/media/activitybar-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3.5" y="4.5" width="17" height="16" rx="2"/>
+  <path d="M3.5 8.5h17"/>
+  <path d="M8 3.5v3"/>
+  <path d="M16 3.5v3"/>
+  <path d="M7.5 13l2 2 4.5-4.5"/>
+</svg>

--- a/media/main.js
+++ b/media/main.js
@@ -911,11 +911,12 @@
     const bar = createGanttBar(left, yOffset, width, bgColor);
     bar.classList.add('tm-gantt-group-bar');
 
-    // Progress fill
+    // Progress fill — uses the average task progress across children
+    // (each task's progress is 0-100, [N] notation per Issue #90).
     const pBar = document.createElement('div');
     pBar.className = 'tm-gantt-progress';
     if (entity.tasksTotal > 0) {
-      const progress = (entity.tasksDone / entity.tasksTotal) * 100;
+      const progress = entity.tasksProgressSum / entity.tasksTotal;
       pBar.style.width = progress + '%';
       if (progress > 0 && progress < 100) {
         pBar.style.borderRight = '2px solid var(--tm-card-border)';
@@ -959,7 +960,7 @@
       const pBar = document.createElement('div');
       pBar.className = 'tm-gantt-progress';
       if (child.isTask) {
-        pBar.style.width = child.isDone ? '100%' : '0%';
+        pBar.style.width = child.progress + '%';
       } else {
         pBar.style.width = '100%';
       }
@@ -1001,7 +1002,7 @@
       const pBar = document.createElement('div');
       pBar.className = 'tm-gantt-progress';
       if (child.isTask) {
-        pBar.style.width = child.isDone ? '100%' : '0%';
+        pBar.style.width = child.progress + '%';
       } else {
         pBar.style.width = '100%';
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,25 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "taskmark",
+          "title": "TaskMark",
+          "icon": "media/activitybar-icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "taskmark": [
+        {
+          "id": "taskmarkOverview",
+          "name": "Overview",
+          "icon": "media/activitybar-icon.svg",
+          "contextualTitle": "TaskMark"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "taskmark.openView",
@@ -30,6 +49,16 @@
       {
         "command": "taskmark.addSchedule",
         "title": "TaskMark: Add Schedule"
+      },
+      {
+        "command": "taskmark.tree.refresh",
+        "title": "TaskMark: Refresh Overview",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "taskmark.tree.toggleItem",
+        "title": "TaskMark: Toggle Task",
+        "icon": "$(check)"
       }
     ],
     "keybindings": [
@@ -46,6 +75,26 @@
           "command": "taskmark.openView",
           "when": "editorLangId == tmd",
           "group": "navigation"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "taskmark.tree.refresh",
+          "when": "view == taskmarkOverview",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "taskmark.tree.toggleItem",
+          "when": "view == taskmarkOverview && viewItem == taskmarkTask",
+          "group": "inline"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "taskmark.tree.toggleItem",
+          "when": "false"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
         "title": "TaskMark: Add Schedule"
       },
       {
+        "command": "taskmark.duplicateTask",
+        "title": "TaskMark: Duplicate Task"
+      },
+      {
         "command": "taskmark.tree.refresh",
         "title": "TaskMark: Refresh Overview",
         "icon": "$(refresh)"
@@ -75,6 +79,13 @@
           "command": "taskmark.openView",
           "when": "editorLangId == tmd",
           "group": "navigation"
+        }
+      ],
+      "editor/context": [
+        {
+          "command": "taskmark.duplicateTask",
+          "when": "editorLangId == tmd",
+          "group": "taskmark@1"
         }
       ],
       "view/title": [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,14 @@
         "command": "taskmark.openView",
         "title": "TaskMark: Open View",
         "icon": "$(open-preview)"
+      },
+      {
+        "command": "taskmark.addTask",
+        "title": "TaskMark: Add Task"
+      },
+      {
+        "command": "taskmark.addSchedule",
+        "title": "TaskMark: Add Schedule"
       }
     ],
     "keybindings": [
@@ -59,6 +67,12 @@
         "language": "tmd",
         "scopeName": "source.tmd",
         "path": "./syntaxes/tmd.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "tmd",
+        "path": "./snippets/tmd.code-snippets"
       }
     ],
     "configuration": {

--- a/snippets/tmd.code-snippets
+++ b/snippets/tmd.code-snippets
@@ -1,0 +1,41 @@
+{
+  "Task": {
+    "prefix": "task",
+    "body": "- [ ] $0",
+    "description": "Insert a new task line"
+  },
+  "Event": {
+    "prefix": "event",
+    "body": "- ${1:HH:mm}-${2:HH:mm} $0",
+    "description": "Insert a new timed schedule line"
+  },
+  "Date": {
+    "prefix": "date",
+    "body": "# ${1:YYYY-MM-DD}",
+    "description": "Insert a new date section header"
+  },
+  "Date range": {
+    "prefix": "range",
+    "body": "# ${1:YYYY-MM-DD} : ${2:YYYY-MM-DD}",
+    "description": "Insert a date-range section header"
+  },
+  "Group": {
+    "prefix": "group",
+    "body": "> ${1:Group Name} #${2:Tag}",
+    "description": "Insert a group header"
+  },
+  "Repeat": {
+    "prefix": "repeat",
+    "body": "@repeat(${1|daily,weekly,monthly|})",
+    "description": "Insert an @repeat() modifier"
+  },
+  "Tags block": {
+    "prefix": "tags",
+    "body": [
+      "@tags",
+      "#${1:Tag} : ${2:#color}",
+      "@end"
+    ],
+    "description": "Insert a @tags...@end block"
+  }
+}

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -1,0 +1,76 @@
+// Pure logic for the .tmd CompletionItemProvider.
+// VS Code wiring lives in extension.ts; this module only deals with strings
+// and plain data so it can be unit-tested.
+
+const TAG_DEFINITION_REGEX = /^#([^\s:]+)\s*:/;
+
+export const REPEAT_OPTION_KEYWORDS: string[] = [
+  'daily',
+  'weekly',
+  'monthly',
+  'every:',
+  'until:',
+  'count:',
+  'except:',
+];
+
+export const AT_KEYWORDS: string[] = [
+  'repeat(',
+  'tags',
+  'end',
+];
+
+/**
+ * Collect tag names known to the document.
+ * Sources: `#name : color` rows inside an `@tags ... @end` block, and the
+ * keys of the `taskmark.tagColors` setting if supplied.
+ */
+export function extractDefinedTags(
+  documentText: string,
+  tagColorsSetting?: Record<string, string>
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  const lines = documentText === '' ? [] : documentText.split(/\r?\n/);
+  let inTagsBlock = false;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (line === '@tags') {
+      inTagsBlock = true;
+      continue;
+    }
+    if (line === '@end') {
+      inTagsBlock = false;
+      continue;
+    }
+    if (!inTagsBlock) {
+      continue;
+    }
+    const m = line.match(TAG_DEFINITION_REGEX);
+    if (m && !seen.has(m[1])) {
+      seen.add(m[1]);
+      result.push(m[1]);
+    }
+  }
+
+  if (tagColorsSetting) {
+    for (const name of Object.keys(tagColorsSetting)) {
+      if (!seen.has(name)) {
+        seen.add(name);
+        result.push(name);
+      }
+    }
+  }
+
+  return result;
+}
+
+export interface TagCompletionItem {
+  label: string;
+  insertText: string;
+}
+
+export function buildTagCompletionItems(tags: string[]): TagCompletionItem[] {
+  return tags.map(t => ({ label: t, insertText: t }));
+}

--- a/src/completionProvider.ts
+++ b/src/completionProvider.ts
@@ -1,0 +1,105 @@
+import * as vscode from 'vscode';
+import {
+  AT_KEYWORDS,
+  REPEAT_OPTION_KEYWORDS,
+  extractDefinedTags,
+} from './completion';
+
+const TMD_SELECTOR: vscode.DocumentSelector = { language: 'tmd' };
+
+export function registerCompletionProviders(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      TMD_SELECTOR,
+      new TmdHashCompletionProvider(),
+      '#'
+    ),
+    vscode.languages.registerCompletionItemProvider(
+      TMD_SELECTOR,
+      new TmdAtCompletionProvider(),
+      '@'
+    ),
+    vscode.languages.registerCompletionItemProvider(
+      TMD_SELECTOR,
+      new TmdRepeatOptionProvider(),
+      '(',
+      ',',
+      ' '
+    ),
+  );
+}
+
+class TmdHashCompletionProvider implements vscode.CompletionItemProvider {
+  provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.CompletionItem[] {
+    const linePrefix = document.lineAt(position).text.slice(0, position.character);
+    if (!/(?:^|\s)#[^\s#]*$/.test(linePrefix)) {
+      return [];
+    }
+    const tagColors = vscode.workspace
+      .getConfiguration('taskmark')
+      .get<Record<string, string>>('tagColors', {});
+    const tags = extractDefinedTags(document.getText(), tagColors);
+    return tags.map(name => {
+      const item = new vscode.CompletionItem(name, vscode.CompletionItemKind.Value);
+      item.insertText = name;
+      item.detail = 'TaskMark tag';
+      return item;
+    });
+  }
+}
+
+class TmdAtCompletionProvider implements vscode.CompletionItemProvider {
+  provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.CompletionItem[] {
+    const linePrefix = document.lineAt(position).text.slice(0, position.character);
+    if (!/(?:^|\s)@[A-Za-z]*$/.test(linePrefix)) {
+      return [];
+    }
+    return AT_KEYWORDS.map(keyword => {
+      const label = keyword.endsWith('(') ? keyword.slice(0, -1) : keyword;
+      const item = new vscode.CompletionItem(label, vscode.CompletionItemKind.Keyword);
+      if (keyword === 'repeat(') {
+        const snippet = new vscode.SnippetString('repeat(${1|daily,weekly,monthly|})');
+        item.insertText = snippet;
+        item.detail = '@repeat(...) modifier';
+      } else if (keyword === 'tags') {
+        const snippet = new vscode.SnippetString('tags\n#${1:Tag} : ${2:#color}\n@end');
+        item.insertText = snippet;
+        item.detail = '@tags ... @end block';
+      } else {
+        item.insertText = keyword;
+        item.detail = `@${keyword}`;
+      }
+      return item;
+    });
+  }
+}
+
+class TmdRepeatOptionProvider implements vscode.CompletionItemProvider {
+  provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.CompletionItem[] {
+    const lineText = document.lineAt(position).text;
+    const before = lineText.slice(0, position.character);
+    const open = before.lastIndexOf('@repeat(');
+    if (open === -1) {
+      return [];
+    }
+    const close = before.indexOf(')', open);
+    if (close !== -1) {
+      return [];
+    }
+    return REPEAT_OPTION_KEYWORDS.map(keyword => {
+      const item = new vscode.CompletionItem(keyword, vscode.CompletionItemKind.EnumMember);
+      item.insertText = keyword;
+      item.detail = '@repeat option';
+      return item;
+    });
+  }
+}

--- a/src/duplicateTask.ts
+++ b/src/duplicateTask.ts
@@ -1,0 +1,152 @@
+// Pure helpers backing the TaskMark: Duplicate Task command.
+// Kept free of vscode imports so the logic can be unit-tested without
+// the VS Code test runner.
+
+import { insertItemForDate, isValidDate, formatLocalDate } from './quickAdd';
+
+export interface DuplicatePattern {
+  mode: 'days' | 'months';
+  interval: number;
+}
+
+export interface DuplicateEndCondition {
+  kind: 'count' | 'until';
+  count?: number;
+  until?: string;
+}
+
+export const MAX_DUPLICATE_OCCURRENCES = 3650;
+
+const EVERY_REGEX = /^([1-9]\d*)(days?|weeks?|months?)$/;
+const DATE_HEADER_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})/;
+
+export function parseDuplicatePattern(input: string): DuplicatePattern | null {
+  const s = input.trim();
+  if (s === 'daily') {
+    return { mode: 'days', interval: 1 };
+  }
+  if (s === 'weekly') {
+    return { mode: 'days', interval: 7 };
+  }
+  if (s === 'monthly') {
+    return { mode: 'months', interval: 1 };
+  }
+  if (s.startsWith('every:')) {
+    const m = s.substring(6).match(EVERY_REGEX);
+    if (!m) {
+      return null;
+    }
+    const num = parseInt(m[1], 10);
+    const unit = m[2].replace(/s$/, '');
+    if (unit === 'day') {
+      return { mode: 'days', interval: num };
+    }
+    if (unit === 'week') {
+      return { mode: 'days', interval: num * 7 };
+    }
+    if (unit === 'month') {
+      return { mode: 'months', interval: num };
+    }
+  }
+  return null;
+}
+
+export function parseDuplicateEndCondition(input: string): DuplicateEndCondition | null {
+  const s = input.trim();
+  if (s.startsWith('count:')) {
+    const raw = s.substring(6).trim();
+    if (!/^\d+$/.test(raw)) {
+      return null;
+    }
+    const n = parseInt(raw, 10);
+    if (!Number.isFinite(n) || n < 1) {
+      return null;
+    }
+    return { kind: 'count', count: Math.min(n, MAX_DUPLICATE_OCCURRENCES) };
+  }
+  if (s.startsWith('until:')) {
+    const d = s.substring(6).trim();
+    if (!isValidDate(d)) {
+      return null;
+    }
+    return { kind: 'until', until: d };
+  }
+  return null;
+}
+
+export function generateDuplicateDates(
+  sourceDate: string,
+  pattern: DuplicatePattern,
+  end: DuplicateEndCondition
+): string[] {
+  if (!isValidDate(sourceDate)) {
+    return [];
+  }
+  const origin = toLocalDate(sourceDate);
+  const dates: string[] = [];
+  const maxIterations = end.kind === 'count'
+    ? Math.min(end.count ?? 0, MAX_DUPLICATE_OCCURRENCES)
+    : MAX_DUPLICATE_OCCURRENCES;
+  const untilDate = end.kind === 'until' && end.until ? toLocalDate(end.until) : undefined;
+
+  for (let i = 1; i < maxIterations; i++) {
+    const next = new Date(origin.getFullYear(), origin.getMonth(), origin.getDate());
+    if (pattern.mode === 'months') {
+      const targetMonth = origin.getMonth() + pattern.interval * i;
+      next.setMonth(targetMonth);
+      const expectedMonth = ((targetMonth % 12) + 12) % 12;
+      if (next.getMonth() !== expectedMonth) {
+        next.setDate(0);
+      }
+    } else {
+      next.setDate(origin.getDate() + pattern.interval * i);
+    }
+    if (untilDate && next > untilDate) {
+      break;
+    }
+    dates.push(formatLocalDate(next));
+  }
+  return dates;
+}
+
+export interface DuplicateResult {
+  newText: string;
+  insertedDates: string[];
+}
+
+export function duplicateTaskAcrossDates(
+  documentText: string,
+  sourceDate: string,
+  taskLine: string,
+  pattern: DuplicatePattern,
+  end: DuplicateEndCondition,
+  eol: string = '\n'
+): DuplicateResult {
+  const dates = generateDuplicateDates(sourceDate, pattern, end);
+  let text = documentText;
+  for (const date of dates) {
+    text = insertItemForDate(text, date, taskLine, eol).newText;
+  }
+  return { newText: text, insertedDates: dates };
+}
+
+export function findSourceDateForLine(documentText: string, lineIndex: number): string | null {
+  const lines = documentText === '' ? [] : documentText.split(/\r?\n/);
+  for (let i = Math.min(lineIndex, lines.length - 1); i >= 0; i--) {
+    const m = lines[i].match(DATE_HEADER_REGEX);
+    if (m) {
+      return normalizeDate(m[1]);
+    }
+  }
+  return null;
+}
+
+function normalizeDate(raw: string): string {
+  const [y, m, d] = raw.split('-');
+  return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
+}
+
+function toLocalDate(s: string): Date {
+  const [y, m, d] = s.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}

--- a/src/duplicateTaskCommand.ts
+++ b/src/duplicateTaskCommand.ts
@@ -1,0 +1,145 @@
+import * as vscode from 'vscode';
+import {
+  DuplicateEndCondition,
+  DuplicatePattern,
+  duplicateTaskAcrossDates,
+  findSourceDateForLine,
+  parseDuplicateEndCondition,
+  parseDuplicatePattern,
+} from './duplicateTask';
+import { isValidDate } from './quickAdd';
+
+const TMD_LANGUAGE_ID = 'tmd';
+const TASK_LINE_REGEX = /^\s*(?:>\s*)?-\s*\[/;
+const EVERY_INPUT_REGEX = /^[1-9]\d*(?:days?|weeks?|months?)$/;
+
+export function registerDuplicateTaskCommand(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('taskmark.duplicateTask', () => runDuplicateTask()),
+  );
+}
+
+async function runDuplicateTask(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.languageId !== TMD_LANGUAGE_ID) {
+    vscode.window.showErrorMessage('TaskMark: Open a .tmd file before running Duplicate Task.');
+    return;
+  }
+
+  const document = editor.document;
+  const lineIndex = editor.selection.active.line;
+  const lineText = document.lineAt(lineIndex).text;
+  if (!TASK_LINE_REGEX.test(lineText)) {
+    vscode.window.showErrorMessage('TaskMark: Place the cursor on a task line (- [ ] ...) first.');
+    return;
+  }
+
+  const fullText = document.getText();
+  const sourceDate = findSourceDateForLine(fullText, lineIndex);
+  if (!sourceDate) {
+    vscode.window.showErrorMessage('TaskMark: No date header found above the current task.');
+    return;
+  }
+
+  const pattern = await pickPattern();
+  if (!pattern) {
+    return;
+  }
+
+  const endCondition = await pickEndCondition();
+  if (!endCondition) {
+    return;
+  }
+
+  const eol = document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n';
+  const { newText, insertedDates } = duplicateTaskAcrossDates(
+    fullText,
+    sourceDate,
+    lineText,
+    pattern,
+    endCondition,
+    eol,
+  );
+
+  if (insertedDates.length === 0) {
+    vscode.window.showInformationMessage('TaskMark: No dates matched — nothing to duplicate.');
+    return;
+  }
+
+  const fullRange = new vscode.Range(
+    document.positionAt(0),
+    document.positionAt(fullText.length),
+  );
+  const ok = await editor.edit(eb => eb.replace(fullRange, newText));
+  if (!ok) {
+    vscode.window.showErrorMessage('TaskMark: Failed to duplicate task.');
+    return;
+  }
+
+  vscode.window.showInformationMessage(
+    `TaskMark: Duplicated task into ${insertedDates.length} date${insertedDates.length === 1 ? '' : 's'}.`,
+  );
+}
+
+async function pickPattern(): Promise<DuplicatePattern | undefined> {
+  const choice = await vscode.window.showQuickPick(
+    [
+      { label: 'Daily', detail: 'Every day', value: 'daily' },
+      { label: 'Weekly', detail: 'Every week', value: 'weekly' },
+      { label: 'Monthly', detail: 'Every month', value: 'monthly' },
+      { label: 'Every N days/weeks/months…', detail: 'Enter a custom interval', value: '__custom__' },
+    ],
+    { placeHolder: 'Repeat pattern' },
+  );
+  if (!choice) {
+    return undefined;
+  }
+  if (choice.value !== '__custom__') {
+    return parseDuplicatePattern(choice.value) ?? undefined;
+  }
+  const raw = await vscode.window.showInputBox({
+    prompt: 'Custom interval',
+    placeHolder: 'e.g. 3days, 2weeks, 3months',
+    ignoreFocusOut: true,
+    validateInput: v => (EVERY_INPUT_REGEX.test(v.trim()) ? null : 'Enter <N><unit> where unit is days/weeks/months'),
+  });
+  if (raw === undefined) {
+    return undefined;
+  }
+  return parseDuplicatePattern(`every:${raw.trim()}`) ?? undefined;
+}
+
+async function pickEndCondition(): Promise<DuplicateEndCondition | undefined> {
+  const choice = await vscode.window.showQuickPick(
+    [
+      { label: 'Count', detail: 'Number of occurrences (including the source)', value: 'count' },
+      { label: 'Until', detail: 'End date (YYYY-MM-DD)', value: 'until' },
+    ],
+    { placeHolder: 'End condition' },
+  );
+  if (!choice) {
+    return undefined;
+  }
+  if (choice.value === 'count') {
+    const raw = await vscode.window.showInputBox({
+      prompt: 'Occurrence count (including the source)',
+      placeHolder: '4',
+      ignoreFocusOut: true,
+      validateInput: v => (/^[1-9]\d*$/.test(v.trim()) ? null : 'Enter a positive integer'),
+    });
+    if (raw === undefined) {
+      return undefined;
+    }
+    return parseDuplicateEndCondition(`count:${raw.trim()}`) ?? undefined;
+  }
+  const raw = await vscode.window.showInputBox({
+    prompt: 'End date (YYYY-MM-DD)',
+    placeHolder: '2026-12-31',
+    ignoreFocusOut: true,
+    validateInput: v => (isValidDate(v.trim()) ? null : 'Enter a date as YYYY-MM-DD'),
+  });
+  if (raw === undefined) {
+    return undefined;
+  }
+  return parseDuplicateEndCondition(`until:${raw.trim()}`) ?? undefined;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import { TaskmarkPanel } from './TaskmarkPanel';
+import { registerQuickAddCommands } from './quickAddCommands';
+import { registerCompletionProviders } from './completionProvider';
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -7,6 +9,9 @@ export function activate(context: vscode.ExtensionContext) {
       TaskmarkPanel.createOrShow(context.extensionUri);
     })
   );
+
+  registerQuickAddCommands(context);
+  registerCompletionProviders(context);
 
   if (vscode.window.registerWebviewPanelSerializer) {
     vscode.window.registerWebviewPanelSerializer(TaskmarkPanel.viewType, {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import { TaskmarkPanel } from './TaskmarkPanel';
 import { registerQuickAddCommands } from './quickAddCommands';
 import { registerCompletionProviders } from './completionProvider';
+import { TaskmarkTreeDataProvider } from './treeViewProvider';
+import { debounce } from './utils/debounce';
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
@@ -12,6 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   registerQuickAddCommands(context);
   registerCompletionProviders(context);
+  registerTreeView(context);
 
   if (vscode.window.registerWebviewPanelSerializer) {
     vscode.window.registerWebviewPanelSerializer(TaskmarkPanel.viewType, {
@@ -20,4 +23,38 @@ export function activate(context: vscode.ExtensionContext) {
       }
     });
   }
+}
+
+function registerTreeView(context: vscode.ExtensionContext) {
+  const provider = new TaskmarkTreeDataProvider();
+  const treeView = vscode.window.createTreeView('taskmarkOverview', {
+    treeDataProvider: provider,
+    showCollapseAll: true
+  });
+  context.subscriptions.push(treeView);
+
+  provider.refresh();
+
+  const debouncedRefresh = debounce(() => provider.refresh(), 250);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('taskmark.tree.refresh', () => provider.refresh()),
+    vscode.commands.registerCommand('taskmark.tree.revealItem', (node) => {
+      if (node && node.kind === 'item') {
+        void provider.revealItem(node);
+      }
+    }),
+    vscode.commands.registerCommand('taskmark.tree.toggleItem', (node) => {
+      if (node && node.kind === 'item') {
+        void provider.toggleItem(node);
+      }
+    }),
+    vscode.window.onDidChangeActiveTextEditor(() => provider.refresh()),
+    vscode.workspace.onDidChangeTextDocument(e => {
+      if (e.document.languageId === 'tmd') {
+        debouncedRefresh();
+      }
+    }),
+    { dispose: () => debouncedRefresh.cancel() }
+  );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { TaskmarkPanel } from './TaskmarkPanel';
 import { registerQuickAddCommands } from './quickAddCommands';
+import { registerDuplicateTaskCommand } from './duplicateTaskCommand';
 import { registerCompletionProviders } from './completionProvider';
 import { TaskmarkTreeDataProvider } from './treeViewProvider';
 import { debounce } from './utils/debounce';
@@ -13,6 +14,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   registerQuickAddCommands(context);
+  registerDuplicateTaskCommand(context);
   registerCompletionProviders(context);
   registerTreeView(context);
 

--- a/src/gantt.ts
+++ b/src/gantt.ts
@@ -10,6 +10,8 @@ export interface GanttChildItem {
   endMs: number;
   isTask: boolean;
   isDone: boolean;
+  /** Progress rate (0-100) for tasks. 100 for schedule items. */
+  progress: number;
   rawLine: number;
   sourceLine: string;
 }
@@ -24,6 +26,9 @@ export interface GanttEntity {
   tags: string[];
   tasksTotal: number;
   tasksDone: number;
+  /** Sum of progress (0-100) across all task children. Average is
+   *  tasksProgressSum / tasksTotal; falls back to full bar when no tasks. */
+  tasksProgressSum: number;
   children: GanttChildItem[];
 }
 
@@ -99,12 +104,15 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
             : [...item.tags],
           tasksTotal: 0,
           tasksDone: 0,
+          tasksProgressSum: 0,
           children: []
         };
       } else {
         if (startMs < bucket[key].minTime) { bucket[key].minTime = startMs; }
         if (endMs > bucket[key].maxTime) { bucket[key].maxTime = endMs; }
       }
+
+      const childProgress = item.type === 'task' ? (item.progress ?? 0) : 100;
 
       bucket[key].children.push({
         text: item.text,
@@ -113,6 +121,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
         endMs,
         isTask: item.type === 'task',
         isDone: item.status === 'done',
+        progress: childProgress,
         rawLine: item.rawLine,
         sourceLine: item.sourceLine
       });
@@ -122,6 +131,7 @@ export function buildGanttEntities(data: TaskMarkData): GanttData {
         if (item.status === 'done') {
           bucket[key].tasksDone++;
         }
+        bucket[key].tasksProgressSum += childProgress;
       }
     });
   });

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -36,11 +36,13 @@ export interface ToggleTaskMessage {
 }
 
 // Leading line prefix matches parser ITEM_REGEX (TASK_LINE_PREFIX_NC + \s*).
-// Bracket interior mirrors ITEM: \[\s*([xX\s])\s*\] — one mark character
-// with flexible inner whitespace. Only that mark is swapped ('x' todo→done,
-// ASCII space done→todo) so surrounding spaces inside the brackets are kept.
+// Bracket interior mirrors ITEM: \[\s*([xX]|\d{1,3}|\s)\s*\] — one mark token
+// (x/X, a 1-3 digit progress number, or a single whitespace) with flexible
+// inner whitespace around it. Toggle treats `[ ]` and `[0]` as todo, `[x]`
+// and `[100]` as done; intermediate `[N]` is treated as todo (becomes `[x]`
+// on click) per Issue #90.
 const CHECKBOX_LINE_REGEX = new RegExp(
-  `^(${TASK_LINE_PREFIX_NC}\\s*)(\\[)(\\s*)([xX\\s])(\\s*)(\\])`
+  `^(${TASK_LINE_PREFIX_NC}\\s*)(\\[)(\\s*)([xX]|\\d{1,3}|\\s)(\\s*)(\\])`
 );
 
 export function toggleCheckboxInLine(line: string): string | null {
@@ -49,7 +51,8 @@ export function toggleCheckboxInLine(line: string): string | null {
     return null;
   }
   const mark = match[4];
-  const isDone = mark.trim().toLowerCase() === 'x';
+  const trimmed = mark.trim();
+  const isDone = trimmed.toLowerCase() === 'x' || trimmed === '100';
   const newMark = isDone ? ' ' : 'x';
   return (
     match[1] +

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -49,7 +49,8 @@ const ITEM_REGEX = new RegExp(
 );
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
 const TAG_SPLIT_REGEX = /#([^\s#]+)/g;
-const EVERY_REGEX = /^(\d+)(days?|weeks?|months?)$/;
+const EVERY_REGEX = /^([1-9]\d*)(days?|weeks?|months?)$/;
+const INDENTED_ITEM_REGEX = /^\s+(?:>\s*)?-/;
 
 function toLocaleDateStr(d: Date): string {
   const y = d.getFullYear();
@@ -69,15 +70,23 @@ export function parseLocalDate(dateStr: string): Date {
   return date;
 }
 
-/** Normalize a time part like "9:0" to "9:00" */
-function normalizeTimePart(t: string): string {
-  const [h, m] = t.split(':');
-  return `${h}:${m.padStart(2, '0')}`;
-}
-
-/** Normalize a time string like "9:0-17:0" to "9:00-17:00" */
-function normalizeTimeStr(timeStr: string): string {
-  return timeStr.split('-').map(normalizeTimePart).join('-');
+/** Validate and normalize a time string like "9:0-17:0" to "9:00-17:00".
+ *  Returns undefined and emits a warning if any part is out of range
+ *  (h: 0-23, m: 0-59). */
+function parseTimeStr(timeStr: string, lineNum: number, warnings: string[]): string | undefined {
+  const parts = timeStr.split('-');
+  const normalized: string[] = [];
+  for (const p of parts) {
+    const [hStr, mStr] = p.split(':');
+    const h = parseInt(hStr, 10);
+    const m = parseInt(mStr, 10);
+    if (h < 0 || h > 23 || m < 0 || m > 59) {
+      warnings.push(`Line ${lineNum + 1}: invalid time '${timeStr}', skipped`);
+      return undefined;
+    }
+    normalized.push(`${hStr}:${mStr.padStart(2, '0')}`);
+  }
+  return normalized.join('-');
 }
 
 /** Parse and normalize a date string to 'YYYY-MM-DD'. Returns null if invalid. */
@@ -132,13 +141,16 @@ function parseRepeatOptions(repeatStr: string, lineNum: number, warnings: string
 
   for (const part of parts) {
     if (part.startsWith('every:')) {
-      const match = part.substring(6).match(EVERY_REGEX);
+      const rawInterval = part.substring(6);
+      const match = rawInterval.match(EVERY_REGEX);
       if (match) {
         const num = parseInt(match[1], 10);
         const unit = match[2].replace(/s$/, '');
         if (unit === 'day') { mode = 'days'; interval = num; }
         else if (unit === 'week') { mode = 'days'; interval = num * 7; }
         else if (unit === 'month') { mode = 'months'; interval = num; }
+      } else {
+        warnings.push(`Line ${lineNum + 1}: invalid @repeat interval '${rawInterval}', skipped`);
       }
     } else if (part === 'daily') {
       mode = 'days'; interval = 1;
@@ -155,8 +167,16 @@ function parseRepeatOptions(repeatStr: string, lineNum: number, warnings: string
         warnings.push(`Line ${lineNum + 1}: invalid until date '${dateStr}', skipped`);
       }
     } else if (part.startsWith('count:')) {
-      const parsedCount = parseInt(part.substring(6), 10);
-      if (!isNaN(parsedCount)) count = parsedCount;
+      const countStr = part.substring(6);
+      const parsedCount = parseInt(countStr, 10);
+      if (isNaN(parsedCount) || parsedCount < 0) {
+        warnings.push(`Line ${lineNum + 1}: invalid count '${countStr}', skipped`);
+      } else if (parsedCount > MAX_OCCURRENCES) {
+        warnings.push(`Line ${lineNum + 1}: count '${countStr}' exceeds maximum ${MAX_OCCURRENCES}, capped`);
+        count = MAX_OCCURRENCES;
+      } else {
+        count = parsedCount;
+      }
     } else if (part.startsWith('except:')) {
       for (const d of part.substring(7).trim().split(/\s+/).filter(Boolean)) {
         const normalized = tryNormalizeDate(d);
@@ -166,6 +186,8 @@ function parseRepeatOptions(repeatStr: string, lineNum: number, warnings: string
           warnings.push(`Line ${lineNum + 1}: invalid except date '${d}', skipped`);
         }
       }
+    } else if (part) {
+      warnings.push(`Line ${lineNum + 1}: unknown @repeat token '${part}', ignored`);
     }
   }
 
@@ -257,11 +279,13 @@ export function parseTmd(text: string): ParseResult {
     // 4. Item (schedule or task)
     const itemMatch = rawLine.match(ITEM_REGEX);
     if (itemMatch && itemMatch[2]) {
-      const result = createMarkItem(itemMatch, i, rawLine, currentDate, currentGroup, currentEndDate);
+      const result = createMarkItem(itemMatch, i, rawLine, currentDate, currentGroup, warnings, currentEndDate);
       if (result) {
         data.days[currentDate].items.push(result.item);
         currentGroup = result.newGroup;
       }
+    } else if (currentDate && INDENTED_ITEM_REGEX.test(rawLine)) {
+      warnings.push(`Line ${i + 1}: indented list items are not supported, skipped`);
     }
   }
 
@@ -274,6 +298,7 @@ function createMarkItem(
   sourceLine: string,
   currentDate: string,
   currentGroup: string,
+  warnings: string[],
   endDate = '',
 ): { item: MarkItem; newGroup: string } | null {
   if (!currentDate) {
@@ -285,7 +310,7 @@ function createMarkItem(
 
   const hasCheckbox = itemMatch[3];
   const checkMark = itemMatch[4];
-  const timeString = itemMatch[5] ? normalizeTimeStr(itemMatch[5]) : undefined;
+  const timeString = itemMatch[5] ? parseTimeStr(itemMatch[5], lineIndex, warnings) : undefined;
   let content = itemMatch[8] || '';
 
   const type: ItemType = hasCheckbox ? 'task' : 'schedule';
@@ -332,8 +357,11 @@ function expandRepeats(data: TaskMarkData, warnings: string[]): TaskMarkData {
 
   Object.values(data.days).forEach(day => {
     day.items.forEach(item => {
-      if (!item.repeat || item.type === 'task' || item.endDate) return;
-
+      if (!item.repeat || item.type === 'task') { return; }
+      if (item.endDate) {
+        warnings.push(`Line ${item.rawLine + 1}: @repeat is ignored because endDate is specified`);
+        return;
+      }
       generateRepeatedItems(item, day.date, expandedDays, warnings);
     });
   });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -26,6 +26,9 @@ export interface MarkItem {
   time?: string;
   tags: string[];
   status?: TaskStatus;
+  /** Progress rate in 0-100 for task items. Undefined for schedule items.
+   *  `[ ]` is 0, `[x]` is 100, `[N]` carries the explicit value. */
+  progress?: number;
   repeat?: string;
   group?: string;
   rawLine: number;
@@ -45,7 +48,7 @@ const TASK_LINE_PREFIX_SRC = '(>\\s*)?(-)?';
  *  toggleCheckboxInLine. Keep the two regex shapes in sync. */
 export const TASK_LINE_PREFIX_NC = '(?:>\\s*)?(?:-)?';
 const ITEM_REGEX = new RegExp(
-  `^${TASK_LINE_PREFIX_SRC}\\s*(\\[\\s*([xX\\s])\\s*\\])?\\s*((\\d{1,2}:\\d{1,2})(?:-(\\d{1,2}:\\d{1,2}))?)?\\s*(.*)$`
+  `^${TASK_LINE_PREFIX_SRC}\\s*(\\[\\s*([xX]|\\d{1,3}|\\s)\\s*\\])?\\s*((\\d{1,2}:\\d{1,2})(?:-(\\d{1,2}:\\d{1,2}))?)?\\s*(.*)$`
 );
 const REPEAT_REGEX = /@repeat\(([^)]+)\)/;
 const TAG_SPLIT_REGEX = /#([^\s#]+)/g;
@@ -314,9 +317,28 @@ function createMarkItem(
   let content = itemMatch[8] || '';
 
   const type: ItemType = hasCheckbox ? 'task' : 'schedule';
-  const status: TaskStatus | undefined = hasCheckbox
-    ? (checkMark.trim().toLowerCase() === 'x' ? 'done' : 'todo')
-    : undefined;
+  let status: TaskStatus | undefined;
+  let progress: number | undefined;
+  if (hasCheckbox) {
+    const trimmed = checkMark.trim();
+    if (trimmed === '') {
+      progress = 0;
+      status = 'todo';
+    } else if (trimmed.toLowerCase() === 'x') {
+      progress = 100;
+      status = 'done';
+    } else {
+      const n = parseInt(trimmed, 10);
+      if (n > 100) {
+        warnings.push(`Line ${lineIndex + 1}: invalid progress '${trimmed}' (must be 0-100), fallback to 0`);
+        progress = 0;
+        status = 'todo';
+      } else {
+        progress = n;
+        status = n === 100 ? 'done' : 'todo';
+      }
+    }
+  }
 
   // Extract repeat
   let repeatStr: string | undefined;
@@ -337,6 +359,7 @@ function createMarkItem(
     time: timeString,
     tags,
     status,
+    progress,
     repeat: repeatStr,
     group: newGroup || undefined,
     rawLine: lineIndex,

--- a/src/quickAdd.ts
+++ b/src/quickAdd.ts
@@ -1,0 +1,133 @@
+// Pure helpers backing the TaskMark: Add Task / Add Schedule commands.
+// Kept free of vscode imports so the logic can be unit-tested without
+// the VS Code test runner.
+
+const DATE_HEADER_REGEX = /^#\s+(\d{4}-\d{1,2}-\d{1,2})/;
+const FULL_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const TIME_REGEX = /^([01]?\d|2[0-3]):[0-5]\d$/;
+
+export function formatTaskLine(text: string): string {
+  return `- [ ] ${text.trim()}`;
+}
+
+export function formatScheduleLine(text: string, startTime: string, endTime?: string): string {
+  const trimmed = text.trim();
+  const time = endTime ? `${startTime}-${endTime}` : startTime;
+  return trimmed ? `- ${time} ${trimmed}` : `- ${time}`;
+}
+
+export interface InsertResult {
+  newText: string;
+  /** Zero-based line index of the inserted item line in `newText`. */
+  insertedLineIndex: number;
+}
+
+/**
+ * Insert `itemLine` into the section for `dateStr`.
+ * - If a section header for the date exists, append the line after the
+ *   last non-empty line within that section.
+ * - If no section exists, append a new `# YYYY-MM-DD` section followed
+ *   by the item to the end of the document, keeping any trailing blank
+ *   lines intact.
+ *
+ * `dateStr` is matched against the section header in normalized form so
+ * a header like `# 2026-3-5` still matches `dateStr = '2026-03-05'`.
+ */
+export function insertItemForDate(
+  documentText: string,
+  dateStr: string,
+  itemLine: string
+): InsertResult {
+  const lines = documentText === '' ? [] : documentText.split(/\r?\n/);
+  const sectionStart = findSectionStart(lines, dateStr);
+
+  if (sectionStart === -1) {
+    return appendNewSection(lines, dateStr, itemLine);
+  }
+  return appendToExistingSection(lines, sectionStart, itemLine);
+}
+
+function findSectionStart(lines: string[], dateStr: string): number {
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(DATE_HEADER_REGEX);
+    if (m && normalizeDate(m[1]) === dateStr) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function appendNewSection(lines: string[], dateStr: string, itemLine: string): InsertResult {
+  let trimEnd = lines.length;
+  while (trimEnd > 0 && lines[trimEnd - 1].trim() === '') {
+    trimEnd--;
+  }
+  const head = lines.slice(0, trimEnd);
+  const tail = lines.slice(trimEnd);
+
+  const inserted: string[] = [];
+  if (head.length > 0) {
+    inserted.push('');
+  }
+  inserted.push(`# ${dateStr}`);
+  inserted.push(itemLine);
+
+  const newLines = [...head, ...inserted, ...tail];
+  const insertedLineIndex = head.length + inserted.length - 1;
+  return { newText: newLines.join('\n'), insertedLineIndex };
+}
+
+function appendToExistingSection(lines: string[], sectionStart: number, itemLine: string): InsertResult {
+  let nextSection = lines.length;
+  for (let i = sectionStart + 1; i < lines.length; i++) {
+    if (DATE_HEADER_REGEX.test(lines[i])) {
+      nextSection = i;
+      break;
+    }
+  }
+
+  let insertAfter = sectionStart;
+  for (let i = sectionStart + 1; i < nextSection; i++) {
+    if (lines[i].trim() !== '') {
+      insertAfter = i;
+    }
+  }
+
+  const newLines = [
+    ...lines.slice(0, insertAfter + 1),
+    itemLine,
+    ...lines.slice(insertAfter + 1),
+  ];
+  return { newText: newLines.join('\n'), insertedLineIndex: insertAfter + 1 };
+}
+
+function normalizeDate(raw: string): string {
+  const [y, m, d] = raw.split('-');
+  return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`;
+}
+
+export function isValidDate(s: string): boolean {
+  if (!FULL_DATE_REGEX.test(s)) {
+    return false;
+  }
+  const [y, m, d] = s.split('-').map(Number);
+  const date = new Date(y, m - 1, d);
+  return date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d;
+}
+
+export function isValidTime(s: string): boolean {
+  return TIME_REGEX.test(s);
+}
+
+export function formatLocalDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+export function offsetDate(base: Date, days: number): Date {
+  const next = new Date(base.getFullYear(), base.getMonth(), base.getDate());
+  next.setDate(next.getDate() + days);
+  return next;
+}

--- a/src/quickAdd.ts
+++ b/src/quickAdd.ts
@@ -32,19 +32,33 @@ export interface InsertResult {
  *
  * `dateStr` is matched against the section header in normalized form so
  * a header like `# 2026-3-5` still matches `dateStr = '2026-03-05'`.
+ *
+ * `eol` controls the line separator used when joining the result. Pass
+ * the document's existing EOL (`\n` or `\r\n`) so line endings are not
+ * silently converted on Windows-style files.
  */
 export function insertItemForDate(
   documentText: string,
   dateStr: string,
-  itemLine: string
+  itemLine: string,
+  eol: string = '\n'
 ): InsertResult {
   const lines = documentText === '' ? [] : documentText.split(/\r?\n/);
   const sectionStart = findSectionStart(lines, dateStr);
 
-  if (sectionStart === -1) {
-    return appendNewSection(lines, dateStr, itemLine);
-  }
-  return appendToExistingSection(lines, sectionStart, itemLine);
+  const planned = sectionStart === -1
+    ? planNewSection(lines, dateStr, itemLine)
+    : planExistingSection(lines, sectionStart, itemLine);
+
+  return {
+    newText: planned.lines.join(eol),
+    insertedLineIndex: planned.insertedLineIndex,
+  };
+}
+
+interface InsertPlan {
+  lines: string[];
+  insertedLineIndex: number;
 }
 
 function findSectionStart(lines: string[], dateStr: string): number {
@@ -57,7 +71,7 @@ function findSectionStart(lines: string[], dateStr: string): number {
   return -1;
 }
 
-function appendNewSection(lines: string[], dateStr: string, itemLine: string): InsertResult {
+function planNewSection(lines: string[], dateStr: string, itemLine: string): InsertPlan {
   let trimEnd = lines.length;
   while (trimEnd > 0 && lines[trimEnd - 1].trim() === '') {
     trimEnd--;
@@ -72,12 +86,13 @@ function appendNewSection(lines: string[], dateStr: string, itemLine: string): I
   inserted.push(`# ${dateStr}`);
   inserted.push(itemLine);
 
-  const newLines = [...head, ...inserted, ...tail];
-  const insertedLineIndex = head.length + inserted.length - 1;
-  return { newText: newLines.join('\n'), insertedLineIndex };
+  return {
+    lines: [...head, ...inserted, ...tail],
+    insertedLineIndex: head.length + inserted.length - 1,
+  };
 }
 
-function appendToExistingSection(lines: string[], sectionStart: number, itemLine: string): InsertResult {
+function planExistingSection(lines: string[], sectionStart: number, itemLine: string): InsertPlan {
   let nextSection = lines.length;
   for (let i = sectionStart + 1; i < lines.length; i++) {
     if (DATE_HEADER_REGEX.test(lines[i])) {
@@ -93,12 +108,14 @@ function appendToExistingSection(lines: string[], sectionStart: number, itemLine
     }
   }
 
-  const newLines = [
-    ...lines.slice(0, insertAfter + 1),
-    itemLine,
-    ...lines.slice(insertAfter + 1),
-  ];
-  return { newText: newLines.join('\n'), insertedLineIndex: insertAfter + 1 };
+  return {
+    lines: [
+      ...lines.slice(0, insertAfter + 1),
+      itemLine,
+      ...lines.slice(insertAfter + 1),
+    ],
+    insertedLineIndex: insertAfter + 1,
+  };
 }
 
 function normalizeDate(raw: string): string {

--- a/src/quickAddCommands.ts
+++ b/src/quickAddCommands.ts
@@ -154,7 +154,8 @@ async function pickDate(): Promise<string | undefined> {
 async function applyInsertion(editor: vscode.TextEditor, dateStr: string, itemLine: string): Promise<void> {
   const document = editor.document;
   const original = document.getText();
-  const { newText, insertedLineIndex } = insertItemForDate(original, dateStr, itemLine);
+  const eol = document.eol === vscode.EndOfLine.CRLF ? '\r\n' : '\n';
+  const { newText, insertedLineIndex } = insertItemForDate(original, dateStr, itemLine, eol);
 
   const fullRange = new vscode.Range(
     document.positionAt(0),

--- a/src/quickAddCommands.ts
+++ b/src/quickAddCommands.ts
@@ -1,0 +1,173 @@
+import * as vscode from 'vscode';
+import {
+  formatLocalDate,
+  formatScheduleLine,
+  formatTaskLine,
+  insertItemForDate,
+  isValidDate,
+  isValidTime,
+  offsetDate,
+} from './quickAdd';
+
+const TMD_LANGUAGE_ID = 'tmd';
+
+export function registerQuickAddCommands(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('taskmark.addTask', () => runAddTask()),
+    vscode.commands.registerCommand('taskmark.addSchedule', () => runAddSchedule()),
+  );
+}
+
+async function runAddTask(): Promise<void> {
+  const editor = await resolveTmdEditor();
+  if (!editor) {
+    return;
+  }
+
+  const body = await vscode.window.showInputBox({
+    prompt: 'Task text',
+    placeHolder: 'e.g. Review pull request',
+    ignoreFocusOut: true,
+    validateInput: v => (v.trim() === '' ? 'Task text cannot be empty' : null),
+  });
+  if (body === undefined) {
+    return;
+  }
+
+  const dateStr = await pickDate();
+  if (!dateStr) {
+    return;
+  }
+
+  await applyInsertion(editor, dateStr, formatTaskLine(body));
+}
+
+async function runAddSchedule(): Promise<void> {
+  const editor = await resolveTmdEditor();
+  if (!editor) {
+    return;
+  }
+
+  const body = await vscode.window.showInputBox({
+    prompt: 'Schedule text',
+    placeHolder: 'e.g. Team meeting',
+    ignoreFocusOut: true,
+    validateInput: v => (v.trim() === '' ? 'Schedule text cannot be empty' : null),
+  });
+  if (body === undefined) {
+    return;
+  }
+
+  const startTime = await vscode.window.showInputBox({
+    prompt: 'Start time (HH:mm)',
+    placeHolder: '09:00',
+    ignoreFocusOut: true,
+    validateInput: v => (isValidTime(v) ? null : 'Enter time as HH:mm (24-hour)'),
+  });
+  if (startTime === undefined) {
+    return;
+  }
+
+  const endTime = await vscode.window.showInputBox({
+    prompt: 'End time (HH:mm) — leave blank for no end time',
+    placeHolder: '10:00',
+    ignoreFocusOut: true,
+    validateInput: v => (v === '' || isValidTime(v) ? null : 'Enter time as HH:mm (24-hour)'),
+  });
+  if (endTime === undefined) {
+    return;
+  }
+
+  const dateStr = await pickDate();
+  if (!dateStr) {
+    return;
+  }
+
+  const line = formatScheduleLine(body, startTime, endTime === '' ? undefined : endTime);
+  await applyInsertion(editor, dateStr, line);
+}
+
+async function resolveTmdEditor(): Promise<vscode.TextEditor | undefined> {
+  const active = vscode.window.activeTextEditor;
+  if (active && active.document.languageId === TMD_LANGUAGE_ID) {
+    return active;
+  }
+
+  const tmdDocs = vscode.workspace.textDocuments.filter(d => d.languageId === TMD_LANGUAGE_ID);
+  if (tmdDocs.length === 0) {
+    const tmdFiles = await vscode.workspace.findFiles('**/*.tmd', '**/node_modules/**', 20);
+    if (tmdFiles.length === 0) {
+      vscode.window.showErrorMessage('TaskMark: No .tmd file found in the workspace.');
+      return undefined;
+    }
+    const picked = tmdFiles.length === 1
+      ? tmdFiles[0]
+      : await vscode.window.showQuickPick(
+          tmdFiles.map(uri => ({ label: vscode.workspace.asRelativePath(uri), uri })),
+          { placeHolder: 'Select a .tmd file' }
+        ).then(p => p?.uri);
+    if (!picked) {
+      return undefined;
+    }
+    const doc = await vscode.workspace.openTextDocument(picked);
+    return vscode.window.showTextDocument(doc);
+  }
+
+  if (tmdDocs.length === 1) {
+    return vscode.window.showTextDocument(tmdDocs[0]);
+  }
+
+  const pick = await vscode.window.showQuickPick(
+    tmdDocs.map(d => ({ label: vscode.workspace.asRelativePath(d.uri), document: d })),
+    { placeHolder: 'Select a .tmd file' }
+  );
+  return pick ? vscode.window.showTextDocument(pick.document) : undefined;
+}
+
+async function pickDate(): Promise<string | undefined> {
+  const now = new Date();
+  const today = formatLocalDate(now);
+  const tomorrow = formatLocalDate(offsetDate(now, 1));
+
+  const choice = await vscode.window.showQuickPick(
+    [
+      { label: 'Today', detail: today, value: today },
+      { label: 'Tomorrow', detail: tomorrow, value: tomorrow },
+      { label: 'Pick a date…', detail: 'Enter YYYY-MM-DD', value: '__custom__' },
+    ],
+    { placeHolder: 'Target date' }
+  );
+  if (!choice) {
+    return undefined;
+  }
+  if (choice.value !== '__custom__') {
+    return choice.value;
+  }
+  return vscode.window.showInputBox({
+    prompt: 'Date (YYYY-MM-DD)',
+    placeHolder: today,
+    ignoreFocusOut: true,
+    validateInput: v => (isValidDate(v) ? null : 'Enter a date as YYYY-MM-DD'),
+  });
+}
+
+async function applyInsertion(editor: vscode.TextEditor, dateStr: string, itemLine: string): Promise<void> {
+  const document = editor.document;
+  const original = document.getText();
+  const { newText, insertedLineIndex } = insertItemForDate(original, dateStr, itemLine);
+
+  const fullRange = new vscode.Range(
+    document.positionAt(0),
+    document.positionAt(original.length)
+  );
+
+  const ok = await editor.edit(eb => eb.replace(fullRange, newText));
+  if (!ok) {
+    vscode.window.showErrorMessage('TaskMark: Failed to insert item.');
+    return;
+  }
+
+  const target = new vscode.Position(insertedLineIndex, document.lineAt(insertedLineIndex).text.length);
+  editor.selection = new vscode.Selection(target, target);
+  editor.revealRange(new vscode.Range(target, target), vscode.TextEditorRevealType.InCenterIfOutsideViewport);
+}

--- a/src/test/suite/TaskmarkPanel.test.ts
+++ b/src/test/suite/TaskmarkPanel.test.ts
@@ -167,6 +167,20 @@ suite('toggleCheckboxInLine', () => {
   test('returns null when non-bullet text precedes the checkbox', () => {
     assert.strictEqual(toggleCheckboxInLine('foo - [ ] bar'), null);
   });
+
+  test('flips intermediate [N] task to [x] (treats N as not yet done)', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [30] foo'), '- [x] foo');
+    assert.strictEqual(toggleCheckboxInLine('- [60] foo'), '- [x] foo');
+    assert.strictEqual(toggleCheckboxInLine('- [99] foo'), '- [x] foo');
+  });
+
+  test('treats [0] as todo and flips to [x]', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [0] foo'), '- [x] foo');
+  });
+
+  test('treats [100] as done and flips to [ ]', () => {
+    assert.strictEqual(toggleCheckboxInLine('- [100] foo'), '- [ ] foo');
+  });
 });
 
 suite('resolveFontSize', () => {

--- a/src/test/suite/completion.test.ts
+++ b/src/test/suite/completion.test.ts
@@ -1,0 +1,83 @@
+import * as assert from 'assert';
+import {
+  extractDefinedTags,
+  REPEAT_OPTION_KEYWORDS,
+  AT_KEYWORDS,
+  buildTagCompletionItems,
+} from '../../completion';
+
+suite('Completion Test Suite', () => {
+  test('extractDefinedTags returns tags listed inside the @tags block', () => {
+    const text = [
+      '@tags',
+      '#meeting : #ff0000',
+      '#work : #0088ff',
+      '@end',
+      '',
+      '# 2026-03-26',
+      '- A #meeting',
+    ].join('\n');
+
+    assert.deepStrictEqual(extractDefinedTags(text), ['meeting', 'work']);
+  });
+
+  test('extractDefinedTags ignores tags written outside the block', () => {
+    const text = [
+      '# 2026-03-26',
+      '- A #stray',
+    ].join('\n');
+
+    assert.deepStrictEqual(extractDefinedTags(text), []);
+  });
+
+  test('extractDefinedTags skips lines that are not tag definitions', () => {
+    const text = [
+      '@tags',
+      '#good : #ff0000',
+      'invalid line',
+      '#also-good : red',
+      '@end',
+    ].join('\n');
+
+    assert.deepStrictEqual(extractDefinedTags(text), ['good', 'also-good']);
+  });
+
+  test('extractDefinedTags merges tag names from taskmark.tagColors when provided', () => {
+    const text = '';
+    const tagColors: Record<string, string> = { important: '#ff0000', mtg: '#3498db' };
+    const tags = extractDefinedTags(text, tagColors);
+    assert.deepStrictEqual([...tags].sort(), ['important', 'mtg']);
+  });
+
+  test('extractDefinedTags deduplicates tags coming from both sources', () => {
+    const text = [
+      '@tags',
+      '#mtg : #3498db',
+      '@end',
+    ].join('\n');
+    const tagColors: Record<string, string> = { mtg: '#000000', other: '#fff' };
+    const tags = extractDefinedTags(text, tagColors);
+    assert.strictEqual(tags.length, 2);
+    assert.ok(tags.includes('mtg'));
+    assert.ok(tags.includes('other'));
+  });
+
+  test('REPEAT_OPTION_KEYWORDS includes the documented modifiers', () => {
+    for (const k of ['daily', 'weekly', 'monthly', 'every:', 'until:', 'count:', 'except:']) {
+      assert.ok(REPEAT_OPTION_KEYWORDS.includes(k), `expected ${k} in REPEAT_OPTION_KEYWORDS`);
+    }
+  });
+
+  test('AT_KEYWORDS includes repeat / tags / end', () => {
+    assert.ok(AT_KEYWORDS.some(k => k.startsWith('repeat')));
+    assert.ok(AT_KEYWORDS.includes('tags'));
+    assert.ok(AT_KEYWORDS.includes('end'));
+  });
+
+  test('buildTagCompletionItems returns one entry per tag with the bare name as label', () => {
+    const items = buildTagCompletionItems(['meeting', 'work']);
+    assert.strictEqual(items.length, 2);
+    assert.deepStrictEqual(items.map(i => i.label), ['meeting', 'work']);
+    assert.deepStrictEqual(items.map(i => i.insertText), ['meeting', 'work']);
+  });
+});

--- a/src/test/suite/duplicateTask.test.ts
+++ b/src/test/suite/duplicateTask.test.ts
@@ -1,0 +1,260 @@
+import * as assert from 'assert';
+import {
+  parseDuplicatePattern,
+  parseDuplicateEndCondition,
+  generateDuplicateDates,
+  duplicateTaskAcrossDates,
+  findSourceDateForLine,
+} from '../../duplicateTask';
+
+suite('Duplicate Task Test Suite', () => {
+  suite('parseDuplicatePattern', () => {
+    test('parses preset keywords', () => {
+      assert.deepStrictEqual(parseDuplicatePattern('daily'), { mode: 'days', interval: 1 });
+      assert.deepStrictEqual(parseDuplicatePattern('weekly'), { mode: 'days', interval: 7 });
+      assert.deepStrictEqual(parseDuplicatePattern('monthly'), { mode: 'months', interval: 1 });
+    });
+
+    test('parses every:Ndays / Nweeks / Nmonths', () => {
+      assert.deepStrictEqual(parseDuplicatePattern('every:3days'), { mode: 'days', interval: 3 });
+      assert.deepStrictEqual(parseDuplicatePattern('every:2weeks'), { mode: 'days', interval: 14 });
+      assert.deepStrictEqual(parseDuplicatePattern('every:3months'), { mode: 'months', interval: 3 });
+    });
+
+    test('trims surrounding whitespace', () => {
+      assert.deepStrictEqual(parseDuplicatePattern('  weekly  '), { mode: 'days', interval: 7 });
+    });
+
+    test('rejects invalid input', () => {
+      assert.strictEqual(parseDuplicatePattern(''), null);
+      assert.strictEqual(parseDuplicatePattern('yearly'), null);
+      assert.strictEqual(parseDuplicatePattern('every:0days'), null);
+      assert.strictEqual(parseDuplicatePattern('every:-1days'), null);
+      assert.strictEqual(parseDuplicatePattern('every:days'), null);
+      assert.strictEqual(parseDuplicatePattern('every:3'), null);
+    });
+  });
+
+  suite('parseDuplicateEndCondition', () => {
+    test('parses count:N', () => {
+      assert.deepStrictEqual(parseDuplicateEndCondition('count:5'), { kind: 'count', count: 5 });
+      assert.deepStrictEqual(parseDuplicateEndCondition('count:1'), { kind: 'count', count: 1 });
+    });
+
+    test('parses until:YYYY-MM-DD', () => {
+      assert.deepStrictEqual(
+        parseDuplicateEndCondition('until:2026-12-31'),
+        { kind: 'until', until: '2026-12-31' }
+      );
+    });
+
+    test('rejects invalid input', () => {
+      assert.strictEqual(parseDuplicateEndCondition(''), null);
+      assert.strictEqual(parseDuplicateEndCondition('count:0'), null);
+      assert.strictEqual(parseDuplicateEndCondition('count:-1'), null);
+      assert.strictEqual(parseDuplicateEndCondition('count:abc'), null);
+      assert.strictEqual(parseDuplicateEndCondition('until:2026-13-01'), null);
+      assert.strictEqual(parseDuplicateEndCondition('until:not-a-date'), null);
+      assert.strictEqual(parseDuplicateEndCondition('forever'), null);
+    });
+
+    test('caps count at maximum occurrences', () => {
+      const r = parseDuplicateEndCondition('count:99999');
+      assert.ok(r);
+      assert.strictEqual(r!.kind, 'count');
+      assert.strictEqual(r!.count, 3650);
+    });
+  });
+
+  suite('generateDuplicateDates', () => {
+    test('daily count:4 yields three additional dates', () => {
+      const dates = generateDuplicateDates(
+        '2026-04-27',
+        { mode: 'days', interval: 1 },
+        { kind: 'count', count: 4 }
+      );
+      assert.deepStrictEqual(dates, ['2026-04-28', '2026-04-29', '2026-04-30']);
+    });
+
+    test('weekly count:4 follows the issue example', () => {
+      const dates = generateDuplicateDates(
+        '2026-04-27',
+        { mode: 'days', interval: 7 },
+        { kind: 'count', count: 4 }
+      );
+      assert.deepStrictEqual(dates, ['2026-05-04', '2026-05-11', '2026-05-18']);
+    });
+
+    test('monthly clamps to last day for short months', () => {
+      const dates = generateDuplicateDates(
+        '2026-01-31',
+        { mode: 'months', interval: 1 },
+        { kind: 'count', count: 3 }
+      );
+      assert.deepStrictEqual(dates, ['2026-02-28', '2026-03-31']);
+    });
+
+    test('every:2days with count', () => {
+      const dates = generateDuplicateDates(
+        '2026-04-27',
+        { mode: 'days', interval: 2 },
+        { kind: 'count', count: 3 }
+      );
+      assert.deepStrictEqual(dates, ['2026-04-29', '2026-05-01']);
+    });
+
+    test('until stops at the given date inclusive', () => {
+      const dates = generateDuplicateDates(
+        '2026-04-27',
+        { mode: 'days', interval: 7 },
+        { kind: 'until', until: '2026-05-18' }
+      );
+      assert.deepStrictEqual(dates, ['2026-05-04', '2026-05-11', '2026-05-18']);
+    });
+
+    test('until on or before source date yields empty', () => {
+      assert.deepStrictEqual(
+        generateDuplicateDates(
+          '2026-04-27',
+          { mode: 'days', interval: 7 },
+          { kind: 'until', until: '2026-04-27' }
+        ),
+        []
+      );
+      assert.deepStrictEqual(
+        generateDuplicateDates(
+          '2026-04-27',
+          { mode: 'days', interval: 7 },
+          { kind: 'until', until: '2026-05-03' }
+        ),
+        []
+      );
+    });
+
+    test('count:1 yields no additional dates', () => {
+      assert.deepStrictEqual(
+        generateDuplicateDates(
+          '2026-04-27',
+          { mode: 'days', interval: 7 },
+          { kind: 'count', count: 1 }
+        ),
+        []
+      );
+    });
+  });
+
+  suite('duplicateTaskAcrossDates', () => {
+    test('inserts copies into new sections following the issue example', () => {
+      const text = ['# 2026-04-27', '- [ ] Weekly Report'].join('\n');
+      const { newText, insertedDates } = duplicateTaskAcrossDates(
+        text,
+        '2026-04-27',
+        '- [ ] Weekly Report',
+        { mode: 'days', interval: 7 },
+        { kind: 'count', count: 4 }
+      );
+
+      assert.deepStrictEqual(insertedDates, ['2026-05-04', '2026-05-11', '2026-05-18']);
+      assert.strictEqual(
+        newText,
+        [
+          '# 2026-04-27',
+          '- [ ] Weekly Report',
+          '',
+          '# 2026-05-04',
+          '- [ ] Weekly Report',
+          '',
+          '# 2026-05-11',
+          '- [ ] Weekly Report',
+          '',
+          '# 2026-05-18',
+          '- [ ] Weekly Report',
+        ].join('\n')
+      );
+    });
+
+    test('appends to an existing target section instead of creating a new one', () => {
+      const text = [
+        '# 2026-04-27',
+        '- [ ] Weekly Report',
+        '',
+        '# 2026-05-04',
+        '- 10:00 Other',
+      ].join('\n');
+      const { newText } = duplicateTaskAcrossDates(
+        text,
+        '2026-04-27',
+        '- [ ] Weekly Report',
+        { mode: 'days', interval: 7 },
+        { kind: 'count', count: 2 }
+      );
+
+      assert.strictEqual(
+        newText,
+        [
+          '# 2026-04-27',
+          '- [ ] Weekly Report',
+          '',
+          '# 2026-05-04',
+          '- 10:00 Other',
+          '- [ ] Weekly Report',
+        ].join('\n')
+      );
+    });
+
+    test('preserves CRLF line endings', () => {
+      const text = ['# 2026-04-27', '- [ ] Weekly Report'].join('\r\n');
+      const { newText } = duplicateTaskAcrossDates(
+        text,
+        '2026-04-27',
+        '- [ ] Weekly Report',
+        { mode: 'days', interval: 7 },
+        { kind: 'count', count: 2 },
+        '\r\n'
+      );
+
+      assert.ok(!/(?<!\r)\n/.test(newText), 'should not contain bare \\n');
+      assert.ok(newText.includes('\r\n# 2026-05-04\r\n- [ ] Weekly Report'));
+    });
+
+    test('returns the original text unchanged when count:1', () => {
+      const text = ['# 2026-04-27', '- [ ] Weekly Report'].join('\n');
+      const { newText, insertedDates } = duplicateTaskAcrossDates(
+        text,
+        '2026-04-27',
+        '- [ ] Weekly Report',
+        { mode: 'days', interval: 7 },
+        { kind: 'count', count: 1 }
+      );
+      assert.strictEqual(newText, text);
+      assert.deepStrictEqual(insertedDates, []);
+    });
+  });
+
+  suite('findSourceDateForLine', () => {
+    test('finds the nearest preceding date header', () => {
+      const text = [
+        '# 2026-04-27',
+        '- [ ] A',
+        '- [ ] B',
+        '',
+        '# 2026-05-04',
+        '- [ ] C',
+      ].join('\n');
+      assert.strictEqual(findSourceDateForLine(text, 1), '2026-04-27');
+      assert.strictEqual(findSourceDateForLine(text, 2), '2026-04-27');
+      assert.strictEqual(findSourceDateForLine(text, 5), '2026-05-04');
+    });
+
+    test('normalizes single-digit month/day', () => {
+      const text = ['# 2026-3-5', '- [ ] A'].join('\n');
+      assert.strictEqual(findSourceDateForLine(text, 1), '2026-03-05');
+    });
+
+    test('returns null when no date header precedes the line', () => {
+      const text = ['- [ ] A', '- [ ] B'].join('\n');
+      assert.strictEqual(findSourceDateForLine(text, 0), null);
+      assert.strictEqual(findSourceDateForLine(text, 1), null);
+    });
+  });
+});

--- a/src/test/suite/gantt.test.ts
+++ b/src/test/suite/gantt.test.ts
@@ -350,6 +350,32 @@ suite('Gantt Test Suite', () => {
     assert.strictEqual(group.children[1].sourceLine, '> - [x] Task B');
   });
 
+  test('group entity tasksProgressSum reflects intermediate [N] progress values', () => {
+    const { data } = parseTmd(`# 2026-03-01
+> Sprint
+> - [30] Task A
+> - [50] Task B
+> - [x] Task C
+`);
+    const { entities } = buildGanttEntities(data);
+    const group = entities[0];
+    assert.strictEqual(group.tasksTotal, 3);
+    assert.strictEqual(group.tasksProgressSum, 30 + 50 + 100);
+    // Average = 60
+  });
+
+  test('standalone task child exposes progress 0-100', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [40] Task\n`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities[0].children[0].progress, 40);
+  });
+
+  test('schedule child progress is 100 (rendered as a full bar)', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- Plain schedule\n`);
+    const { entities } = buildGanttEntities(data);
+    assert.strictEqual(entities[0].children[0].progress, 100);
+  });
+
   test('schedule children also carry rawLine and sourceLine from source item', () => {
     const { data } = parseTmd(`# 2026-03-01
 - 9:00-10:00 Meeting

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -531,6 +531,111 @@ not a valid tag line
     assert.strictEqual(item.startDate, '2026-03-01');
   });
 
+  // ─── Input Validation Tests ──────────────────────────────────
+
+  test('parseTmd @repeat every:0days is rejected with a warning and does not expand', () => {
+    const text = `
+# 2026-04-23
+- 09:00 Morning stretch @repeat(every:0days)
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1, 'Should warn about the invalid interval');
+    assert.match(warnings[0], /invalid @repeat interval '0days'/);
+    // Falls back to default weekly (interval=7), not same-day duplication
+    assert.strictEqual(data.days['2026-04-23'].items.length, 1, 'No duplication on origin day');
+  });
+
+  test('parseTmd @repeat every:0weeks / every:0months are rejected', () => {
+    const text = `
+# 2026-04-23
+- A @repeat(every:0weeks)
+- B @repeat(every:0months)
+`;
+    const { warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 2);
+    assert.ok(warnings.some(w => w.includes('0weeks')));
+    assert.ok(warnings.some(w => w.includes('0months')));
+  });
+
+  test('parseTmd @repeat count is capped at MAX_OCCURRENCES', () => {
+    const text = `
+# 2026-03-01
+- Daily @repeat(daily, count:1000000)
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /count '1000000' exceeds maximum/);
+    assert.ok(Object.keys(data.days).length <= 3650, 'Day count must not exceed MAX_OCCURRENCES');
+  });
+
+  test('parseTmd @repeat negative count is rejected with a warning', () => {
+    const text = `
+# 2026-03-01
+- Stand-up @repeat(daily, count:-5)
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /invalid count '-5'/);
+    // Rejected count falls back to MAX_OCCURRENCES (but only origin day has the item here)
+    assert.ok(data.days['2026-03-01']);
+  });
+
+  test('parseTmd @repeat unknown token emits a warning', () => {
+    const text = `
+# 2026-03-01
+- Sync @repeat(weekly, unti:2026-06-30)
+`;
+    const { warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /unknown @repeat token 'unti:2026-06-30'/);
+  });
+
+  test('parseTmd @repeat + endDate emits a warning and is not expanded', () => {
+    const text = `
+# 2026-04-01 : 2026-04-10
+- Conference @repeat(weekly)
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /@repeat is ignored because endDate is specified/);
+    assert.strictEqual(Object.keys(data.days).length, 1);
+  });
+
+  test('parseTmd rejects out-of-range times and drops the time field', () => {
+    const text = `
+# 2026-04-23
+- 25:99 Overflow hour
+- 09:60 Overflow minute
+- 09:30 Valid event
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 2);
+    assert.ok(warnings.every(w => /invalid time/.test(w)));
+    const items = data.days['2026-04-23'].items;
+    assert.strictEqual(items.length, 3, 'Items are still created without time');
+    assert.strictEqual(items[0].time, undefined);
+    assert.strictEqual(items[1].time, undefined);
+    assert.strictEqual(items[2].time, '09:30');
+  });
+
+  test('parseTmd rejects out-of-range end times in a time range', () => {
+    const text = `
+# 2026-04-23
+- 09:00-25:00 Overflow end
+`;
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 1);
+    assert.strictEqual(data.days['2026-04-23'].items[0].time, undefined);
+  });
+
+  test('parseTmd warns on indented list items', () => {
+    const text = '\n# 2026-04-23\n  - [ ] Indented task\n\t- [ ] Tab-indented task\n';
+    const { data, warnings } = parseTmd(text);
+    assert.strictEqual(warnings.length, 2, 'Both indented lines should warn');
+    assert.ok(warnings.every(w => /indented list items are not supported/.test(w)));
+    assert.strictEqual(data.days['2026-04-23'].items.length, 0, 'Indented items are not included');
+  });
+
   test('parseTmd range item has startDate matching the range start date', () => {
     const text = `
 # 2026-03-01 : 2026-03-10

--- a/src/test/suite/parser.test.ts
+++ b/src/test/suite/parser.test.ts
@@ -636,6 +636,75 @@ not a valid tag line
     assert.strictEqual(data.days['2026-04-23'].items.length, 0, 'Indented items are not included');
   });
 
+  // ─── Progress Rate ([N] notation) Tests ──────────────────────
+
+  test('parseTmd [ ] task has progress=0 and status=todo', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [ ] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.status, 'todo');
+    assert.strictEqual(item.progress, 0);
+  });
+
+  test('parseTmd [x] task has progress=100 and status=done', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [x] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.status, 'done');
+    assert.strictEqual(item.progress, 100);
+  });
+
+  test('parseTmd [N] task carries the explicit progress value', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [30] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.progress, 30);
+    assert.strictEqual(item.status, 'todo', 'Intermediate values are not "done"');
+  });
+
+  test('parseTmd [0] is treated as todo with progress=0 (synonym of [ ])', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [0] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.status, 'todo');
+    assert.strictEqual(item.progress, 0);
+  });
+
+  test('parseTmd [100] is treated as done (synonym of [x])', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [100] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.status, 'done');
+    assert.strictEqual(item.progress, 100);
+  });
+
+  test('parseTmd [N] out of range warns and falls back to 0', () => {
+    const { data, warnings } = parseTmd(`# 2026-03-01\n- [150] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.progress, 0);
+    assert.strictEqual(item.status, 'todo');
+    assert.strictEqual(warnings.length, 1);
+    assert.match(warnings[0], /invalid progress '150'/);
+  });
+
+  test('parseTmd schedule items have no progress field', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- Plain schedule\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.progress, undefined);
+    assert.strictEqual(item.status, undefined);
+  });
+
+  test('parseTmd [N] with inner whitespace is accepted', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [ 60 ] Task\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.progress, 60);
+    assert.strictEqual(item.status, 'todo');
+  });
+
+  test('parseTmd [N] preserves time and content parsing', () => {
+    const { data } = parseTmd(`# 2026-03-01\n- [45] 09:00-10:00 Meeting #work\n`);
+    const item = data.days['2026-03-01'].items[0];
+    assert.strictEqual(item.progress, 45);
+    assert.strictEqual(item.time, '09:00-10:00');
+    assert.strictEqual(item.text, 'Meeting');
+    assert.deepStrictEqual(item.tags, ['work']);
+  });
+
   test('parseTmd range item has startDate matching the range start date', () => {
     const text = `
 # 2026-03-01 : 2026-03-10

--- a/src/test/suite/quickAdd.test.ts
+++ b/src/test/suite/quickAdd.test.ts
@@ -1,0 +1,143 @@
+import * as assert from 'assert';
+import {
+  formatTaskLine,
+  formatScheduleLine,
+  insertItemForDate,
+  isValidDate,
+  isValidTime,
+  formatLocalDate,
+  offsetDate,
+} from '../../quickAdd';
+
+suite('Quick Add Test Suite', () => {
+  test('formatTaskLine wraps text in checkbox syntax', () => {
+    assert.strictEqual(formatTaskLine('Buy milk'), '- [ ] Buy milk');
+  });
+
+  test('formatScheduleLine produces start-end form when endTime is set', () => {
+    assert.strictEqual(
+      formatScheduleLine('Meeting', '09:00', '10:00'),
+      '- 09:00-10:00 Meeting'
+    );
+  });
+
+  test('formatScheduleLine produces start-only form when endTime is omitted', () => {
+    assert.strictEqual(
+      formatScheduleLine('Lunch', '12:00'),
+      '- 12:00 Lunch'
+    );
+  });
+
+  test('formatScheduleLine trims whitespace around the body', () => {
+    assert.strictEqual(
+      formatScheduleLine('  Meeting  ', '09:00', '10:00'),
+      '- 09:00-10:00 Meeting'
+    );
+  });
+
+  test('insertItemForDate inserts a line into the existing date section', () => {
+    const text = [
+      '# 2026-03-26',
+      '- 09:00 Existing',
+      '',
+      '# 2026-03-27',
+      '- 10:00 Other',
+    ].join('\n');
+
+    const { newText, insertedLineIndex } = insertItemForDate(text, '2026-03-26', '- [ ] New');
+
+    assert.strictEqual(insertedLineIndex, 2);
+    assert.strictEqual(
+      newText,
+      [
+        '# 2026-03-26',
+        '- 09:00 Existing',
+        '- [ ] New',
+        '',
+        '# 2026-03-27',
+        '- 10:00 Other',
+      ].join('\n')
+    );
+  });
+
+  test('insertItemForDate creates a new section when the date is missing', () => {
+    const text = [
+      '# 2026-03-26',
+      '- 09:00 Existing',
+    ].join('\n');
+
+    const { newText, insertedLineIndex } = insertItemForDate(text, '2026-03-30', '- [ ] New');
+
+    assert.strictEqual(
+      newText,
+      [
+        '# 2026-03-26',
+        '- 09:00 Existing',
+        '',
+        '# 2026-03-30',
+        '- [ ] New',
+      ].join('\n')
+    );
+    assert.strictEqual(insertedLineIndex, 4);
+  });
+
+  test('insertItemForDate handles empty documents', () => {
+    const { newText, insertedLineIndex } = insertItemForDate('', '2026-03-30', '- [ ] New');
+
+    assert.strictEqual(newText, ['# 2026-03-30', '- [ ] New'].join('\n'));
+    assert.strictEqual(insertedLineIndex, 1);
+  });
+
+  test('insertItemForDate keeps trailing empty lines after the new section', () => {
+    const text = '# 2026-03-26\n- A\n\n\n';
+    const { newText } = insertItemForDate(text, '2026-03-30', '- [ ] B');
+    assert.ok(newText.endsWith('\n\n\n'));
+    assert.ok(newText.includes('# 2026-03-30\n- [ ] B'));
+  });
+
+  test('insertItemForDate matches sections written with single-digit month/day', () => {
+    const text = '# 2026-3-5\n- A';
+    const { newText } = insertItemForDate(text, '2026-03-05', '- [ ] B');
+    assert.strictEqual(newText, '# 2026-3-5\n- A\n- [ ] B');
+  });
+
+  test('isValidDate accepts well-formed YYYY-MM-DD', () => {
+    assert.strictEqual(isValidDate('2026-03-26'), true);
+    assert.strictEqual(isValidDate('2026-12-31'), true);
+  });
+
+  test('isValidDate rejects malformed and impossible dates', () => {
+    assert.strictEqual(isValidDate('2026-13-01'), false);
+    assert.strictEqual(isValidDate('2026-02-30'), false);
+    assert.strictEqual(isValidDate('2026/03/26'), false);
+    assert.strictEqual(isValidDate(''), false);
+    assert.strictEqual(isValidDate('not-a-date'), false);
+  });
+
+  test('isValidTime accepts HH:mm in 24-hour range', () => {
+    assert.strictEqual(isValidTime('00:00'), true);
+    assert.strictEqual(isValidTime('09:30'), true);
+    assert.strictEqual(isValidTime('23:59'), true);
+    assert.strictEqual(isValidTime('9:30'), true);
+  });
+
+  test('isValidTime rejects out-of-range values', () => {
+    assert.strictEqual(isValidTime('24:00'), false);
+    assert.strictEqual(isValidTime('12:60'), false);
+    assert.strictEqual(isValidTime('9-30'), false);
+    assert.strictEqual(isValidTime(''), false);
+  });
+
+  test('formatLocalDate emits zero-padded YYYY-MM-DD from a Date', () => {
+    assert.strictEqual(formatLocalDate(new Date(2026, 2, 5)), '2026-03-05');
+    assert.strictEqual(formatLocalDate(new Date(2026, 11, 31)), '2026-12-31');
+  });
+
+  test('offsetDate adds days without mutating the input', () => {
+    const base = new Date(2026, 2, 30);
+    const next = offsetDate(base, 1);
+    assert.strictEqual(formatLocalDate(next), '2026-03-31');
+    assert.strictEqual(formatLocalDate(offsetDate(base, 2)), '2026-04-01');
+    assert.strictEqual(formatLocalDate(base), '2026-03-30');
+  });
+});

--- a/src/test/suite/quickAdd.test.ts
+++ b/src/test/suite/quickAdd.test.ts
@@ -101,6 +101,27 @@ suite('Quick Add Test Suite', () => {
     assert.strictEqual(newText, '# 2026-3-5\n- A\n- [ ] B');
   });
 
+  test('insertItemForDate preserves CRLF line endings when eol="\\r\\n"', () => {
+    const text = ['# 2026-03-26', '- A', '', '# 2026-03-27', '- B'].join('\r\n');
+    const { newText, insertedLineIndex } = insertItemForDate(text, '2026-03-26', '- [ ] New', '\r\n');
+
+    assert.strictEqual(insertedLineIndex, 2);
+    assert.strictEqual(
+      newText,
+      ['# 2026-03-26', '- A', '- [ ] New', '', '# 2026-03-27', '- B'].join('\r\n')
+    );
+    assert.ok(!/(?<!\r)\n/.test(newText), 'should not contain bare \\n');
+  });
+
+  test('insertItemForDate appends a new section using the given eol', () => {
+    const text = ['# 2026-03-26', '- A'].join('\r\n');
+    const { newText } = insertItemForDate(text, '2026-03-30', '- [ ] B', '\r\n');
+    assert.strictEqual(
+      newText,
+      ['# 2026-03-26', '- A', '', '# 2026-03-30', '- [ ] B'].join('\r\n')
+    );
+  });
+
   test('isValidDate accepts well-formed YYYY-MM-DD', () => {
     assert.strictEqual(isValidDate('2026-03-26'), true);
     assert.strictEqual(isValidDate('2026-12-31'), true);

--- a/src/test/suite/treeView.test.ts
+++ b/src/test/suite/treeView.test.ts
@@ -123,6 +123,18 @@ suite('categorizeForTreeView', () => {
     assert.deepStrictEqual(texts, ['Morning', 'Afternoon', 'Untimed']);
   });
 
+  test('today sort handles unpadded hours numerically (9:00 < 10:00)', () => {
+    const text = `
+# 2026-05-02
+- 10:00 Ten
+- 9:00 Nine
+- 9:30-10:30 NineThirty
+`;
+    const result = getCategorized(text, '2026-05-02');
+    const texts = result.today.map(i => i.text);
+    assert.deepStrictEqual(texts, ['Nine', 'NineThirty', 'Ten']);
+  });
+
   test('week boundary: Monday is first day of week', () => {
     // 2026-05-04 is Monday.
     const text = `

--- a/src/test/suite/treeView.test.ts
+++ b/src/test/suite/treeView.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import { parseTmd } from '../../parser';
-import { categorizeForTreeView, RECENTLY_DONE_LIMIT } from '../../treeView';
+import { categorizeForTreeView, formatItemLabel, RECENTLY_DONE_LIMIT } from '../../treeView';
 
 function getCategorized(text: string, today: string) {
   const { data } = parseTmd(text);
@@ -171,5 +171,33 @@ suite('categorizeForTreeView', () => {
     assert.deepStrictEqual(result.thisWeek, []);
     assert.deepStrictEqual(result.overdue, []);
     assert.deepStrictEqual(result.recentlyDone, []);
+  });
+});
+
+suite('formatItemLabel', () => {
+  function firstItem(text: string) {
+    const { data } = parseTmd(text);
+    const dateKey = Object.keys(data.days)[0];
+    return data.days[dateKey].items[0];
+  }
+
+  test('appends (N%) suffix for an intermediate-progress task', () => {
+    const item = firstItem(`# 2026-05-02\n- [60] Implement\n`);
+    assert.strictEqual(formatItemLabel(item), '[ ] Implement (60%)');
+  });
+
+  test('does not append a suffix for [ ] (0%)', () => {
+    const item = firstItem(`# 2026-05-02\n- [ ] Implement\n`);
+    assert.strictEqual(formatItemLabel(item), '[ ] Implement');
+  });
+
+  test('does not append a suffix for [x] (100%)', () => {
+    const item = firstItem(`# 2026-05-02\n- [x] Implement\n`);
+    assert.strictEqual(formatItemLabel(item), '[x] Implement');
+  });
+
+  test('keeps time prefix together with the (N%) suffix', () => {
+    const item = firstItem(`# 2026-05-02\n- [45] 09:00 Standup\n`);
+    assert.strictEqual(formatItemLabel(item), '[ ] 09:00 Standup (45%)');
   });
 });

--- a/src/test/suite/treeView.test.ts
+++ b/src/test/suite/treeView.test.ts
@@ -1,0 +1,149 @@
+import * as assert from 'assert';
+import { parseTmd } from '../../parser';
+import { categorizeForTreeView, RECENTLY_DONE_LIMIT } from '../../treeView';
+
+function getCategorized(text: string, today: string) {
+  const { data } = parseTmd(text);
+  return categorizeForTreeView(data, today);
+}
+
+suite('categorizeForTreeView', () => {
+  test('today bucket includes items whose startDate equals today', () => {
+    const text = `
+# 2026-05-02
+- [ ] 10:00 Meeting
+- Plain schedule
+
+# 2026-05-01
+- Yesterday item
+`;
+    const result = getCategorized(text, '2026-05-02');
+    const todayTexts = result.today.map(i => i.text);
+    assert.deepStrictEqual(todayTexts.sort(), ['Meeting', 'Plain schedule'].sort());
+  });
+
+  test('today bucket includes spanning items where today is between start and end', () => {
+    const text = `
+# 2026-04-30 : 2026-05-05
+- Long event
+`;
+    const result = getCategorized(text, '2026-05-02');
+    assert.strictEqual(result.today.length, 1);
+    assert.strictEqual(result.today[0].text, 'Long event');
+  });
+
+  test('thisWeek bucket includes items in the same Mon-Sun week excluding today', () => {
+    // 2026-05-02 is a Saturday. Week (Mon-Sun) = 2026-04-27..2026-05-03.
+    const text = `
+# 2026-04-27
+- Monday item
+
+# 2026-05-02
+- Saturday item
+
+# 2026-05-03
+- Sunday item
+
+# 2026-05-04
+- Next Monday item
+`;
+    const result = getCategorized(text, '2026-05-02');
+    const weekTexts = result.thisWeek.map(i => i.text);
+    assert.ok(weekTexts.includes('Monday item'));
+    assert.ok(weekTexts.includes('Sunday item'));
+    assert.ok(!weekTexts.includes('Saturday item'), 'today should be excluded from thisWeek');
+    assert.ok(!weekTexts.includes('Next Monday item'), 'next week should not be in thisWeek');
+  });
+
+  test('overdue bucket includes only undone tasks before today', () => {
+    const text = `
+# 2026-04-25
+- [ ] Old todo
+- [x] Old done
+- Old schedule
+
+# 2026-05-02
+- [ ] Today todo
+`;
+    const result = getCategorized(text, '2026-05-02');
+    const overdueTexts = result.overdue.map(i => i.text);
+    assert.deepStrictEqual(overdueTexts, ['Old todo']);
+  });
+
+  test('overdue uses endDate when present (an item is not overdue while its range includes today)', () => {
+    const text = `
+# 2026-04-30 : 2026-05-05
+- [ ] Long task
+`;
+    const result = getCategorized(text, '2026-05-02');
+    assert.strictEqual(result.overdue.length, 0, 'task whose endDate is in the future is not overdue');
+  });
+
+  test('recentlyDone returns up to RECENTLY_DONE_LIMIT done tasks, newest first', () => {
+    const lines: string[] = [];
+    const total = RECENTLY_DONE_LIMIT + 3;
+    for (let i = 0; i < total; i++) {
+      const day = String(i + 1).padStart(2, '0');
+      lines.push(`# 2026-04-${day}`);
+      lines.push(`- [x] done-${i}`);
+      lines.push('');
+    }
+    const result = getCategorized(lines.join('\n'), '2026-05-02');
+    assert.strictEqual(result.recentlyDone.length, RECENTLY_DONE_LIMIT);
+    // Newest (largest date) first.
+    assert.strictEqual(result.recentlyDone[0].text, `done-${total - 1}`);
+    assert.strictEqual(
+      result.recentlyDone[RECENTLY_DONE_LIMIT - 1].text,
+      `done-${total - RECENTLY_DONE_LIMIT}`
+    );
+  });
+
+  test('recentlyDone excludes done tasks dated in the future', () => {
+    const text = `
+# 2026-04-25
+- [x] past done
+
+# 2026-05-10
+- [x] future done
+`;
+    const result = getCategorized(text, '2026-05-02');
+    const texts = result.recentlyDone.map(i => i.text);
+    assert.deepStrictEqual(texts, ['past done']);
+  });
+
+  test('items in today are sorted by time then by line order', () => {
+    const text = `
+# 2026-05-02
+- 14:00 Afternoon
+- 09:00 Morning
+- Untimed
+`;
+    const result = getCategorized(text, '2026-05-02');
+    const texts = result.today.map(i => i.text);
+    assert.deepStrictEqual(texts, ['Morning', 'Afternoon', 'Untimed']);
+  });
+
+  test('week boundary: Monday is first day of week', () => {
+    // 2026-05-04 is Monday.
+    const text = `
+# 2026-05-03
+- Sunday previous week
+
+# 2026-05-04
+- Monday today
+`;
+    const result = getCategorized(text, '2026-05-04');
+    const weekTexts = result.thisWeek.map(i => i.text);
+    assert.ok(!weekTexts.includes('Sunday previous week'));
+    // today is Monday, excluded from thisWeek.
+    assert.ok(!weekTexts.includes('Monday today'));
+  });
+
+  test('returns empty buckets for an empty document', () => {
+    const result = getCategorized('', '2026-05-02');
+    assert.deepStrictEqual(result.today, []);
+    assert.deepStrictEqual(result.thisWeek, []);
+    assert.deepStrictEqual(result.overdue, []);
+    assert.deepStrictEqual(result.recentlyDone, []);
+  });
+});

--- a/src/test/suite/treeView.test.ts
+++ b/src/test/suite/treeView.test.ts
@@ -151,6 +151,20 @@ suite('categorizeForTreeView', () => {
     assert.ok(!weekTexts.includes('Monday today'));
   });
 
+  test('repeat occurrences carry the occurrence date as startDate', () => {
+    // 2026-05-04 is Monday. Weekly repeat starting that day produces occurrences
+    // on 05-04, 05-11, 05-18, ... The week containing today (2026-05-12, Tue)
+    // is 05-11 .. 05-17, so only the 05-11 occurrence belongs to thisWeek.
+    const text = `
+# 2026-05-04
+- Weekly Sync @repeat(weekly, count:4)
+`;
+    const result = getCategorized(text, '2026-05-12');
+    assert.strictEqual(result.thisWeek.length, 1);
+    assert.strictEqual(result.thisWeek[0].startDate, '2026-05-11',
+      'thisWeek occurrence should carry the occurrence date, not the repeat origin');
+  });
+
   test('returns empty buckets for an empty document', () => {
     const result = getCategorized('', '2026-05-02');
     assert.deepStrictEqual(result.today, []);

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -75,6 +75,7 @@ export function categorizeForTreeView(
   const recentlyDoneOcc: Occurrence[] = [];
 
   for (const occ of occurrences) {
+    occ.item.startDate = occ.start;
     const inToday = todayStr >= occ.start && todayStr <= occ.end;
     if (inToday) {
       today.push(occ.item);

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -35,9 +35,15 @@ export function getWeekRange(dateStr: string): { start: string; end: string } {
   return { start: toDateStr(monday), end: toDateStr(sunday) };
 }
 
+function timeStartMinutes(time: string): number {
+  const start = time.split('-')[0];
+  const [h, m] = start.split(':').map(s => parseInt(s, 10));
+  return h * 60 + m;
+}
+
 function compareByTimeThenLine(a: MarkItem, b: MarkItem): number {
   if (a.time && b.time) {
-    return a.time.localeCompare(b.time) || a.rawLine - b.rawLine;
+    return timeStartMinutes(a.time) - timeStartMinutes(b.time) || a.rawLine - b.rawLine;
   }
   if (a.time) { return -1; }
   if (b.time) { return 1; }

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -125,5 +125,9 @@ export function categoryLabel(id: CategoryId, todayStr: string): string {
 export function formatItemLabel(item: MarkItem): string {
   const checkbox = item.type === 'task' ? (item.status === 'done' ? '[x] ' : '[ ] ') : '';
   const time = item.time ? `${item.time} ` : '';
-  return `${checkbox}${time}${item.text}`.trim();
+  const progress =
+    item.type === 'task' && item.progress !== undefined && item.progress > 0 && item.progress < 100
+      ? ` (${item.progress}%)`
+      : '';
+  return `${checkbox}${time}${item.text}${progress}`.trim();
 }

--- a/src/treeView.ts
+++ b/src/treeView.ts
@@ -1,0 +1,122 @@
+import { MarkItem, TaskMarkData, parseLocalDate } from './parser';
+
+export const RECENTLY_DONE_LIMIT = 10;
+
+export interface TreeCategorizedItems {
+  today: MarkItem[];
+  thisWeek: MarkItem[];
+  overdue: MarkItem[];
+  recentlyDone: MarkItem[];
+}
+
+interface Occurrence {
+  item: MarkItem;
+  dayKey: string;
+  start: string;
+  end: string;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function toDateStr(d: Date): string {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+export function getWeekRange(dateStr: string): { start: string; end: string } {
+  const d = parseLocalDate(dateStr);
+  const dow = d.getDay(); // 0=Sun..6=Sat
+  const offsetToMonday = dow === 0 ? -6 : 1 - dow;
+  const monday = new Date(d);
+  monday.setDate(d.getDate() + offsetToMonday);
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  return { start: toDateStr(monday), end: toDateStr(sunday) };
+}
+
+function compareByTimeThenLine(a: MarkItem, b: MarkItem): number {
+  if (a.time && b.time) {
+    return a.time.localeCompare(b.time) || a.rawLine - b.rawLine;
+  }
+  if (a.time) { return -1; }
+  if (b.time) { return 1; }
+  return a.rawLine - b.rawLine;
+}
+
+function buildOccurrences(data: TaskMarkData): Occurrence[] {
+  const out: Occurrence[] = [];
+  for (const [dayKey, day] of Object.entries(data.days)) {
+    for (const item of day.items) {
+      const start = item.endDate ? item.startDate : dayKey;
+      const end = item.endDate ?? dayKey;
+      out.push({ item, dayKey, start, end });
+    }
+  }
+  return out;
+}
+
+export function categorizeForTreeView(
+  data: TaskMarkData,
+  todayStr: string
+): TreeCategorizedItems {
+  const occurrences = buildOccurrences(data);
+  const week = getWeekRange(todayStr);
+
+  const today: MarkItem[] = [];
+  const thisWeek: MarkItem[] = [];
+  const overdue: MarkItem[] = [];
+  const recentlyDoneOcc: Occurrence[] = [];
+
+  for (const occ of occurrences) {
+    const inToday = todayStr >= occ.start && todayStr <= occ.end;
+    if (inToday) {
+      today.push(occ.item);
+    } else if (occ.start <= week.end && occ.end >= week.start) {
+      thisWeek.push(occ.item);
+    }
+
+    if (occ.item.type === 'task' && occ.item.status === 'todo' && occ.end < todayStr) {
+      overdue.push(occ.item);
+    }
+
+    if (occ.item.type === 'task' && occ.item.status === 'done' && occ.end <= todayStr) {
+      recentlyDoneOcc.push(occ);
+    }
+  }
+
+  today.sort(compareByTimeThenLine);
+  thisWeek.sort((a, b) => a.startDate.localeCompare(b.startDate) || compareByTimeThenLine(a, b));
+  overdue.sort((a, b) => a.startDate.localeCompare(b.startDate) || a.rawLine - b.rawLine);
+  recentlyDoneOcc.sort((a, b) => b.end.localeCompare(a.end) || b.item.rawLine - a.item.rawLine);
+
+  return {
+    today,
+    thisWeek,
+    overdue,
+    recentlyDone: recentlyDoneOcc.slice(0, RECENTLY_DONE_LIMIT).map(o => o.item)
+  };
+}
+
+export function todayDateStr(now: Date = new Date()): string {
+  return toDateStr(now);
+}
+
+export type CategoryId = 'today' | 'thisWeek' | 'overdue' | 'recentlyDone';
+
+export const CATEGORY_ORDER: CategoryId[] = ['today', 'thisWeek', 'overdue', 'recentlyDone'];
+
+export function categoryLabel(id: CategoryId, todayStr: string): string {
+  switch (id) {
+    case 'today': return `Today (${todayStr})`;
+    case 'thisWeek': return 'This week';
+    case 'overdue': return 'Overdue';
+    case 'recentlyDone': return 'Recently done';
+  }
+}
+
+export function formatItemLabel(item: MarkItem): string {
+  const checkbox = item.type === 'task' ? (item.status === 'done' ? '[x] ' : '[ ] ') : '';
+  const time = item.time ? `${item.time} ` : '';
+  return `${checkbox}${time}${item.text}`.trim();
+}

--- a/src/treeViewProvider.ts
+++ b/src/treeViewProvider.ts
@@ -87,9 +87,9 @@ export class TaskmarkTreeDataProvider implements vscode.TreeDataProvider<TreeNod
     }
 
     const treeItem = new vscode.TreeItem(formatItemLabel(node.item), vscode.TreeItemCollapsibleState.None);
-    treeItem.description = node.item.tags.length > 0
-      ? node.item.tags.map(t => `#${t}`).join(' ')
-      : undefined;
+    const datePart = node.category !== 'today' ? `${node.item.startDate} ` : '';
+    const tagsPart = node.item.tags.map(t => `#${t}`).join(' ');
+    treeItem.description = (datePart + tagsPart).trim() || undefined;
     treeItem.tooltip = `${node.item.startDate}${node.item.endDate ? ` : ${node.item.endDate}` : ''}\n${node.item.sourceLine}`;
     treeItem.command = {
       command: 'taskmark.tree.revealItem',

--- a/src/treeViewProvider.ts
+++ b/src/treeViewProvider.ts
@@ -1,0 +1,164 @@
+import * as vscode from 'vscode';
+import { MarkItem, parseTmd } from './parser';
+import { resolveToggleTargetLineIndex, toggleCheckboxInLine } from './messages';
+import {
+  CategoryId,
+  CATEGORY_ORDER,
+  TreeCategorizedItems,
+  categorizeForTreeView,
+  categoryLabel,
+  formatItemLabel,
+  todayDateStr
+} from './treeView';
+
+interface CategoryNode {
+  kind: 'category';
+  id: CategoryId;
+}
+
+interface ItemNode {
+  kind: 'item';
+  category: CategoryId;
+  item: MarkItem;
+  uri: vscode.Uri;
+}
+
+export type TreeNode = CategoryNode | ItemNode;
+
+function categoryIcon(id: CategoryId): vscode.ThemeIcon {
+  switch (id) {
+    case 'today': return new vscode.ThemeIcon('calendar');
+    case 'thisWeek': return new vscode.ThemeIcon('calendar');
+    case 'overdue': return new vscode.ThemeIcon('warning');
+    case 'recentlyDone': return new vscode.ThemeIcon('check');
+  }
+}
+
+export class TaskmarkTreeDataProvider implements vscode.TreeDataProvider<TreeNode> {
+  private readonly _onDidChange = new vscode.EventEmitter<TreeNode | undefined>();
+  public readonly onDidChangeTreeData = this._onDidChange.event;
+
+  private _activeUri: vscode.Uri | undefined;
+  private _categorized: TreeCategorizedItems = {
+    today: [], thisWeek: [], overdue: [], recentlyDone: []
+  };
+  private _todayStr: string = todayDateStr();
+
+  refresh(): void {
+    this._todayStr = todayDateStr();
+    const editor = this._findTmdEditor();
+    if (editor) {
+      this._activeUri = editor.document.uri;
+      const { data } = parseTmd(editor.document.getText());
+      this._categorized = categorizeForTreeView(data, this._todayStr);
+    } else {
+      this._activeUri = undefined;
+      this._categorized = { today: [], thisWeek: [], overdue: [], recentlyDone: [] };
+    }
+    this._onDidChange.fire(undefined);
+  }
+
+  private _findTmdEditor(): vscode.TextEditor | undefined {
+    const active = vscode.window.activeTextEditor;
+    if (active && active.document.languageId === 'tmd') {
+      return active;
+    }
+    for (const editor of vscode.window.visibleTextEditors) {
+      if (editor.document.languageId === 'tmd') {
+        return editor;
+      }
+    }
+    return undefined;
+  }
+
+  getTreeItem(node: TreeNode): vscode.TreeItem {
+    if (node.kind === 'category') {
+      const items = this._categorized[node.id];
+      const label = categoryLabel(node.id, this._todayStr);
+      const treeItem = new vscode.TreeItem(
+        `${label} (${items.length})`,
+        items.length > 0
+          ? vscode.TreeItemCollapsibleState.Expanded
+          : vscode.TreeItemCollapsibleState.None
+      );
+      treeItem.iconPath = categoryIcon(node.id);
+      treeItem.contextValue = `taskmarkCategory.${node.id}`;
+      return treeItem;
+    }
+
+    const treeItem = new vscode.TreeItem(formatItemLabel(node.item), vscode.TreeItemCollapsibleState.None);
+    treeItem.description = node.item.tags.length > 0
+      ? node.item.tags.map(t => `#${t}`).join(' ')
+      : undefined;
+    treeItem.tooltip = `${node.item.startDate}${node.item.endDate ? ` : ${node.item.endDate}` : ''}\n${node.item.sourceLine}`;
+    treeItem.command = {
+      command: 'taskmark.tree.revealItem',
+      title: 'Reveal in editor',
+      arguments: [node]
+    };
+    treeItem.contextValue = node.item.type === 'task' ? 'taskmarkTask' : 'taskmarkSchedule';
+    if (node.item.type === 'task') {
+      treeItem.iconPath = new vscode.ThemeIcon(
+        node.item.status === 'done' ? 'pass-filled' : 'circle-large-outline'
+      );
+    } else {
+      treeItem.iconPath = new vscode.ThemeIcon('clock');
+    }
+    return treeItem;
+  }
+
+  getChildren(node?: TreeNode): TreeNode[] {
+    if (!node) {
+      return CATEGORY_ORDER.map(id => ({ kind: 'category', id }));
+    }
+    if (node.kind === 'category') {
+      const uri = this._activeUri;
+      if (!uri) { return []; }
+      return this._categorized[node.id].map(item => ({
+        kind: 'item',
+        category: node.id,
+        item,
+        uri
+      }));
+    }
+    return [];
+  }
+
+  async revealItem(node: ItemNode): Promise<void> {
+    const document = await vscode.workspace.openTextDocument(node.uri);
+    const lineIdx = resolveToggleTargetLineIndex(
+      document.lineCount,
+      i => document.lineAt(i).text,
+      node.item.rawLine,
+      node.item.sourceLine
+    );
+    const targetLine = lineIdx ?? Math.min(node.item.rawLine, document.lineCount - 1);
+    const editor = await vscode.window.showTextDocument(document, { preview: false });
+    const range = document.lineAt(targetLine).range;
+    editor.selection = new vscode.Selection(range.start, range.start);
+    editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+  }
+
+  async toggleItem(node: ItemNode): Promise<void> {
+    if (node.item.type !== 'task') { return; }
+    const document = await vscode.workspace.openTextDocument(node.uri);
+    const lineIdx = resolveToggleTargetLineIndex(
+      document.lineCount,
+      i => document.lineAt(i).text,
+      node.item.rawLine,
+      node.item.sourceLine
+    );
+    if (lineIdx === null) {
+      vscode.window.showInformationMessage(
+        'TaskMark: That task no longer matches the file (it may have been edited).'
+      );
+      return;
+    }
+    const line = document.lineAt(lineIdx);
+    const toggled = toggleCheckboxInLine(line.text);
+    if (toggled === null || toggled === line.text) { return; }
+    const edit = new vscode.WorkspaceEdit();
+    edit.replace(node.uri, line.range, toggled);
+    await vscode.workspace.applyEdit(edit);
+  }
+}


### PR DESCRIPTION
## 関連Issue
Closes #88, Closes #89, Closes #90, Closes #91

## 概要
develop ブランチに蓄積された新機能・修正をバージョン 1.6.0 として main にリリースします。クイック追加コマンド、アクティビティバーのサイドバー、進捗率記法、タスク複製コマンドの4つの主要機能を含みます。

## 変更内容
- #88: `.tmd` への項目を素早く挿入するクイック追加コマンド、スニペット、タグ名/リピートオプションの補完を追加
- #89: アクティブな `.tmd` を Today / This week / Overdue / Recently done に分類するアクティビティバーの TreeView ("TaskMark: Overview") を追加
- #90: チェックボックス記法 `[N]` (0-100) による進捗率対応。Gantt のタスクバー塗りつぶし、グループバーの平均算出、TreeView の `(N%)` サフィックス表示を実装
- #91: 現在行のタスクを `daily` / `weekly` / `monthly` / `every:N{days|weeks|months}` のリピートパターンと `count:N` / `until:YYYY-MM-DD` の終了条件で複数日に複製する `TaskMark: Duplicate Task` コマンドを追加
- 関連する不具合修正: パーサの入力検証強化、時刻ソートを数値比較に変更、リピート項目の発生日カテゴライズ、`insertItemForDate` の改行コード維持
- CHANGELOG を `[1.6.0] - 2026-05-24` に繰り上げ、`package.json` の `version` を `1.6.0` に更新

## 動作確認・テスト
- [x] 各機能 PR (#93, #95, #99, #100) で個別に動作確認とテスト追加済み
- [x] 既存の機能に影響（デグレ）がないことを確認済み
- [x] README と CHANGELOG を更新済み
- [ ] main マージ後に `v1.6.0` のリリースタグを切る

## スクリーンショット / GIF (UI変更がある場合)
各機能 PR (#93, #95, #99, #100) を参照。

## 備考・次やること
- マージ後、`v1.6.0` タグを作成して GitHub Release を発行する。